### PR TITLE
✨ Implement 'yt reports' command group functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,61 @@ yt boards view BOARD-456 --format json
 - **Multiple Output Formats**: View data in tables or export as JSON
 - **Error Handling**: Clear error messages for permissions and API issues
 
+### Reports
+
+Generate cross-entity reports for analytics and project insights with the `yt reports` command group:
+
+```bash
+# Generate a burndown report for a project
+yt reports burndown PROJECT-123
+
+# Generate a burndown report for a specific sprint
+yt reports burndown PROJECT-123 --sprint "Sprint 1"
+
+# Generate a burndown report for a date range
+yt reports burndown PROJECT-123 --start-date "2024-01-01" --end-date "2024-01-31"
+
+# Generate a burndown report with all filters combined
+yt reports burndown PROJECT-123 --sprint "Sprint 2" --start-date "2024-02-01" --end-date "2024-02-15"
+
+# Generate a velocity report for the last 5 sprints (default)
+yt reports velocity PROJECT-123
+
+# Generate a velocity report for the last 10 sprints
+yt reports velocity PROJECT-123 --sprints 10
+
+# Generate a velocity report for fewer sprints
+yt reports velocity PROJECT-123 --sprints 3
+```
+
+#### Report Types
+
+**Burndown Reports**
+- Show project or sprint progress over time
+- Display total, resolved, and remaining issues
+- Calculate completion rates and effort metrics
+- Support filtering by sprint and date ranges
+- Visual progress bar showing completion percentage
+
+**Velocity Reports**
+- Analyze team performance across recent sprints
+- Show issues completed and effort expended per sprint
+- Calculate average velocity metrics
+- Help with sprint planning and capacity estimation
+- Display trends in team productivity
+
+#### Report Features
+
+- **Project-Based Analysis**: Generate reports for specific projects
+- **Sprint Filtering**: Focus on specific sprints or date ranges
+- **Completion Metrics**: Track progress with completion rates and effort analysis
+- **Velocity Tracking**: Monitor team velocity across multiple sprints
+- **Rich Visualization**: Beautiful tables with progress indicators and status displays
+- **Trend Analysis**: Identify patterns in team performance and project progress
+- **Planning Support**: Use historical data for better sprint planning
+- **Error Handling**: Clear error messages for authentication and API issues
+- **Flexible Time Periods**: Support for custom date ranges and sprint counts
+
 ## Development
 
 This project uses `uv` for dependency management.

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,307 @@
+"""Tests for the reports module."""
+
+from unittest.mock import Mock, patch
+
+import httpx
+import pytest
+from click.testing import CliRunner
+
+from youtrack_cli.auth import AuthConfig, AuthManager
+from youtrack_cli.main import main
+from youtrack_cli.reports import ReportManager
+
+
+class TestReportManager:
+    """Test ReportManager functionality."""
+
+    @pytest.fixture
+    def auth_manager(self):
+        """Create a mock auth manager for testing."""
+        auth_manager = Mock(spec=AuthManager)
+        auth_manager.load_credentials.return_value = AuthConfig(
+            base_url="https://test.youtrack.cloud",
+            token="test-token",
+            username="test-user",
+        )
+        return auth_manager
+
+    @pytest.fixture
+    def report_manager(self, auth_manager):
+        """Create a ReportManager instance for testing."""
+        return ReportManager(auth_manager)
+
+    @pytest.mark.asyncio
+    async def test_generate_burndown_report_success(self, report_manager, auth_manager):
+        """Test successful burndown report generation."""
+        mock_issues = [
+            {
+                "id": "1",
+                "summary": "Test Issue 1",
+                "resolved": 1234567890,
+                "created": 1234567000,
+                "state": {"name": "Done"},
+                "spent": {"value": 120},  # 2 hours in minutes
+            },
+            {
+                "id": "2",
+                "summary": "Test Issue 2",
+                "resolved": None,
+                "created": 1234567000,
+                "state": {"name": "In Progress"},
+                "spent": {"value": 60},  # 1 hour in minutes
+            },
+        ]
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_response = Mock()
+            mock_response.json.return_value = mock_issues
+            mock_response.raise_for_status.return_value = None
+
+            mock_client.return_value.__aenter__.return_value.get.return_value = (
+                mock_response
+            )
+
+            result = await report_manager.generate_burndown_report(
+                project_id="TEST",
+                sprint_id="sprint-1",
+                start_date="2024-01-01",
+                end_date="2024-01-31",
+            )
+
+            assert result["status"] == "success"
+            assert result["data"]["project"] == "TEST"
+            assert result["data"]["sprint"] == "sprint-1"
+            assert result["data"]["total_issues"] == 2
+            assert result["data"]["resolved_issues"] == 1
+            assert result["data"]["remaining_issues"] == 1
+            assert result["data"]["completion_rate"] == 50.0
+            assert result["data"]["total_effort_hours"] == 3.0  # (120 + 60) / 60
+
+    @pytest.mark.asyncio
+    async def test_generate_burndown_report_no_auth(self, report_manager):
+        """Test burndown report generation without authentication."""
+        report_manager.auth_manager.load_credentials.return_value = None
+
+        result = await report_manager.generate_burndown_report("TEST")
+
+        assert result["status"] == "error"
+        assert "Not authenticated" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_generate_burndown_report_http_error(
+        self, report_manager, auth_manager
+    ):
+        """Test burndown report generation with HTTP error."""
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get.side_effect = (
+                httpx.HTTPError("Connection failed")
+            )
+
+            result = await report_manager.generate_burndown_report("TEST")
+
+            assert result["status"] == "error"
+            assert "HTTP error" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_generate_velocity_report_success(self, report_manager, auth_manager):
+        """Test successful velocity report generation."""
+        mock_project_data = {
+            "id": "TEST",
+            "name": "Test Project",
+            "versions": [
+                {"id": "v1", "name": "Sprint 1", "releaseDate": "2024-01-15"},
+                {"id": "v2", "name": "Sprint 2", "releaseDate": "2024-01-30"},
+            ],
+        }
+
+        mock_sprint_issues = [
+            {"id": "1", "resolved": 1234567890, "spent": {"value": 120}},
+            {"id": "2", "resolved": None, "spent": {"value": 60}},
+        ]
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_responses = [
+                Mock(json=lambda: mock_project_data),  # Project response
+                Mock(json=lambda: mock_sprint_issues),  # Sprint 1 issues
+                Mock(json=lambda: mock_sprint_issues),  # Sprint 2 issues
+            ]
+
+            for mock_response in mock_responses:
+                mock_response.raise_for_status.return_value = None
+
+            mock_client.return_value.__aenter__.return_value.get.side_effect = (
+                mock_responses
+            )
+
+            result = await report_manager.generate_velocity_report("TEST", sprints=2)
+
+            assert result["status"] == "success"
+            assert result["data"]["project"] == "TEST"
+            assert result["data"]["sprints_analyzed"] == 2
+            assert len(result["data"]["sprints"]) == 2
+            assert result["data"]["average_issues_per_sprint"] == 1.0
+            assert result["data"]["average_effort_per_sprint"] == 3.0
+
+    @pytest.mark.asyncio
+    async def test_generate_velocity_report_no_auth(self, report_manager):
+        """Test velocity report generation without authentication."""
+        report_manager.auth_manager.load_credentials.return_value = None
+
+        result = await report_manager.generate_velocity_report("TEST")
+
+        assert result["status"] == "error"
+        assert "Not authenticated" in result["message"]
+
+    def test_display_burndown_report(self, report_manager, capsys):
+        """Test burndown report display."""
+        burndown_data = {
+            "project": "TEST",
+            "sprint": "sprint-1",
+            "period": "2024-01-01 to 2024-01-31",
+            "total_issues": 10,
+            "resolved_issues": 7,
+            "remaining_issues": 3,
+            "completion_rate": 70.0,
+            "total_effort_hours": 15.5,
+        }
+
+        with patch("rich.console.Console.print") as mock_print:
+            report_manager.display_burndown_report(burndown_data)
+
+            # Verify that print was called multiple times with project info
+            mock_print.assert_called()
+            call_args = [call[0][0] for call in mock_print.call_args_list]
+            project_info_found = any("TEST" in str(arg) for arg in call_args)
+            assert project_info_found
+
+    def test_display_velocity_report(self, report_manager):
+        """Test velocity report display."""
+        velocity_data = {
+            "project": "TEST",
+            "sprints_analyzed": 2,
+            "sprints": [
+                {
+                    "name": "Sprint 1",
+                    "release_date": "2024-01-15",
+                    "total_issues": 8,
+                    "resolved_issues": 6,
+                    "total_effort_hours": 12.0,
+                },
+                {
+                    "name": "Sprint 2",
+                    "release_date": "2024-01-30",
+                    "total_issues": 10,
+                    "resolved_issues": 8,
+                    "total_effort_hours": 15.0,
+                },
+            ],
+            "average_issues_per_sprint": 9.0,
+            "average_effort_per_sprint": 13.5,
+        }
+
+        with patch("rich.console.Console.print") as mock_print:
+            report_manager.display_velocity_report(velocity_data)
+
+            # Verify that print was called
+            mock_print.assert_called()
+
+    def test_display_velocity_report_empty(self, report_manager):
+        """Test velocity report display with no sprint data."""
+        velocity_data = {"project": "TEST", "sprints_analyzed": 0, "sprints": []}
+
+        with patch("rich.console.Console.print") as mock_print:
+            report_manager.display_velocity_report(velocity_data)
+
+            # Verify that it shows "No sprint data available"
+            mock_print.assert_called()
+            call_args = [call[0][0] for call in mock_print.call_args_list]
+            no_data_found = any(
+                "No sprint data available" in str(arg) for arg in call_args
+            )
+            assert no_data_found
+
+
+class TestReportsCommands:
+    """Test reports CLI commands."""
+
+    def setup_method(self):
+        """Set up test method."""
+        self.runner = CliRunner()
+
+    @patch("youtrack_cli.main.ReportManager")
+    @patch("youtrack_cli.main.AuthManager")
+    @patch("youtrack_cli.main.ConfigManager")
+    def test_burndown_command_success(self, mock_config, mock_auth, mock_report):
+        """Test burndown command execution."""
+        # Mock the async function
+        mock_report_instance = mock_report.return_value
+        mock_report_instance.generate_burndown_report.return_value = {
+            "status": "success",
+            "data": {
+                "project": "TEST",
+                "total_issues": 10,
+                "resolved_issues": 7,
+                "remaining_issues": 3,
+                "completion_rate": 70.0,
+                "total_effort_hours": 15.5,
+            },
+        }
+
+        with patch("asyncio.run") as mock_asyncio:
+            result = self.runner.invoke(main, ["reports", "burndown", "TEST"])
+
+            assert result.exit_code == 0
+            mock_asyncio.assert_called_once()
+
+    @patch("youtrack_cli.main.ReportManager")
+    @patch("youtrack_cli.main.AuthManager")
+    @patch("youtrack_cli.main.ConfigManager")
+    def test_velocity_command_success(self, mock_config, mock_auth, mock_report):
+        """Test velocity command execution."""
+        # Mock the async function
+        mock_report_instance = mock_report.return_value
+        mock_report_instance.generate_velocity_report.return_value = {
+            "status": "success",
+            "data": {
+                "project": "TEST",
+                "sprints_analyzed": 3,
+                "sprints": [],
+                "average_issues_per_sprint": 8.0,
+                "average_effort_per_sprint": 12.0,
+            },
+        }
+
+        with patch("asyncio.run") as mock_asyncio:
+            result = self.runner.invoke(
+                main, ["reports", "velocity", "TEST", "--sprints", "3"]
+            )
+
+            assert result.exit_code == 0
+            mock_asyncio.assert_called_once()
+
+    def test_reports_group_help(self):
+        """Test reports group help command."""
+        result = self.runner.invoke(main, ["reports", "--help"])
+
+        assert result.exit_code == 0
+        assert "Generate cross-entity reports" in result.output
+        assert "burndown" in result.output
+        assert "velocity" in result.output
+
+    def test_burndown_command_help(self):
+        """Test burndown command help."""
+        result = self.runner.invoke(main, ["reports", "burndown", "--help"])
+
+        assert result.exit_code == 0
+        assert "Generate a burndown report" in result.output
+        assert "--sprint" in result.output
+        assert "--start-date" in result.output
+        assert "--end-date" in result.output
+
+    def test_velocity_command_help(self):
+        """Test velocity command help."""
+        result = self.runner.invoke(main, ["reports", "velocity", "--help"])
+
+        assert result.exit_code == 0
+        assert "Generate a velocity report" in result.output
+        assert "--sprints" in result.output

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands =
 
 [testenv:type]
 deps = mypy
-commands = mypy yt_cli
+commands = mypy youtrack_cli
 
 [testenv:format]
 deps = ruff

--- a/youtrack_cli/reports.py
+++ b/youtrack_cli/reports.py
@@ -1,0 +1,307 @@
+"""Report generation for YouTrack CLI."""
+
+from typing import Any, Optional
+
+import httpx
+from rich.console import Console
+from rich.table import Table
+
+from .auth import AuthManager
+
+
+class ReportManager:
+    """Manages YouTrack report generation operations."""
+
+    def __init__(self, auth_manager: AuthManager):
+        """Initialize the report manager.
+
+        Args:
+            auth_manager: AuthManager instance for authentication
+        """
+        self.auth_manager = auth_manager
+        self.console = Console()
+
+    async def generate_burndown_report(
+        self,
+        project_id: str,
+        sprint_id: Optional[str] = None,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Generate a burndown report for a project or sprint.
+
+        Args:
+            project_id: Project ID or short name
+            sprint_id: Sprint ID (optional)
+            start_date: Start date in YYYY-MM-DD format
+            end_date: End date in YYYY-MM-DD format
+
+        Returns:
+            Dictionary with operation result
+        """
+        credentials = self.auth_manager.load_credentials()
+        if not credentials:
+            return {
+                "status": "error",
+                "message": "Not authenticated. Run 'yt auth login' first.",
+            }
+
+        # Build query for issues
+        query_parts = [f"project: {project_id}"]
+
+        if sprint_id:
+            query_parts.append(f"Fix versions: {sprint_id}")
+
+        if start_date and end_date:
+            query_parts.append(f"created: {start_date} .. {end_date}")
+
+        query = " ".join(query_parts)
+
+        headers = {
+            "Authorization": f"Bearer {credentials.token}",
+            "Accept": "application/json",
+        }
+
+        params = {
+            "query": query,
+            "fields": "id,summary,resolved,created,updated,state(name),spent(value)",
+            "$top": "1000",
+        }
+
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.get(
+                    f"{credentials.base_url.rstrip('/')}/api/issues",
+                    headers=headers,
+                    params=params,
+                    timeout=30.0,
+                )
+                response.raise_for_status()
+
+                issues = response.json()
+
+                # Calculate burndown metrics
+                total_issues = len(issues)
+                resolved_issues = len([i for i in issues if i.get("resolved")])
+                remaining_issues = total_issues - resolved_issues
+
+                # Calculate total effort if story points available
+                total_effort = sum(
+                    issue.get("spent", {}).get("value", 0) for issue in issues
+                )
+
+                burndown_data = {
+                    "project": project_id,
+                    "sprint": sprint_id,
+                    "period": (
+                        f"{start_date} to {end_date}"
+                        if start_date and end_date
+                        else "All time"
+                    ),
+                    "total_issues": total_issues,
+                    "resolved_issues": resolved_issues,
+                    "remaining_issues": remaining_issues,
+                    "completion_rate": (
+                        round((resolved_issues / total_issues * 100), 2)
+                        if total_issues > 0
+                        else 0
+                    ),
+                    "total_effort_hours": (
+                        total_effort / 60 if total_effort > 0 else 0
+                    ),  # Convert minutes to hours
+                    "issues": issues,
+                }
+
+                return {"status": "success", "data": burndown_data}
+
+            except httpx.HTTPError as e:
+                return {"status": "error", "message": f"HTTP error: {e}"}
+            except Exception as e:
+                return {"status": "error", "message": f"Unexpected error: {e}"}
+
+    async def generate_velocity_report(
+        self, project_id: str, sprints: int = 5
+    ) -> dict[str, Any]:
+        """Generate a velocity report for recent sprints.
+
+        Args:
+            project_id: Project ID or short name
+            sprints: Number of recent sprints to analyze
+
+        Returns:
+            Dictionary with operation result
+        """
+        credentials = self.auth_manager.load_credentials()
+        if not credentials:
+            return {
+                "status": "error",
+                "message": "Not authenticated. Run 'yt auth login' first.",
+            }
+
+        headers = {
+            "Authorization": f"Bearer {credentials.token}",
+            "Accept": "application/json",
+        }
+
+        # Get project versions (sprints)
+        async with httpx.AsyncClient() as client:
+            try:
+                # First get the project to find versions
+                project_response = await client.get(
+                    f"{credentials.base_url.rstrip('/')}/api/admin/projects/{project_id}",
+                    headers=headers,
+                    params={"fields": "id,name,versions(id,name,released,releaseDate)"},
+                    timeout=10.0,
+                )
+                project_response.raise_for_status()
+                project_data = project_response.json()
+
+                versions = project_data.get("versions", [])
+                recent_versions = sorted(
+                    versions, key=lambda v: v.get("releaseDate", ""), reverse=True
+                )[:sprints]
+
+                velocity_data: dict[str, Any] = {
+                    "project": project_id,
+                    "sprints_analyzed": len(recent_versions),
+                    "sprints": [],
+                }
+
+                for version in recent_versions:
+                    # Get issues for this sprint/version
+                    query = f"project: {project_id} Fix versions: {version['name']}"
+
+                    issues_response = await client.get(
+                        f"{credentials.base_url.rstrip('/')}/api/issues",
+                        headers=headers,
+                        params={
+                            "query": query,
+                            "fields": "id,resolved,spent(value)",
+                            "$top": "1000",
+                        },
+                        timeout=30.0,
+                    )
+                    issues_response.raise_for_status()
+                    sprint_issues = issues_response.json()
+
+                    resolved_count = len(
+                        [i for i in sprint_issues if i.get("resolved")]
+                    )
+                    total_effort = sum(
+                        issue.get("spent", {}).get("value", 0)
+                        for issue in sprint_issues
+                    )
+
+                    sprint_data = {
+                        "name": version["name"],
+                        "release_date": version.get("releaseDate"),
+                        "total_issues": len(sprint_issues),
+                        "resolved_issues": resolved_count,
+                        "total_effort_hours": (
+                            total_effort / 60 if total_effort > 0 else 0
+                        ),
+                    }
+                    velocity_data["sprints"].append(sprint_data)
+
+                # Calculate average velocity
+                if velocity_data["sprints"]:
+                    avg_resolved = sum(
+                        s["resolved_issues"] for s in velocity_data["sprints"]
+                    ) / len(velocity_data["sprints"])
+                    avg_effort = sum(
+                        s["total_effort_hours"] for s in velocity_data["sprints"]
+                    ) / len(velocity_data["sprints"])
+
+                    velocity_data["average_issues_per_sprint"] = round(avg_resolved, 2)
+                    velocity_data["average_effort_per_sprint"] = round(avg_effort, 2)
+
+                return {"status": "success", "data": velocity_data}
+
+            except httpx.HTTPError as e:
+                return {"status": "error", "message": f"HTTP error: {e}"}
+            except Exception as e:
+                return {"status": "error", "message": f"Unexpected error: {e}"}
+
+    def display_burndown_report(self, burndown_data: dict[str, Any]) -> None:
+        """Display burndown report in a formatted table.
+
+        Args:
+            burndown_data: Burndown report data
+        """
+        self.console.print(
+            f"\n[bold blue]Burndown Report - {burndown_data['project']}[/bold blue]"
+        )
+
+        if burndown_data.get("sprint"):
+            self.console.print(f"[cyan]Sprint:[/cyan] {burndown_data['sprint']}")
+
+        self.console.print(f"[cyan]Period:[/cyan] {burndown_data['period']}")
+        self.console.print(
+            f"[cyan]Total Issues:[/cyan] {burndown_data['total_issues']}"
+        )
+        self.console.print(
+            f"[cyan]Resolved Issues:[/cyan] {burndown_data['resolved_issues']}"
+        )
+        self.console.print(
+            f"[cyan]Remaining Issues:[/cyan] {burndown_data['remaining_issues']}"
+        )
+        self.console.print(
+            f"[cyan]Completion Rate:[/cyan] {burndown_data['completion_rate']}%"
+        )
+
+        if burndown_data["total_effort_hours"] > 0:
+            self.console.print(
+                f"[cyan]Total Effort:[/cyan] "
+                f"{burndown_data['total_effort_hours']:.1f} hours"
+            )
+
+        # Create progress bar visualization
+        completion_rate = burndown_data["completion_rate"]
+        bar_length = 20
+        filled_length = int(bar_length * completion_rate / 100)
+        bar = "█" * filled_length + "░" * (bar_length - filled_length)
+
+        self.console.print(f"\n[cyan]Progress:[/cyan] [{bar}] {completion_rate}%")
+
+    def display_velocity_report(self, velocity_data: dict[str, Any]) -> None:
+        """Display velocity report in a formatted table.
+
+        Args:
+            velocity_data: Velocity report data
+        """
+        self.console.print(
+            f"\n[bold blue]Velocity Report - {velocity_data['project']}[/bold blue]"
+        )
+
+        if not velocity_data["sprints"]:
+            self.console.print("No sprint data available.", style="yellow")
+            return
+
+        table = Table(title=f"Recent {velocity_data['sprints_analyzed']} Sprints")
+        table.add_column("Sprint", style="cyan", no_wrap=True)
+        table.add_column("Release Date", style="dim")
+        table.add_column("Total Issues", style="blue")
+        table.add_column("Resolved", style="green")
+        table.add_column("Effort (hrs)", style="magenta")
+
+        for sprint in velocity_data["sprints"]:
+            table.add_row(
+                sprint["name"],
+                sprint.get("release_date", "N/A"),
+                str(sprint["total_issues"]),
+                str(sprint["resolved_issues"]),
+                f"{sprint['total_effort_hours']:.1f}",
+            )
+
+        self.console.print(table)
+
+        # Display averages
+        if velocity_data.get("average_issues_per_sprint"):
+            self.console.print(
+                f"\n[cyan]Average Issues per Sprint:[/cyan] "
+                f"{velocity_data['average_issues_per_sprint']}"
+            )
+            self.console.print(
+                f"[cyan]Average Effort per Sprint:[/cyan] "
+                f"{velocity_data['average_effort_per_sprint']:.1f} hours"
+            )


### PR DESCRIPTION
## Summary
- ✅ **Complete implementation** of `yt reports` command group as specified in issue #11
- 🔥 **Burndown reports** for tracking project/sprint progress with completion metrics  
- 📈 **Velocity reports** for analyzing team performance across recent sprints
- 🎨 **Rich visualization** with progress bars, tables, and status indicators
- 🧪 **Comprehensive testing** with 13 new test cases covering all functionality
- 📚 **Full documentation** with usage examples and feature descriptions

## Features Implemented

### Commands Added
- `yt reports burndown PROJECT-ID` - Generate burndown reports with optional sprint and date filtering
- `yt reports velocity PROJECT-ID` - Generate velocity reports for recent sprints (configurable count)

### Key Capabilities
- **Flexible Filtering**: Sprint-specific reports, date range filtering, configurable sprint counts
- **Rich Metrics**: Completion rates, effort tracking, velocity trends, progress visualization
- **Error Handling**: Proper authentication checks, API error handling, user-friendly messages
- **Display Options**: Beautiful tables, progress bars, and formatted output using Rich library

## Technical Implementation
- **New Module**: `youtrack_cli/reports.py` with `ReportManager` class
- **API Integration**: Uses YouTrack REST API for issues, projects, and sprint data
- **Async Operations**: Proper async/await patterns matching existing codebase
- **Type Safety**: Full type annotations and mypy compliance
- **Code Quality**: Passes all linting, formatting, and quality checks

## Test Coverage
- ✅ **13 comprehensive test cases** covering all report functionality
- ✅ **Unit tests** for report generation, display methods, and error scenarios  
- ✅ **Integration tests** for CLI commands and help functionality
- ✅ **Error handling tests** for authentication and HTTP errors

## Test Plan
- [x] All existing tests continue to pass (169 total tests)
- [x] New reports functionality fully tested
- [x] Linting and formatting checks pass (`ruff check`, `ruff format`)
- [x] Type checking passes (`mypy`)
- [x] Security checks pass (`zizmor`)
- [x] Tox environments pass (`tox -e lint`, `tox -e type`)

🤖 Generated with [Claude Code](https://claude.ai/code)