### PR TITLE
📦 Standardize dependency groups in pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ cd yt-cli
 uv sync --dev
 uv pip install -e .
 
-# Or using pip
-pip install -e .[dev]
+# Or using pip (requires pip >= 24.0 for PEP 735 support)
+pip install -e . --group dev
 ```
 
 ### Authentication

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -91,6 +91,45 @@ Project Structure
    ├── justfile               # Task runner configuration
    └── README.md              # Project overview
 
+Dependency Management
+---------------------
+
+The project uses PEP 735 dependency groups for managing development dependencies. This provides a standardized way to organize and install different sets of dependencies.
+
+Dependency Groups
+~~~~~~~~~~~~~~~~~
+
+The project defines the following dependency groups in ``pyproject.toml``:
+
+* **dev**: Development tools including testing, linting, and type checking
+* **docs**: Documentation generation tools
+
+Installing Dependencies
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Using uv (recommended):
+
+.. code-block:: bash
+
+   # Install all dependencies including dev group
+   uv sync --dev
+
+   # Install only production dependencies
+   uv sync
+
+Using pip (requires pip >= 24.0):
+
+.. code-block:: bash
+
+   # Install with dev dependencies
+   pip install -e . --group dev
+
+   # Install with docs dependencies
+   pip install -e . --group docs
+
+   # Install multiple groups
+   pip install -e . --group dev --group docs
+
 Development Workflow
 --------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,21 +49,6 @@ Changelog = "https://github.com/ryan-murphy/yt-cli/blob/main/CHANGELOG.md"
 [project.scripts]
 yt = "youtrack_cli.main:main"
 
-[project.optional-dependencies]
-dev = [
-    "pytest>=7.0.0",
-    "pytest-cov>=4.0.0",
-    "pytest-asyncio>=0.21.0",
-    "ruff>=0.1.0",
-    "tox>=4.0.0",
-    "zizmor>=0.1.0",
-]
-docs = [
-    "sphinx>=7.0.0",
-    "sphinx-rtd-theme>=2.0.0",
-    "myst-parser>=2.0.0",
-    "sphinx-autobuild>=2021.3.14",
-]
 
 [build-system]
 requires = ["hatchling"]
@@ -134,4 +119,10 @@ dev = [
     "zizmor>=1.11.0",
     "twine>=6.1.0",
     "pre-commit>=3.0.0",
+]
+docs = [
+    "sphinx>=7.0.0",
+    "sphinx-rtd-theme>=2.0.0",
+    "myst-parser>=2.0.0",
+    "sphinx-autobuild>=2021.3.14",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1767,22 +1767,6 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 
-[package.optional-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "ruff" },
-    { name = "tox" },
-    { name = "zizmor" },
-]
-docs = [
-    { name = "myst-parser" },
-    { name = "sphinx" },
-    { name = "sphinx-autobuild" },
-    { name = "sphinx-rtd-theme" },
-]
-
 [package.dependency-groups]
 dev = [
     { name = "pre-commit" },
@@ -1796,6 +1780,12 @@ dev = [
     { name = "ty" },
     { name = "zizmor" },
 ]
+docs = [
+    { name = "myst-parser" },
+    { name = "sphinx" },
+    { name = "sphinx-autobuild" },
+    { name = "sphinx-rtd-theme" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1803,23 +1793,13 @@ requires-dist = [
     { name = "cryptography", specifier = ">=41.0.0" },
     { name = "httpx", specifier = ">=0.24.0" },
     { name = "keyring", specifier = ">=25.0.0" },
-    { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=2.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "rich", specifier = ">=13.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
-    { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7.0.0" },
-    { name = "sphinx-autobuild", marker = "extra == 'docs'", specifier = ">=2021.3.14" },
-    { name = "sphinx-rtd-theme", marker = "extra == 'docs'", specifier = ">=2.0.0" },
     { name = "structlog", specifier = ">=25.4.0" },
     { name = "textual", specifier = ">=0.40.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=1.2.0" },
-    { name = "tox", marker = "extra == 'dev'", specifier = ">=4.0.0" },
-    { name = "zizmor", marker = "extra == 'dev'", specifier = ">=0.1.0" },
 ]
 
 [package.metadata.dependency-groups]
@@ -1834,6 +1814,12 @@ dev = [
     { name = "twine", specifier = ">=6.1.0" },
     { name = "ty", specifier = ">=0.0.1a13" },
     { name = "zizmor", specifier = ">=1.11.0" },
+]
+docs = [
+    { name = "myst-parser", specifier = ">=2.0.0" },
+    { name = "sphinx", specifier = ">=7.0.0" },
+    { name = "sphinx-autobuild", specifier = ">=2021.3.14" },
+    { name = "sphinx-rtd-theme", specifier = ">=2.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Migrated from old `[project.optional-dependencies]` to new `[dependency-groups]` format (PEP 735)
- Added docs dependency group with Sphinx-related packages
- Updated documentation and instructions

## Changes
- Removed old `[project.optional-dependencies]` section from `pyproject.toml`
- Consolidated all dependencies into the new `[dependency-groups]` section
- Updated `README.md` pip install instructions for new format
- Added comprehensive dependency management documentation in `docs/development.rst`
- Updated `uv.lock` to reflect the changes

## Test Plan
- [x] All tests pass (`uv run pytest`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Type checking passes (`uv run ty check`)
- [x] Pre-commit hooks pass
- [x] Verified `uv sync --dev` works correctly
- [x] Documentation builds correctly

Fixes #55

🤖 Generated with [Claude Code](https://claude.ai/code)