### PR TITLE
🐛 Fix type checker mismatch in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,8 @@ commands =
     ruff format --check
 
 [testenv:type]
-deps = mypy
-commands = mypy youtrack_cli
+deps = ty
+commands = ty check --ignore call-non-callable --ignore unresolved-attribute youtrack_cli
 
 [testenv:format]
 deps = ruff


### PR DESCRIPTION
## Summary
Fixes the type checker mismatch in tox.ini where mypy was configured instead of ty.

## Changes Made
- Updated `tox.ini` [testenv:type] section to use `ty` instead of `mypy`
- Matched the command used in CI workflow: `ty check --ignore call-non-callable --ignore unresolved-attribute youtrack_cli`

## Testing
- ✅ Verified ty command runs successfully
- ✅ All linting checks pass
- ✅ All formatting checks pass

## Fixes
Closes #50

🤖 Generated with [Claude Code](https://claude.ai/code)