### PR TITLE
🐛 Fix API endpoint construction issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "youtrack-cli"
-version = "0.3.3"
+version = "0.3.4"
 description = "YouTrack CLI - Command line interface for JetBrains YouTrack issue tracking system"
 readme = "README.md"
 requires-python = ">=3.9, <3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -1751,7 +1751,7 @@ wheels = [
 
 [[package]]
 name = "youtrack-cli"
-version = "0.3.3"
+version = "0.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/youtrack_cli/admin.py
+++ b/youtrack_cli/admin.py
@@ -201,7 +201,7 @@ class AdminManager:
         async with httpx.AsyncClient() as client:
             try:
                 response = await client.get(
-                    f"{credentials.base_url.rstrip('/')}/api/admin/globalSettings/license/usage",
+                    f"{credentials.base_url.rstrip('/')}/api/admin/globalSettings/license?fields=id,username,license,error",
                     headers=headers,
                     timeout=10.0,
                 )
@@ -370,7 +370,7 @@ class AdminManager:
         async with httpx.AsyncClient() as client:
             try:
                 response = await client.get(
-                    f"{credentials.base_url.rstrip('/')}/api/rest/usergroups",
+                    f"{credentials.base_url.rstrip('/')}/hub/api/rest/usergroups",
                     headers=headers,
                     params=params,
                     timeout=10.0,

--- a/youtrack_cli/main.py
+++ b/youtrack_cli/main.py
@@ -1044,11 +1044,15 @@ def usage(ctx: click.Context) -> None:
             console.print(f"[red]Error:[/red] {result['message']}")
             return
 
-        usage_data = result["data"]
-        console.print("[bold]License Usage Statistics:[/bold]")
-        console.print(f"Total Users: {usage_data.get('totalUsers', 'N/A')}")
-        console.print(f"Active Users: {usage_data.get('activeUsers', 'N/A')}")
-        console.print(f"Remaining Users: {usage_data.get('remainingUsers', 'N/A')}")
+        license_data = result["data"]
+        console.print("[bold]License Information:[/bold]")
+        console.print(f"License ID: {license_data.get('id', 'N/A')}")
+        console.print(f"Username: {license_data.get('username', 'N/A')}")
+        console.print(f"License Key: {license_data.get('license', 'N/A')}")
+        if license_data.get("error"):
+            console.print(f"[red]Error:[/red] {license_data['error']}")
+        else:
+            console.print("[green]Status: Valid[/green]")
 
     asyncio.run(run_license_usage())
 


### PR DESCRIPTION
## Summary
- Fix user-groups endpoint to use Hub REST API (`/hub/api/rest/usergroups`)
- Fix license endpoint to use correct YouTrack API (`/api/admin/globalSettings/license`)
- Update license display to show actual license information instead of non-existent usage statistics

## Issue Resolution
Resolves the 404 Not Found errors when running:
- `yt admin user-groups list` - now returns HTTP 200 OK with user groups table
- `yt admin license usage` - now returns HTTP 200 OK with license information

## Changes Made
1. **User Groups Fix**: Changed endpoint from `/api/rest/usergroups` to `/hub/api/rest/usergroups` (Hub REST API)
2. **License Fix**: Changed endpoint from `/api/admin/globalSettings/license/usage` to `/api/admin/globalSettings/license?fields=id,username,license,error`
3. **Display Update**: Updated license display to show actual license data instead of non-existent usage statistics

## Test Results
Both commands now work correctly:
- User groups command displays table with "All Users" and "Registered Users"
- License command displays license ID, username, license key, and status

🤖 Generated with [Claude Code](https://claude.ai/code)