### PR TITLE
🐛 Fix admin health check command 404 error (#72)

### DIFF
--- a/youtrack_cli/admin.py
+++ b/youtrack_cli/admin.py
@@ -234,7 +234,7 @@ class AdminManager:
         async with httpx.AsyncClient() as client:
             try:
                 response = await client.get(
-                    f"{credentials.base_url.rstrip('/')}/api/admin/health",
+                    f"{credentials.base_url.rstrip('/')}/api/admin/globalSettings/systemSettings",
                     headers=headers,
                     timeout=10.0,
                 )


### PR DESCRIPTION
## Summary
- Fixed 404 Not Found error in `yt admin health check` command
- Replaced invalid `/api/admin/health` endpoint with working `/api/admin/globalSettings/systemSettings` endpoint
- Health check now properly returns system settings information for health monitoring

## Test plan
- [x] Verified the new endpoint exists and is used elsewhere in the codebase
- [x] Ran all tests - they pass
- [x] Ran linting with `uv ruff` - passes
- [x] Ran type checking with `uv ty` - passes
- [x] Reviewed existing documentation - no updates needed as interface remains the same

🤖 Generated with [Claude Code](https://claude.ai/code)