### PR TITLE
🔧 Fix version mismatch between __init__.py and pyproject.toml

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -36,7 +36,8 @@
       "Bash(yt:*)",
       "Bash(git branch:*)",
       "Bash(yt:*)",
-      "WebFetch(domain:pypi.org)"
+      "WebFetch(domain:pypi.org)",
+      "mcp__github__create_issue"
     ],
     "deny": []
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "httpx>=0.24.0",
     "python-dotenv>=1.0.0",
     "pydantic-settings>=2.0.0",
+    "tomli>=1.2.0; python_version<'3.11'",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -1709,7 +1709,7 @@ wheels = [
 
 [[package]]
 name = "youtrack-cli"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -1719,6 +1719,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "rich" },
     { name = "textual" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 
 [package.optional-dependencies]
@@ -1768,6 +1769,7 @@ requires-dist = [
     { name = "sphinx-autobuild", marker = "extra == 'docs'", specifier = ">=2021.3.14" },
     { name = "sphinx-rtd-theme", marker = "extra == 'docs'", specifier = ">=2.0.0" },
     { name = "textual", specifier = ">=0.40.0" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=1.2.0" },
     { name = "tox", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "zizmor", marker = "extra == 'dev'", specifier = ">=0.1.0" },
 ]

--- a/youtrack_cli/__init__.py
+++ b/youtrack_cli/__init__.py
@@ -1,3 +1,27 @@
 """YouTrack CLI - Command line interface for JetBrains YouTrack."""
 
-__version__ = "0.2.0"
+from typing import Any
+
+try:
+    from importlib.metadata import version
+
+    __version__ = version("youtrack-cli")
+except Exception:
+    # Fallback to reading from pyproject.toml
+    try:
+        from pathlib import Path
+
+        try:
+            import tomllib  # type: ignore[import-not-found]
+        except ImportError:
+            import tomli as tomllib  # type: ignore[import-not-found]
+
+        pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
+        if pyproject_path.exists():
+            with open(pyproject_path, "rb") as f:
+                data: dict[str, Any] = tomllib.load(f)
+            __version__ = data["project"]["version"]
+        else:
+            __version__ = "unknown"
+    except Exception:
+        __version__ = "unknown"


### PR DESCRIPTION
## Summary
- Implement single source of truth for versioning using importlib.metadata
- Add fallback to read version from pyproject.toml when metadata unavailable
- Add tomli dependency for Python < 3.11 compatibility

## Changes
- Modified `youtrack_cli/__init__.py` to use `importlib.metadata.version()` as primary source
- Added fallback mechanism to read version from `pyproject.toml` when metadata is unavailable
- Added `tomli` as conditional dependency for Python < 3.11 compatibility
- Ensured version consistency across all package files

## Test plan
- [x] Version detection works correctly (returns 0.2.1 from pyproject.toml)
- [x] Fallback mechanism works when importlib.metadata fails
- [x] All linting and formatting checks pass
- [x] Pre-commit hooks pass
- [x] Type checking passes

Fixes #47

🤖 Generated with [Claude Code](https://claude.ai/code)