### PR TITLE
🐛 Fix admin user-groups 404 error by using Hub REST API

### DIFF
--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -209,7 +209,7 @@ class TestAdminManager:
 
         with patch("httpx.AsyncClient") as mock_client:
             mock_response = Mock()
-            mock_response.json.return_value = mock_groups
+            mock_response.json.return_value = {"usergroups": mock_groups}
             mock_response.raise_for_status.return_value = None
 
             mock_client.return_value.__aenter__.return_value.get.return_value = mock_response

--- a/youtrack_cli/admin.py
+++ b/youtrack_cli/admin.py
@@ -327,14 +327,15 @@ class AdminManager:
         async with httpx.AsyncClient() as client:
             try:
                 response = await client.get(
-                    f"{credentials.base_url.rstrip('/')}/api/admin/groups",
+                    f"{credentials.base_url.rstrip('/')}/api/rest/usergroups",
                     headers=headers,
                     params=params,
                     timeout=10.0,
                 )
                 response.raise_for_status()
 
-                groups = response.json()
+                groups_response = response.json()
+                groups = groups_response.get("usergroups", [])
                 return {"status": "success", "data": groups}
 
             except httpx.HTTPError as e:
@@ -378,7 +379,7 @@ class AdminManager:
         async with httpx.AsyncClient() as client:
             try:
                 response = await client.post(
-                    f"{credentials.base_url.rstrip('/')}/api/admin/groups",
+                    f"{credentials.base_url.rstrip('/')}/api/rest/usergroups",
                     headers=headers,
                     json=group_data,
                     params={"fields": "id,name,description"},


### PR DESCRIPTION
## Summary
- Fixed 404 error when running `yt admin user-groups list` command
- Changed endpoint from `/api/admin/groups` to `/api/rest/usergroups`
- User groups are managed by Hub service, not YouTrack service
- Updated response parsing to handle Hub API format

## Root Cause
The CLI was attempting to access user groups through the YouTrack service endpoint `/api/admin/groups`, but user groups are managed by the Hub service in YouTrack architecture. The correct endpoint is `/api/rest/usergroups` on the Hub REST API.

## Changes Made
1. Updated `list_user_groups()` method to use Hub REST API endpoint
2. Updated `create_user_group()` method to use Hub REST API endpoint 
3. Modified response parsing to handle Hub API response format `{"usergroups": [...]}`
4. Updated corresponding test to match new API response format

## Test Plan
- [x] All existing tests pass
- [x] Updated test to match new API response format
- [x] Linting and type checking pass
- [x] Pre-commit hooks pass

Fixes #75

🤖 Generated with [Claude Code](https://claude.ai/code)