### PR TITLE
Fix SSL certificate verification error during authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ pip install -e . --group dev
 # Login to your YouTrack instance
 yt auth login
 
+# Login with SSL certificate verification disabled (for self-signed certificates)
+yt auth login --no-verify-ssl
+
 # Verify authentication
 yt auth token --show
 ```

--- a/docs/commands/auth.rst
+++ b/docs/commands/auth.rst
@@ -57,6 +57,9 @@ Authenticate with YouTrack and save credentials for subsequent CLI usage.
    * - ``--username, -n``
      - string
      - Username for reference (optional)
+   * - ``--no-verify-ssl``
+     - flag
+     - Disable SSL certificate verification (use with caution for self-signed certificates)
 
 **Examples:**
 
@@ -73,6 +76,9 @@ Authenticate with YouTrack and save credentials for subsequent CLI usage.
 
    # Completely non-interactive (not recommended for security)
    yt auth login --base-url https://company.youtrack.cloud --token YOUR_API_TOKEN
+
+   # Login with self-signed SSL certificate
+   yt auth login --base-url https://internal.youtrack.local --no-verify-ssl
 
 **Security Notes:**
 
@@ -339,6 +345,21 @@ Connection Problems
    yt auth logout
    yt auth login --base-url https://correct.youtrack.cloud
 
+SSL Certificate Issues
+~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   # For self-signed certificates or internal CAs
+   yt auth login --base-url https://internal.youtrack.local --no-verify-ssl
+
+   # Test connectivity with SSL verification disabled
+   curl -k -H "Authorization: Bearer YOUR_TOKEN" \
+        "https://internal.youtrack.local/api/admin/projects"
+
+   # Note: SSL verification setting is saved with credentials
+   # All subsequent API calls will use the same SSL verification setting
+
 Error Handling
 --------------
 
@@ -363,6 +384,11 @@ Common error scenarios and solutions:
 **Network Issues**
   * Verify connectivity to YouTrack instance
   * Check firewall and proxy settings
+
+**SSL Certificate Errors**
+  * For self-signed certificates: ``yt auth login --no-verify-ssl``
+  * For corporate CAs: Add CA certificate to system trust store
+  * Warning: Only disable SSL verification on trusted networks
 
 **Corrupted Credentials**
   * Clear stored credentials: ``yt auth logout``
@@ -393,6 +419,7 @@ The configuration file contains encrypted authentication data:
    YOUTRACK_BASE_URL=https://company.youtrack.cloud
    YOUTRACK_TOKEN=perm:encrypted_token_data
    YOUTRACK_USERNAME=john.doe
+   YOUTRACK_VERIFY_SSL=true
 
 Custom Configuration
 ~~~~~~~~~~~~~~~~~~~

--- a/youtrack_cli/main.py
+++ b/youtrack_cli/main.py
@@ -607,21 +607,35 @@ def auth(ctx: click.Context) -> None:
 )
 @click.option("--token", "-t", prompt=True, hide_input=True, help="YouTrack API token")
 @click.option("--username", "-n", help="Username (optional)")
+@click.option(
+    "--no-verify-ssl",
+    is_flag=True,
+    help="Disable SSL certificate verification (use with caution)",
+)
 @click.pass_context
-def login(ctx: click.Context, base_url: str, token: str, username: Optional[str]) -> None:
+def login(
+    ctx: click.Context,
+    base_url: str,
+    token: str,
+    username: Optional[str],
+    no_verify_ssl: bool,
+) -> None:
     """Authenticate with YouTrack."""
     console = Console()
     auth_manager = AuthManager(ctx.obj.get("config"))
 
     console.print("🔐 Authenticating with YouTrack...", style="blue")
 
+    if no_verify_ssl:
+        console.print("⚠️  SSL certificate verification disabled. Use with caution!", style="yellow")
+
     try:
         # Verify credentials
-        result = asyncio.run(auth_manager.verify_credentials(base_url, token))
+        result = asyncio.run(auth_manager.verify_credentials(base_url, token, verify_ssl=not no_verify_ssl))
 
         if result["status"] == "success":
             # Save credentials
-            auth_manager.save_credentials(base_url, token, username)
+            auth_manager.save_credentials(base_url, token, username, verify_ssl=not no_verify_ssl)
 
             console.print("✅ Authentication successful!", style="green")
             console.print(f"Logged in as: {result['username']}", style="green")


### PR DESCRIPTION
## Summary
- Added `--no-verify-ssl` flag to `yt auth login` command to handle self-signed certificates
- Updated authentication system to support configurable SSL verification
- SSL verification preference is now saved with credentials for consistent behavior

## Test plan
- [x] Test authentication with SSL verification enabled (default)
- [x] Test authentication with SSL verification disabled using `--no-verify-ssl`
- [x] Verify SSL preference is saved and used for subsequent API calls
- [x] Update documentation

Fixes #89

🤖 Generated with [Claude Code](https://claude.ai/code)