### PR TITLE
🐛 Fix admin license usage command returning 404 Not Found

### DIFF
--- a/youtrack_cli/admin.py
+++ b/youtrack_cli/admin.py
@@ -192,7 +192,7 @@ class AdminManager:
         async with httpx.AsyncClient() as client:
             try:
                 response = await client.get(
-                    f"{credentials.base_url.rstrip('/')}/api/admin/license/usage",
+                    f"{credentials.base_url.rstrip('/')}/api/admin/globalSettings/license/usage",
                     headers=headers,
                     timeout=10.0,
                 )


### PR DESCRIPTION
## Summary
- Fixed admin license usage API endpoint from `/api/admin/license/usage` to `/api/admin/globalSettings/license/usage`
- Resolves 404 Not Found error when running `yt admin license usage` command
- Follows the same pattern as recent admin endpoint fixes (commits f874820 and 5e34c7e)

## Test plan
- [x] All existing tests pass (37/37)
- [x] Ruff linting passes
- [x] Type checking with ty completed
- [x] Pre-commit hooks pass

Fixes #74

🤖 Generated with [Claude Code](https://claude.ai/code)