### PR TITLE
🐛 Fix test environment contamination causing auth test failures (#41)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,40 @@
+"""Global test configuration and fixtures."""
+
+import os
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(scope="function", autouse=True)
+def isolate_environment():
+    """Ensure test isolation by saving and restoring environment variables."""
+    # YouTrack environment variables that could cause test contamination
+    youtrack_env_vars = ["YOUTRACK_BASE_URL", "YOUTRACK_TOKEN", "YOUTRACK_USERNAME"]
+
+    # Store original values
+    original_env: dict[str, Optional[str]] = {}
+    for key in youtrack_env_vars:
+        original_env[key] = os.environ.get(key)
+
+    # Clear YouTrack environment variables before each test
+    for key in youtrack_env_vars:
+        if key in os.environ:
+            del os.environ[key]
+
+    yield
+
+    # Restore original environment after test
+    for key, value in original_env.items():
+        if value is not None:
+            os.environ[key] = value
+        elif key in os.environ:
+            del os.environ[key]
+
+
+@pytest.fixture(scope="function", autouse=True)
+def mock_dotenv_loading():
+    """Mock dotenv loading to prevent real config files from loading."""
+    with patch("youtrack_cli.auth.load_dotenv") as mock_load_dotenv:
+        yield mock_load_dotenv

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -49,6 +49,24 @@ class TestAuthManager:
         self.config_path = os.path.join(self.temp_dir, ".env")
         self.auth_manager = AuthManager(self.config_path)
 
+        # Store original environment variables to restore later
+        self.original_env = {
+            key: os.environ.get(key)
+            for key in ["YOUTRACK_BASE_URL", "YOUTRACK_TOKEN", "YOUTRACK_USERNAME"]
+        }
+
+    def teardown_method(self):
+        """Clean up test fixtures and restore environment."""
+        # Remove any YouTrack environment variables that were set during tests
+        for key in ["YOUTRACK_BASE_URL", "YOUTRACK_TOKEN", "YOUTRACK_USERNAME"]:
+            if key in os.environ:
+                del os.environ[key]
+
+        # Restore original environment variables
+        for key, value in self.original_env.items():
+            if value is not None:
+                os.environ[key] = value
+
     def test_default_config_path(self):
         """Test default config path generation."""
         manager = AuthManager()


### PR DESCRIPTION
## Summary
- Fixes environment contamination issue where environment variables from one test persist and affect subsequent tests
- Addresses intermittent test failures in `test_load_credentials_incomplete`
- Adds global test isolation fixtures to prevent cross-test contamination

## Changes Made
- **Added `tests/conftest.py`** with global test fixtures:
  - `isolate_environment`: Auto-applied fixture that saves/restores YouTrack environment variables before/after each test
  - `mock_dotenv_loading`: Auto-applied fixture that mocks `load_dotenv` to prevent real config file loading
- **Enhanced `TestAuthManager`** in `test_auth.py`:
  - Added environment variable cleanup in `setup_method` and `teardown_method`
  - Ensures test isolation even within the auth test class

## Root Cause
The issue occurred because:
1. The `test_default_config_path` test created an `AuthManager()` without specifying a config path
2. This used the default config path (`~/.config/youtrack-cli/.env`) and called `load_dotenv()`
3. Environment variables from the default config file were loaded into the process environment
4. These variables persisted for subsequent tests, causing `test_load_credentials_incomplete` to fail

## Test Results
- ✅ All auth tests now pass consistently
- ✅ No more intermittent failures when running the full test suite
- ✅ Tests pass both in isolation and when run after other test modules

## Files Changed
- `tests/conftest.py` - New global test configuration
- `tests/test_auth.py` - Enhanced environment cleanup

Closes #41

🤖 Generated with [Claude Code](https://claude.ai/code)