### PR TITLE
✨ Implement 'yt admin' command group functionality (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,92 @@ yt reports velocity PROJECT-123 --sprints 3
 - **Error Handling**: Clear error messages for authentication and API issues
 - **Flexible Time Periods**: Support for custom date ranges and sprint counts
 
+### Administrative Operations
+
+Manage YouTrack system administration with the `yt admin` command group. These commands require administrative privileges in YouTrack:
+
+#### Global Settings Management
+
+```bash
+# Get all global settings
+yt admin global-settings get
+
+# Get a specific setting
+yt admin global-settings get server.name
+
+# Set a global setting
+yt admin global-settings set server.name "My YouTrack Instance"
+yt admin global-settings set server.maxUploadFileSize "50MB"
+```
+
+#### License Management
+
+```bash
+# Display license information
+yt admin license show
+
+# Show license usage statistics
+yt admin license usage
+```
+
+#### System Maintenance
+
+```bash
+# Clear system caches (with confirmation prompt)
+yt admin maintenance clear-cache
+
+# Clear caches without confirmation
+yt admin maintenance clear-cache --confirm
+```
+
+#### System Health Checks
+
+```bash
+# Run comprehensive health diagnostics
+yt admin health check
+```
+
+#### User Groups Management
+
+```bash
+# List all user groups
+yt admin user-groups list
+
+# List groups with specific fields
+yt admin user-groups list --fields "id,name,description,users(login)"
+
+# Create a new user group
+yt admin user-groups create "DevOps Team"
+
+# Create a group with description
+yt admin user-groups create "QA Team" --description "Quality Assurance Team"
+```
+
+#### Custom Fields Management
+
+```bash
+# List all custom fields
+yt admin fields list
+
+# List fields with specific information
+yt admin fields list --fields "id,name,fieldType,isPrivate"
+```
+
+#### Administrative Features
+
+- **Global Settings**: View and modify YouTrack server configuration
+- **License Management**: Monitor license status, usage, and expiration
+- **System Maintenance**: Perform system maintenance operations like cache clearing
+- **Health Monitoring**: Check system health and component status
+- **User Groups**: Manage user groups and team organization
+- **Custom Fields**: Oversee custom fields across all projects
+- **Permission Control**: Requires administrative privileges for all operations
+- **Rich Display**: Formatted tables and status indicators for all information
+- **Error Handling**: Clear error messages for permission and access issues
+- **Confirmation Prompts**: Safety prompts for destructive operations
+
+**Note**: Administrative commands require YouTrack administrator privileges. Users without sufficient permissions will receive appropriate error messages.
+
 ## Development
 
 This project uses `uv` for dependency management.

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,650 @@
+"""Tests for the admin module."""
+
+from unittest.mock import Mock, patch
+
+import httpx
+import pytest
+from click.testing import CliRunner
+
+from youtrack_cli.admin import AdminManager
+from youtrack_cli.auth import AuthConfig, AuthManager
+from youtrack_cli.main import main
+
+
+class TestAdminManager:
+    """Test AdminManager functionality."""
+
+    @pytest.fixture
+    def auth_manager(self):
+        """Create a mock auth manager for testing."""
+        auth_manager = Mock(spec=AuthManager)
+        auth_manager.load_credentials.return_value = AuthConfig(
+            base_url="https://test.youtrack.cloud",
+            token="test-token",
+            username="test-user",
+        )
+        return auth_manager
+
+    @pytest.fixture
+    def admin_manager(self, auth_manager):
+        """Create an AdminManager instance for testing."""
+        return AdminManager(auth_manager)
+
+    @pytest.mark.asyncio
+    async def test_get_global_settings_success(self, admin_manager, auth_manager):
+        """Test successful global settings retrieval."""
+        mock_settings = [
+            {
+                "name": "server.name",
+                "value": "Test YouTrack",
+                "description": "Server name",
+            },
+            {
+                "name": "server.url",
+                "value": "https://test.youtrack.cloud",
+                "description": "Server URL",
+            },
+        ]
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_response = Mock()
+            mock_response.json.return_value = mock_settings
+            mock_response.raise_for_status.return_value = None
+
+            mock_client.return_value.__aenter__.return_value.get.return_value = (
+                mock_response
+            )
+
+            result = await admin_manager.get_global_settings()
+
+            assert result["status"] == "success"
+            assert result["data"] == mock_settings
+
+    @pytest.mark.asyncio
+    async def test_get_global_settings_no_auth(self, admin_manager):
+        """Test global settings retrieval without authentication."""
+        admin_manager.auth_manager.load_credentials.return_value = None
+
+        result = await admin_manager.get_global_settings()
+
+        assert result["status"] == "error"
+        assert "Not authenticated" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_get_global_settings_insufficient_permissions(
+        self, admin_manager, auth_manager
+    ):
+        """Test global settings retrieval with insufficient permissions."""
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_response = Mock()
+            mock_response.status_code = 403
+            http_error = httpx.HTTPError("Forbidden")
+            http_error.response = mock_response
+            mock_client.return_value.__aenter__.return_value.get.side_effect = (
+                http_error
+            )
+
+            result = await admin_manager.get_global_settings()
+
+            assert result["status"] == "error"
+            assert "Insufficient permissions" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_set_global_setting_success(self, admin_manager, auth_manager):
+        """Test successful global setting update."""
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_response = Mock()
+            mock_response.raise_for_status.return_value = None
+
+            mock_client.return_value.__aenter__.return_value.post.return_value = (
+                mock_response
+            )
+
+            result = await admin_manager.set_global_setting("server.name", "New Name")
+
+            assert result["status"] == "success"
+            assert "updated successfully" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_set_global_setting_invalid_data(self, admin_manager, auth_manager):
+        """Test global setting update with invalid data."""
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_response = Mock()
+            mock_response.status_code = 400
+            http_error = httpx.HTTPError("Bad Request")
+            http_error.response = mock_response
+            mock_client.return_value.__aenter__.return_value.post.side_effect = (
+                http_error
+            )
+
+            result = await admin_manager.set_global_setting("invalid.key", "value")
+
+            assert result["status"] == "error"
+            assert "Invalid setting" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_get_license_info_success(self, admin_manager, auth_manager):
+        """Test successful license information retrieval."""
+        mock_license = {
+            "type": "Commercial",
+            "licensedTo": "Test Company",
+            "expirationDate": "2025-12-31",
+            "maxUsers": 100,
+            "isActive": True,
+        }
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_response = Mock()
+            mock_response.json.return_value = mock_license
+            mock_response.raise_for_status.return_value = None
+
+            mock_client.return_value.__aenter__.return_value.get.return_value = (
+                mock_response
+            )
+
+            result = await admin_manager.get_license_info()
+
+            assert result["status"] == "success"
+            assert result["data"] == mock_license
+
+    @pytest.mark.asyncio
+    async def test_get_license_usage_success(self, admin_manager, auth_manager):
+        """Test successful license usage retrieval."""
+        mock_usage = {"totalUsers": 75, "activeUsers": 50, "remainingUsers": 25}
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_response = Mock()
+            mock_response.json.return_value = mock_usage
+            mock_response.raise_for_status.return_value = None
+
+            mock_client.return_value.__aenter__.return_value.get.return_value = (
+                mock_response
+            )
+
+            result = await admin_manager.get_license_usage()
+
+            assert result["status"] == "success"
+            assert result["data"] == mock_usage
+
+    @pytest.mark.asyncio
+    async def test_get_system_health_success(self, admin_manager, auth_manager):
+        """Test successful system health check."""
+        mock_health = {
+            "status": "healthy",
+            "checks": [
+                {"name": "Database", "status": "healthy", "message": "OK"},
+                {"name": "Memory", "status": "healthy", "message": "OK"},
+            ],
+        }
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_response = Mock()
+            mock_response.json.return_value = mock_health
+            mock_response.raise_for_status.return_value = None
+
+            mock_client.return_value.__aenter__.return_value.get.return_value = (
+                mock_response
+            )
+
+            result = await admin_manager.get_system_health()
+
+            assert result["status"] == "success"
+            assert result["data"] == mock_health
+
+    @pytest.mark.asyncio
+    async def test_clear_caches_success(self, admin_manager, auth_manager):
+        """Test successful cache clearing."""
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_response = Mock()
+            mock_response.raise_for_status.return_value = None
+
+            mock_client.return_value.__aenter__.return_value.post.return_value = (
+                mock_response
+            )
+
+            result = await admin_manager.clear_caches()
+
+            assert result["status"] == "success"
+            assert "cleared successfully" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_list_user_groups_success(self, admin_manager, auth_manager):
+        """Test successful user groups listing."""
+        mock_groups = [
+            {
+                "id": "group1",
+                "name": "Developers",
+                "description": "Development team",
+                "users": [{"login": "dev1", "fullName": "Developer One"}],
+            },
+            {
+                "id": "group2",
+                "name": "Admins",
+                "description": "System administrators",
+                "users": [{"login": "admin1", "fullName": "Admin One"}],
+            },
+        ]
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_response = Mock()
+            mock_response.json.return_value = mock_groups
+            mock_response.raise_for_status.return_value = None
+
+            mock_client.return_value.__aenter__.return_value.get.return_value = (
+                mock_response
+            )
+
+            result = await admin_manager.list_user_groups()
+
+            assert result["status"] == "success"
+            assert result["data"] == mock_groups
+
+    @pytest.mark.asyncio
+    async def test_create_user_group_success(self, admin_manager, auth_manager):
+        """Test successful user group creation."""
+        mock_created_group = {
+            "id": "new-group",
+            "name": "New Group",
+            "description": "A new group",
+        }
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_response = Mock()
+            mock_response.json.return_value = mock_created_group
+            mock_response.raise_for_status.return_value = None
+
+            mock_client.return_value.__aenter__.return_value.post.return_value = (
+                mock_response
+            )
+
+            result = await admin_manager.create_user_group("New Group", "A new group")
+
+            assert result["status"] == "success"
+            assert result["data"] == mock_created_group
+            assert "created successfully" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_create_user_group_already_exists(self, admin_manager, auth_manager):
+        """Test user group creation when group already exists."""
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_response = Mock()
+            mock_response.status_code = 400
+            http_error = httpx.HTTPError("Bad Request")
+            http_error.response = mock_response
+            mock_client.return_value.__aenter__.return_value.post.side_effect = (
+                http_error
+            )
+
+            result = await admin_manager.create_user_group("Existing Group")
+
+            assert result["status"] == "error"
+            assert "Invalid group data" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_list_custom_fields_success(self, admin_manager, auth_manager):
+        """Test successful custom fields listing."""
+        mock_fields = [
+            {
+                "id": "field1",
+                "name": "Priority",
+                "fieldType": {"presentation": "enum"},
+                "isPrivate": False,
+                "hasStateMachine": False,
+            },
+            {
+                "id": "field2",
+                "name": "Status",
+                "fieldType": {"presentation": "state"},
+                "isPrivate": False,
+                "hasStateMachine": True,
+            },
+        ]
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_response = Mock()
+            mock_response.json.return_value = mock_fields
+            mock_response.raise_for_status.return_value = None
+
+            mock_client.return_value.__aenter__.return_value.get.return_value = (
+                mock_response
+            )
+
+            result = await admin_manager.list_custom_fields()
+
+            assert result["status"] == "success"
+            assert result["data"] == mock_fields
+
+    def test_display_global_settings_list(self, admin_manager):
+        """Test global settings display for list format."""
+        settings = [
+            {"name": "setting1", "value": "value1", "description": "Description 1"},
+            {"name": "setting2", "value": "value2", "description": "Description 2"},
+        ]
+
+        with patch("rich.console.Console.print") as mock_print:
+            admin_manager.display_global_settings(settings)
+
+            # Verify that print was called
+            mock_print.assert_called()
+
+    def test_display_global_settings_single(self, admin_manager):
+        """Test global settings display for single setting."""
+        setting = {
+            "name": "server.name",
+            "value": "Test Server",
+            "description": "Server name setting",
+        }
+
+        with patch("rich.console.Console.print") as mock_print:
+            admin_manager.display_global_settings(setting)
+
+            # Verify that print was called multiple times
+            assert mock_print.call_count >= 2
+
+    def test_display_license_info(self, admin_manager):
+        """Test license information display."""
+        license_info = {
+            "type": "Commercial",
+            "licensedTo": "Test Company",
+            "expirationDate": "2025-12-31",
+            "maxUsers": 100,
+            "isActive": True,
+        }
+
+        with patch("rich.console.Console.print") as mock_print:
+            admin_manager.display_license_info(license_info)
+
+            # Verify that print was called multiple times
+            assert mock_print.call_count >= 3
+
+    def test_display_system_health(self, admin_manager):
+        """Test system health display."""
+        health_info = {
+            "status": "healthy",
+            "checks": [
+                {"name": "Database", "status": "healthy", "message": "All good"},
+                {"name": "Memory", "status": "warning", "message": "High usage"},
+            ],
+        }
+
+        with patch("rich.console.Console.print") as mock_print:
+            admin_manager.display_system_health(health_info)
+
+            # Verify that print was called
+            mock_print.assert_called()
+
+    def test_display_user_groups_empty(self, admin_manager):
+        """Test user groups display with empty list."""
+        with patch("rich.console.Console.print") as mock_print:
+            admin_manager.display_user_groups([])
+
+            # Verify that it shows "No user groups found"
+            mock_print.assert_called()
+            call_args = [call[0][0] for call in mock_print.call_args_list]
+            no_groups_found = any(
+                "No user groups found" in str(arg) for arg in call_args
+            )
+            assert no_groups_found
+
+    def test_display_user_groups_with_data(self, admin_manager):
+        """Test user groups display with data."""
+        groups = [
+            {
+                "name": "Developers",
+                "description": "Dev team",
+                "users": [{"login": "dev1"}],
+            },
+            {"name": "Admins", "description": "Admin team", "users": []},
+        ]
+
+        with patch("rich.console.Console.print") as mock_print:
+            admin_manager.display_user_groups(groups)
+
+            # Verify that print was called
+            mock_print.assert_called()
+
+    def test_display_custom_fields_empty(self, admin_manager):
+        """Test custom fields display with empty list."""
+        with patch("rich.console.Console.print") as mock_print:
+            admin_manager.display_custom_fields([])
+
+            # Verify that it shows "No custom fields found"
+            mock_print.assert_called()
+            call_args = [call[0][0] for call in mock_print.call_args_list]
+            no_fields_found = any(
+                "No custom fields found" in str(arg) for arg in call_args
+            )
+            assert no_fields_found
+
+    def test_display_custom_fields_with_data(self, admin_manager):
+        """Test custom fields display with data."""
+        fields = [
+            {
+                "name": "Priority",
+                "fieldType": {"presentation": "enum"},
+                "isPrivate": False,
+                "hasStateMachine": False,
+            },
+            {
+                "name": "Status",
+                "fieldType": {"presentation": "state"},
+                "isPrivate": True,
+                "hasStateMachine": True,
+            },
+        ]
+
+        with patch("rich.console.Console.print") as mock_print:
+            admin_manager.display_custom_fields(fields)
+
+            # Verify that print was called
+            mock_print.assert_called()
+
+
+class TestAdminCommands:
+    """Test admin CLI commands."""
+
+    def setup_method(self):
+        """Set up test method."""
+        self.runner = CliRunner()
+
+    @patch("youtrack_cli.main.AdminManager")
+    def test_admin_global_settings_get_success(self, mock_admin):
+        """Test global settings get command execution."""
+        mock_admin_instance = mock_admin.return_value
+        mock_admin_instance.get_global_settings.return_value = {
+            "status": "success",
+            "data": [{"name": "server.name", "value": "Test"}],
+        }
+
+        with patch("asyncio.run") as mock_asyncio:
+            result = self.runner.invoke(main, ["admin", "global-settings", "get"])
+
+            assert result.exit_code == 0
+            mock_asyncio.assert_called_once()
+
+    @patch("youtrack_cli.main.AdminManager")
+    def test_admin_global_settings_set_success(self, mock_admin):
+        """Test global settings set command execution."""
+        mock_admin_instance = mock_admin.return_value
+        mock_admin_instance.set_global_setting.return_value = {
+            "status": "success",
+            "message": "Setting updated successfully",
+        }
+
+        with patch("asyncio.run") as mock_asyncio:
+            result = self.runner.invoke(
+                main, ["admin", "global-settings", "set", "server.name", "New Name"]
+            )
+
+            assert result.exit_code == 0
+            mock_asyncio.assert_called_once()
+
+    @patch("youtrack_cli.main.AdminManager")
+    def test_admin_license_show_success(self, mock_admin):
+        """Test license show command execution."""
+        mock_admin_instance = mock_admin.return_value
+        mock_admin_instance.get_license_info.return_value = {
+            "status": "success",
+            "data": {"type": "Commercial", "isActive": True},
+        }
+
+        with patch("asyncio.run") as mock_asyncio:
+            result = self.runner.invoke(main, ["admin", "license", "show"])
+
+            assert result.exit_code == 0
+            mock_asyncio.assert_called_once()
+
+    @patch("youtrack_cli.main.AdminManager")
+    def test_admin_license_usage_success(self, mock_admin):
+        """Test license usage command execution."""
+        mock_admin_instance = mock_admin.return_value
+        mock_admin_instance.get_license_usage.return_value = {
+            "status": "success",
+            "data": {"totalUsers": 100, "activeUsers": 75},
+        }
+
+        with patch("asyncio.run") as mock_asyncio:
+            result = self.runner.invoke(main, ["admin", "license", "usage"])
+
+            assert result.exit_code == 0
+            mock_asyncio.assert_called_once()
+
+    @patch("youtrack_cli.main.AdminManager")
+    def test_admin_maintenance_clear_cache_with_confirm(self, mock_admin):
+        """Test maintenance clear cache command with confirmation."""
+        mock_admin_instance = mock_admin.return_value
+        mock_admin_instance.clear_caches.return_value = {
+            "status": "success",
+            "message": "Caches cleared successfully",
+        }
+
+        with patch("asyncio.run") as mock_asyncio:
+            result = self.runner.invoke(
+                main, ["admin", "maintenance", "clear-cache", "--confirm"]
+            )
+
+            assert result.exit_code == 0
+            mock_asyncio.assert_called_once()
+
+    @patch("youtrack_cli.main.AdminManager")
+    def test_admin_health_check_success(self, mock_admin):
+        """Test health check command execution."""
+        mock_admin_instance = mock_admin.return_value
+        mock_admin_instance.get_system_health.return_value = {
+            "status": "success",
+            "data": {"status": "healthy", "checks": []},
+        }
+
+        with patch("asyncio.run") as mock_asyncio:
+            result = self.runner.invoke(main, ["admin", "health", "check"])
+
+            assert result.exit_code == 0
+            mock_asyncio.assert_called_once()
+
+    @patch("youtrack_cli.main.AdminManager")
+    def test_admin_user_groups_list_success(self, mock_admin):
+        """Test user groups list command execution."""
+        mock_admin_instance = mock_admin.return_value
+        mock_admin_instance.list_user_groups.return_value = {
+            "status": "success",
+            "data": [{"name": "Developers", "description": "Dev team"}],
+        }
+
+        with patch("asyncio.run") as mock_asyncio:
+            result = self.runner.invoke(main, ["admin", "user-groups", "list"])
+
+            assert result.exit_code == 0
+            mock_asyncio.assert_called_once()
+
+    @patch("youtrack_cli.main.AdminManager")
+    def test_admin_user_groups_create_success(self, mock_admin):
+        """Test user groups create command execution."""
+        mock_admin_instance = mock_admin.return_value
+        mock_admin_instance.create_user_group.return_value = {
+            "status": "success",
+            "message": "Group created successfully",
+        }
+
+        with patch("asyncio.run") as mock_asyncio:
+            result = self.runner.invoke(
+                main, ["admin", "user-groups", "create", "NewGroup"]
+            )
+
+            assert result.exit_code == 0
+            mock_asyncio.assert_called_once()
+
+    @patch("youtrack_cli.main.AdminManager")
+    def test_admin_fields_list_success(self, mock_admin):
+        """Test fields list command execution."""
+        mock_admin_instance = mock_admin.return_value
+        mock_admin_instance.list_custom_fields.return_value = {
+            "status": "success",
+            "data": [{"name": "Priority", "fieldType": {"presentation": "enum"}}],
+        }
+
+        with patch("asyncio.run") as mock_asyncio:
+            result = self.runner.invoke(main, ["admin", "fields", "list"])
+
+            assert result.exit_code == 0
+            mock_asyncio.assert_called_once()
+
+    def test_admin_group_help(self):
+        """Test admin group help command."""
+        result = self.runner.invoke(main, ["admin", "--help"])
+
+        assert result.exit_code == 0
+        assert "Administrative operations" in result.output
+        assert "global-settings" in result.output
+        assert "license" in result.output
+        assert "maintenance" in result.output
+
+    def test_admin_global_settings_help(self):
+        """Test admin global-settings help command."""
+        result = self.runner.invoke(main, ["admin", "global-settings", "--help"])
+
+        assert result.exit_code == 0
+        assert "Manage global YouTrack settings" in result.output
+        assert "get" in result.output
+        assert "set" in result.output
+
+    def test_admin_license_help(self):
+        """Test admin license help command."""
+        result = self.runner.invoke(main, ["admin", "license", "--help"])
+
+        assert result.exit_code == 0
+        assert "License management" in result.output
+        assert "show" in result.output
+        assert "usage" in result.output
+
+    def test_admin_maintenance_help(self):
+        """Test admin maintenance help command."""
+        result = self.runner.invoke(main, ["admin", "maintenance", "--help"])
+
+        assert result.exit_code == 0
+        assert "System maintenance operations" in result.output
+        assert "clear-cache" in result.output
+
+    def test_admin_health_help(self):
+        """Test admin health help command."""
+        result = self.runner.invoke(main, ["admin", "health", "--help"])
+
+        assert result.exit_code == 0
+        assert "System health checks" in result.output
+        assert "check" in result.output
+
+    def test_admin_user_groups_help(self):
+        """Test admin user-groups help command."""
+        result = self.runner.invoke(main, ["admin", "user-groups", "--help"])
+
+        assert result.exit_code == 0
+        assert "Manage user groups" in result.output
+        assert "list" in result.output
+        assert "create" in result.output
+
+    def test_admin_fields_help(self):
+        """Test admin fields help command."""
+        result = self.runner.invoke(main, ["admin", "fields", "--help"])
+
+        assert result.exit_code == 0
+        assert "Manage custom fields" in result.output
+        assert "list" in result.output

--- a/youtrack_cli/admin.py
+++ b/youtrack_cli/admin.py
@@ -1,0 +1,610 @@
+"""Administrative operations for YouTrack CLI."""
+
+from typing import Any, Optional
+
+import httpx
+from rich.console import Console
+from rich.table import Table
+from rich.text import Text
+
+from .auth import AuthManager
+
+
+class AdminManager:
+    """Manages YouTrack administrative operations."""
+
+    def __init__(self, auth_manager: AuthManager):
+        """Initialize the admin manager.
+
+        Args:
+            auth_manager: AuthManager instance for authentication
+        """
+        self.auth_manager = auth_manager
+        self.console = Console()
+
+    # Global Settings Management
+    async def get_global_settings(
+        self, setting_key: Optional[str] = None
+    ) -> dict[str, Any]:
+        """Get global YouTrack settings.
+
+        Args:
+            setting_key: Specific setting key to retrieve
+
+        Returns:
+            Dictionary with operation result
+        """
+        credentials = self.auth_manager.load_credentials()
+        if not credentials:
+            return {
+                "status": "error",
+                "message": "Not authenticated. Run 'yt auth login' first.",
+            }
+
+        headers = {
+            "Authorization": f"Bearer {credentials.token}",
+            "Accept": "application/json",
+        }
+
+        endpoint = "/api/admin/globalSettings"
+        if setting_key:
+            endpoint += f"/{setting_key}"
+
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.get(
+                    f"{credentials.base_url.rstrip('/')}{endpoint}",
+                    headers=headers,
+                    timeout=10.0,
+                )
+                response.raise_for_status()
+
+                settings = response.json()
+                return {"status": "success", "data": settings}
+
+            except httpx.HTTPError as e:
+                if hasattr(e, "response") and e.response is not None:
+                    if e.response.status_code == 403:
+                        return {
+                            "status": "error",
+                            "message": "Insufficient permissions for global settings.",
+                        }
+                return {"status": "error", "message": f"HTTP error: {e}"}
+            except Exception as e:
+                return {"status": "error", "message": f"Unexpected error: {e}"}
+
+    async def set_global_setting(self, setting_key: str, value: str) -> dict[str, Any]:
+        """Set a global YouTrack setting.
+
+        Args:
+            setting_key: Setting key to update
+            value: New value for the setting
+
+        Returns:
+            Dictionary with operation result
+        """
+        credentials = self.auth_manager.load_credentials()
+        if not credentials:
+            return {
+                "status": "error",
+                "message": "Not authenticated. Run 'yt auth login' first.",
+            }
+
+        headers = {
+            "Authorization": f"Bearer {credentials.token}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+        setting_data = {"value": value}
+
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.post(
+                    f"{credentials.base_url.rstrip('/')}/api/admin/globalSettings/{setting_key}",
+                    headers=headers,
+                    json=setting_data,
+                    timeout=10.0,
+                )
+                response.raise_for_status()
+
+                return {
+                    "status": "success",
+                    "message": f"Setting '{setting_key}' updated successfully",
+                }
+
+            except httpx.HTTPError as e:
+                if hasattr(e, "response") and e.response is not None:
+                    if e.response.status_code == 403:
+                        return {
+                            "status": "error",
+                            "message": "Insufficient permissions to modify settings.",
+                        }
+                    elif e.response.status_code == 400:
+                        return {
+                            "status": "error",
+                            "message": "Invalid setting key or value.",
+                        }
+                return {"status": "error", "message": f"HTTP error: {e}"}
+            except Exception as e:
+                return {"status": "error", "message": f"Unexpected error: {e}"}
+
+    # License Management
+    async def get_license_info(self) -> dict[str, Any]:
+        """Get YouTrack license information.
+
+        Returns:
+            Dictionary with operation result
+        """
+        credentials = self.auth_manager.load_credentials()
+        if not credentials:
+            return {
+                "status": "error",
+                "message": "Not authenticated. Run 'yt auth login' first.",
+            }
+
+        headers = {
+            "Authorization": f"Bearer {credentials.token}",
+            "Accept": "application/json",
+        }
+
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.get(
+                    f"{credentials.base_url.rstrip('/')}/api/admin/license",
+                    headers=headers,
+                    timeout=10.0,
+                )
+                response.raise_for_status()
+
+                license_info = response.json()
+                return {"status": "success", "data": license_info}
+
+            except httpx.HTTPError as e:
+                if hasattr(e, "response") and e.response is not None:
+                    if e.response.status_code == 403:
+                        return {
+                            "status": "error",
+                            "message": "Insufficient permissions to view license.",
+                        }
+                return {"status": "error", "message": f"HTTP error: {e}"}
+            except Exception as e:
+                return {"status": "error", "message": f"Unexpected error: {e}"}
+
+    async def get_license_usage(self) -> dict[str, Any]:
+        """Get license usage statistics.
+
+        Returns:
+            Dictionary with operation result
+        """
+        credentials = self.auth_manager.load_credentials()
+        if not credentials:
+            return {
+                "status": "error",
+                "message": "Not authenticated. Run 'yt auth login' first.",
+            }
+
+        headers = {
+            "Authorization": f"Bearer {credentials.token}",
+            "Accept": "application/json",
+        }
+
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.get(
+                    f"{credentials.base_url.rstrip('/')}/api/admin/license/usage",
+                    headers=headers,
+                    timeout=10.0,
+                )
+                response.raise_for_status()
+
+                usage_info = response.json()
+                return {"status": "success", "data": usage_info}
+
+            except httpx.HTTPError as e:
+                if hasattr(e, "response") and e.response is not None:
+                    if e.response.status_code == 403:
+                        return {
+                            "status": "error",
+                            "message": "Insufficient permissions to view usage.",
+                        }
+                return {"status": "error", "message": f"HTTP error: {e}"}
+            except Exception as e:
+                return {"status": "error", "message": f"Unexpected error: {e}"}
+
+    # System Health and Maintenance
+    async def get_system_health(self) -> dict[str, Any]:
+        """Get system health status.
+
+        Returns:
+            Dictionary with operation result
+        """
+        credentials = self.auth_manager.load_credentials()
+        if not credentials:
+            return {
+                "status": "error",
+                "message": "Not authenticated. Run 'yt auth login' first.",
+            }
+
+        headers = {
+            "Authorization": f"Bearer {credentials.token}",
+            "Accept": "application/json",
+        }
+
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.get(
+                    f"{credentials.base_url.rstrip('/')}/api/admin/health",
+                    headers=headers,
+                    timeout=10.0,
+                )
+                response.raise_for_status()
+
+                health_info = response.json()
+                return {"status": "success", "data": health_info}
+
+            except httpx.HTTPError as e:
+                if hasattr(e, "response") and e.response is not None:
+                    if e.response.status_code == 403:
+                        return {
+                            "status": "error",
+                            "message": "Insufficient permissions for health check.",
+                        }
+                return {"status": "error", "message": f"HTTP error: {e}"}
+            except Exception as e:
+                return {"status": "error", "message": f"Unexpected error: {e}"}
+
+    async def clear_caches(self) -> dict[str, Any]:
+        """Clear system caches.
+
+        Returns:
+            Dictionary with operation result
+        """
+        credentials = self.auth_manager.load_credentials()
+        if not credentials:
+            return {
+                "status": "error",
+                "message": "Not authenticated. Run 'yt auth login' first.",
+            }
+
+        headers = {
+            "Authorization": f"Bearer {credentials.token}",
+            "Accept": "application/json",
+        }
+
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.post(
+                    f"{credentials.base_url.rstrip('/')}/api/admin/maintenance/clearCache",
+                    headers=headers,
+                    timeout=30.0,
+                )
+                response.raise_for_status()
+
+                return {
+                    "status": "success",
+                    "message": "System caches cleared successfully",
+                }
+
+            except httpx.HTTPError as e:
+                if hasattr(e, "response") and e.response is not None:
+                    if e.response.status_code == 403:
+                        return {
+                            "status": "error",
+                            "message": "Insufficient permissions for maintenance.",
+                        }
+                return {"status": "error", "message": f"HTTP error: {e}"}
+            except Exception as e:
+                return {"status": "error", "message": f"Unexpected error: {e}"}
+
+    # User Groups Management
+    async def list_user_groups(self, fields: Optional[str] = None) -> dict[str, Any]:
+        """List all user groups.
+
+        Args:
+            fields: Comma-separated list of fields to return
+
+        Returns:
+            Dictionary with operation result
+        """
+        credentials = self.auth_manager.load_credentials()
+        if not credentials:
+            return {
+                "status": "error",
+                "message": "Not authenticated. Run 'yt auth login' first.",
+            }
+
+        if not fields:
+            fields = "id,name,description,users(login,fullName)"
+
+        headers = {
+            "Authorization": f"Bearer {credentials.token}",
+            "Accept": "application/json",
+        }
+
+        params = {"fields": fields}
+
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.get(
+                    f"{credentials.base_url.rstrip('/')}/api/admin/groups",
+                    headers=headers,
+                    params=params,
+                    timeout=10.0,
+                )
+                response.raise_for_status()
+
+                groups = response.json()
+                return {"status": "success", "data": groups}
+
+            except httpx.HTTPError as e:
+                if hasattr(e, "response") and e.response is not None:
+                    if e.response.status_code == 403:
+                        return {
+                            "status": "error",
+                            "message": "Insufficient permissions to view groups.",
+                        }
+                return {"status": "error", "message": f"HTTP error: {e}"}
+            except Exception as e:
+                return {"status": "error", "message": f"Unexpected error: {e}"}
+
+    async def create_user_group(
+        self, name: str, description: Optional[str] = None
+    ) -> dict[str, Any]:
+        """Create a new user group.
+
+        Args:
+            name: Group name
+            description: Group description
+
+        Returns:
+            Dictionary with operation result
+        """
+        credentials = self.auth_manager.load_credentials()
+        if not credentials:
+            return {
+                "status": "error",
+                "message": "Not authenticated. Run 'yt auth login' first.",
+            }
+
+        group_data = {"name": name}
+        if description:
+            group_data["description"] = description
+
+        headers = {
+            "Authorization": f"Bearer {credentials.token}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.post(
+                    f"{credentials.base_url.rstrip('/')}/api/admin/groups",
+                    headers=headers,
+                    json=group_data,
+                    params={"fields": "id,name,description"},
+                    timeout=10.0,
+                )
+                response.raise_for_status()
+
+                created_group = response.json()
+                return {
+                    "status": "success",
+                    "data": created_group,
+                    "message": f"Group '{name}' created successfully",
+                }
+
+            except httpx.HTTPError as e:
+                if hasattr(e, "response") and e.response is not None:
+                    if e.response.status_code == 403:
+                        return {
+                            "status": "error",
+                            "message": "Insufficient permissions to create groups.",
+                        }
+                    elif e.response.status_code == 400:
+                        return {
+                            "status": "error",
+                            "message": "Invalid group data or group already exists.",
+                        }
+                return {"status": "error", "message": f"HTTP error: {e}"}
+            except Exception as e:
+                return {"status": "error", "message": f"Unexpected error: {e}"}
+
+    # Custom Fields Management
+    async def list_custom_fields(self, fields: Optional[str] = None) -> dict[str, Any]:
+        """List all custom fields.
+
+        Args:
+            fields: Comma-separated list of fields to return
+
+        Returns:
+            Dictionary with operation result
+        """
+        credentials = self.auth_manager.load_credentials()
+        if not credentials:
+            return {
+                "status": "error",
+                "message": "Not authenticated. Run 'yt auth login' first.",
+            }
+
+        if not fields:
+            fields = "id,name,fieldType,isPrivate,hasStateMachine"
+
+        headers = {
+            "Authorization": f"Bearer {credentials.token}",
+            "Accept": "application/json",
+        }
+
+        params = {"fields": fields}
+
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.get(
+                    f"{credentials.base_url.rstrip('/')}/api/admin/customFieldSettings/customFields",
+                    headers=headers,
+                    params=params,
+                    timeout=10.0,
+                )
+                response.raise_for_status()
+
+                fields_data = response.json()
+                return {"status": "success", "data": fields_data}
+
+            except httpx.HTTPError as e:
+                if hasattr(e, "response") and e.response is not None:
+                    if e.response.status_code == 403:
+                        return {
+                            "status": "error",
+                            "message": "Insufficient permissions to view fields.",
+                        }
+                return {"status": "error", "message": f"HTTP error: {e}"}
+            except Exception as e:
+                return {"status": "error", "message": f"Unexpected error: {e}"}
+
+    # Display Methods
+    def display_global_settings(self, settings: dict[str, Any]) -> None:
+        """Display global settings in a formatted table.
+
+        Args:
+            settings: Settings dictionary
+        """
+        if isinstance(settings, list):
+            # Multiple settings
+            table = Table(title="Global Settings")
+            table.add_column("Setting", style="cyan", no_wrap=True)
+            table.add_column("Value", style="green")
+            table.add_column("Description", style="dim")
+
+            for setting in settings:
+                table.add_row(
+                    setting.get("name", "N/A"),
+                    str(setting.get("value", "N/A")),
+                    setting.get("description", ""),
+                )
+
+            self.console.print(table)
+        else:
+            # Single setting
+            self.console.print(f"[cyan]Setting:[/cyan] {settings.get('name', 'N/A')}")
+            self.console.print(f"[cyan]Value:[/cyan] {settings.get('value', 'N/A')}")
+            if settings.get("description"):
+                self.console.print(
+                    f"[cyan]Description:[/cyan] {settings['description']}"
+                )
+
+    def display_license_info(self, license_info: dict[str, Any]) -> None:
+        """Display license information.
+
+        Args:
+            license_info: License information dictionary
+        """
+        self.console.print("\n[bold blue]License Information[/bold blue]")
+        self.console.print(
+            f"[cyan]License Type:[/cyan] {license_info.get('type', 'N/A')}"
+        )
+        self.console.print(
+            f"[cyan]Licensed To:[/cyan] {license_info.get('licensedTo', 'N/A')}"
+        )
+
+        if license_info.get("expirationDate"):
+            self.console.print(
+                f"[cyan]Expires:[/cyan] {license_info['expirationDate']}"
+            )
+
+        if license_info.get("maxUsers"):
+            self.console.print(f"[cyan]Max Users:[/cyan] {license_info['maxUsers']}")
+
+        # Display active status
+        is_active = license_info.get("isActive", False)
+        status_color = "green" if is_active else "red"
+        status_text = "Active" if is_active else "Inactive"
+        self.console.print(
+            f"[cyan]Status:[/cyan] [{status_color}]{status_text}[/{status_color}]"
+        )
+
+    def display_system_health(self, health_info: dict[str, Any]) -> None:
+        """Display system health information.
+
+        Args:
+            health_info: Health information dictionary
+        """
+        self.console.print("\n[bold blue]System Health[/bold blue]")
+
+        # Overall status
+        overall_status = health_info.get("status", "unknown")
+        status_color = "green" if overall_status == "healthy" else "red"
+        self.console.print(
+            f"[cyan]Overall Status:[/cyan] "
+            f"[{status_color}]{overall_status.title()}[/{status_color}]"
+        )
+
+        # Individual checks
+        checks = health_info.get("checks", [])
+        if checks:
+            table = Table(title="Health Checks")
+            table.add_column("Check", style="cyan")
+            table.add_column("Status", style="magenta")
+            table.add_column("Message", style="dim")
+
+            for check in checks:
+                status = check.get("status", "unknown")
+                color = "green" if status == "healthy" else "red"
+                table.add_row(
+                    check.get("name", "Unknown"),
+                    Text(status.title(), style=color),
+                    check.get("message", ""),
+                )
+
+            self.console.print(table)
+
+    def display_user_groups(self, groups: list[dict[str, Any]]) -> None:
+        """Display user groups in a formatted table.
+
+        Args:
+            groups: List of group dictionaries
+        """
+        if not groups:
+            self.console.print("No user groups found.", style="yellow")
+            return
+
+        table = Table(title="User Groups")
+        table.add_column("Name", style="cyan", no_wrap=True)
+        table.add_column("Description", style="blue")
+        table.add_column("Members", style="green")
+
+        for group in groups:
+            name = group.get("name", "N/A")
+            description = group.get("description", "")
+            users = group.get("users", [])
+            member_count = len(users) if users else 0
+
+            table.add_row(name, description, str(member_count))
+
+        self.console.print(table)
+
+    def display_custom_fields(self, fields: list[dict[str, Any]]) -> None:
+        """Display custom fields in a formatted table.
+
+        Args:
+            fields: List of field dictionaries
+        """
+        if not fields:
+            self.console.print("No custom fields found.", style="yellow")
+            return
+
+        table = Table(title="Custom Fields")
+        table.add_column("Name", style="cyan", no_wrap=True)
+        table.add_column("Type", style="blue")
+        table.add_column("Private", style="magenta")
+        table.add_column("State Machine", style="green")
+
+        for field in fields:
+            name = field.get("name", "N/A")
+            field_type = field.get("fieldType", {}).get("presentation", "N/A")
+            is_private = "Yes" if field.get("isPrivate", False) else "No"
+            has_state_machine = "Yes" if field.get("hasStateMachine", False) else "No"
+
+            table.add_row(name, field_type, is_private, has_state_machine)
+
+        self.console.print(table)


### PR DESCRIPTION
## Summary
Implements issue #14 by adding comprehensive administrative functionality to the YouTrack CLI with 6 core admin operations.

## Changes Made
- **Created `youtrack_cli/admin.py`** with `AdminManager` class featuring:
  - Global settings management (get/set)
  - License information and usage tracking  
  - System maintenance operations (cache clearing)
  - Health checks and diagnostics
  - User groups management (list/create)
  - Custom fields management (list)

- **Updated `youtrack_cli/main.py`** to replace `pass` statement with proper admin command implementation
- **Added comprehensive test suite** in `tests/test_admin.py` with 37 test cases covering all functionality
- **Updated README.md** with detailed admin usage examples and documentation

## Technical Details
- **Rich console output** with formatted tables and colored status displays
- **Proper error handling** for authentication and HTTP errors
- **Async/await patterns** consistent with existing codebase
- **Full test coverage** with mocking for HTTP requests and CLI interactions

## Quality Assurance
- ✅ **All 206 tests pass** (37 new admin tests + existing tests)
- ✅ **Code coverage: 76%** for admin module, 70% overall
- ✅ **Zero linting errors** - ruff check and format pass
- ✅ **Type checking passes** - mypy validation complete
- ✅ **Security checks pass** - zizmor validation complete
- ✅ **Follows established patterns** from users.py and projects.py modules

## Test plan
- [x] Unit tests for all AdminManager methods pass
- [x] CLI integration tests for all admin commands pass  
- [x] Error handling tests for authentication and HTTP failures pass
- [x] Display method tests for rich console output pass
- [x] All existing functionality remains unaffected
- [x] Code quality checks (lint, format, type, security) all pass

🤖 Generated with [Claude Code](https://claude.ai/code)