### PR TITLE
🐛 Fix admin license show command 404 error

### DIFF
--- a/youtrack_cli/admin.py
+++ b/youtrack_cli/admin.py
@@ -151,7 +151,7 @@ class AdminManager:
         async with httpx.AsyncClient() as client:
             try:
                 response = await client.get(
-                    f"{credentials.base_url.rstrip('/')}/api/admin/license",
+                    f"{credentials.base_url.rstrip('/')}/api/admin/globalSettings/license",
                     headers=headers,
                     timeout=10.0,
                 )


### PR DESCRIPTION
## Summary
- Fix the API endpoint for the admin license show command from `/api/admin/license` to `/api/admin/globalSettings/license`
- This resolves the 404 Not Found error reported in issue #73

## Changes
- Updated the API endpoint in `youtrack_cli/admin.py:154` to use the correct YouTrack REST API path

## Testing
- ✅ Linting passed with `uv run ruff check`
- ✅ Type checking completed with `uv run ty check` 
- ✅ Pre-commit hooks passed

## Closes
Fixes #73

🤖 Generated with [Claude Code](https://claude.ai/code)