### PR TITLE
🏷️ Add py.typed marker for type checking support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,12 @@ docs = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+packages = ["youtrack_cli"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"youtrack_cli/py.typed" = "youtrack_cli/py.typed"
+
 [tool.ruff]
 target-version = "py39"
 line-length = 88


### PR DESCRIPTION
## Summary
Adds a `py.typed` marker file to enable type checking support for package users.

## Changes
- ✅ Created empty `py.typed` file in `youtrack_cli/` directory
- ✅ Updated `pyproject.toml` to include `py.typed` in package distribution using hatchling force-include
- ✅ Verified file is included in built wheel package
- ✅ Type hints are now available when package is installed

## Testing
- Built package successfully with `uv build`
- Verified `py.typed` file is included in wheel distribution
- Ran linting checks (passed)
- Type checking confirms package structure is correct

## References
- Fixes #49
- Implements [PEP 561 - Distributing and Packaging Type Information](https://www.python.org/dev/peps/pep-0561/)

This enables better developer experience for package users by making type hints available to IDEs and type checkers.

🤖 Generated with [Claude Code](https://claude.ai/code)