### PR TITLE
🐛 Fix type checker errors in client and logging tests

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -112,6 +112,7 @@ class TestSensitiveDataFilter:
         result = log_filter.filter(record)
 
         assert result is True
+        assert record.args is not None  # Type guard for ty
         assert "***MASKED***" in record.args[0]
         assert "secret123" not in record.args[0]
 
@@ -131,6 +132,7 @@ class TestSensitiveDataFilter:
         result = log_filter.filter(record)
 
         assert result is True
+        assert record.args is not None  # Type guard for ty
         assert record.args[0] == 200
 
 

--- a/youtrack_cli/client.py
+++ b/youtrack_cli/client.py
@@ -391,6 +391,7 @@ def get_client_manager() -> HTTPClientManager:
 async def cleanup_client_manager() -> None:
     """Cleanup the global client manager."""
     global _client_manager
-    if _client_manager:
-        await _client_manager.close()
+    manager = _client_manager
+    if manager is not None:
+        await manager.close()
         _client_manager = None


### PR DESCRIPTION
## Summary
- Fixed ty type checker errors found in `youtrack_cli/client.py` and `tests/test_logging.py`
- All type checks now pass without errors or warnings

## Changes
1. **Fixed HTTPClientManager.close() warning** (`youtrack_cli/client.py:395`)
   - Used a temporary variable to avoid "possibly unbound attribute" warning
   - ty's type analysis now correctly understands the None check

2. **Fixed LogRecord.args subscripting errors** (`tests/test_logging.py`)
   - Added type assertions before accessing `record.args`
   - Handles the `Optional[tuple]` type annotation from logging module

## Test plan
- [x] All ty type checks pass (`uv run ty check`)
- [x] All tests pass (`uv run pytest`)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)