### PR TITLE
🐛 Fix ReportManager SSL verification - Update to use centralized HTTPClientManager

### DIFF
--- a/youtrack_cli/reports.py
+++ b/youtrack_cli/reports.py
@@ -2,11 +2,11 @@
 
 from typing import Any, Optional
 
-import httpx
 from rich.console import Console
 from rich.table import Table
 
 from .auth import AuthManager
+from .client import get_client_manager
 from .progress import get_progress_manager
 
 __all__ = ["ReportManager"]
@@ -76,53 +76,47 @@ class ReportManager:
                 "$top": "1000",
             }
 
-            async with httpx.AsyncClient() as client:
-                try:
-                    # Step 2: Fetch issues from API
-                    tracker.update(description="Fetching issues from YouTrack...")
-                    response = await client.get(
-                        f"{credentials.base_url.rstrip('/')}/api/issues",
-                        headers=headers,
-                        params=params,
-                        timeout=30.0,
-                    )
-                    response.raise_for_status()
+            client_manager = get_client_manager()
+            try:
+                # Step 2: Fetch issues from API
+                tracker.update(description="Fetching issues from YouTrack...")
+                response = await client_manager.make_request(
+                    "GET",
+                    f"{credentials.base_url.rstrip('/')}/api/issues",
+                    headers=headers,
+                    params=params,
+                    timeout=30.0,
+                )
 
-                    issues = response.json()
-                    tracker.advance()
+                issues = response.json()
+                tracker.advance()
 
-                    # Step 3: Calculate burndown metrics
-                    tracker.update(description="Calculating burndown metrics...")
-                    total_issues = len(issues)
-                    resolved_issues = len([i for i in issues if i.get("resolved")])
-                    remaining_issues = total_issues - resolved_issues
+                # Step 3: Calculate burndown metrics
+                tracker.update(description="Calculating burndown metrics...")
+                total_issues = len(issues)
+                resolved_issues = len([i for i in issues if i.get("resolved")])
+                remaining_issues = total_issues - resolved_issues
 
-                    # Calculate total effort if story points available
-                    total_effort = sum(issue.get("spent", {}).get("value", 0) for issue in issues)
+                # Calculate total effort if story points available
+                total_effort = sum(issue.get("spent", {}).get("value", 0) for issue in issues)
 
-                    burndown_data = {
-                        "project": project_id,
-                        "sprint": sprint_id,
-                        "period": (f"{start_date} to {end_date}" if start_date and end_date else "All time"),
-                        "total_issues": total_issues,
-                        "resolved_issues": resolved_issues,
-                        "remaining_issues": remaining_issues,
-                        "completion_rate": (
-                            round((resolved_issues / total_issues * 100), 2) if total_issues > 0 else 0
-                        ),
-                        "total_effort_hours": (
-                            total_effort / 60 if total_effort > 0 else 0
-                        ),  # Convert minutes to hours
-                        "issues": issues,
-                    }
-                    tracker.advance()
+                burndown_data = {
+                    "project": project_id,
+                    "sprint": sprint_id,
+                    "period": (f"{start_date} to {end_date}" if start_date and end_date else "All time"),
+                    "total_issues": total_issues,
+                    "resolved_issues": resolved_issues,
+                    "remaining_issues": remaining_issues,
+                    "completion_rate": (round((resolved_issues / total_issues * 100), 2) if total_issues > 0 else 0),
+                    "total_effort_hours": (total_effort / 60 if total_effort > 0 else 0),  # Convert minutes to hours
+                    "issues": issues,
+                }
+                tracker.advance()
 
-                    return {"status": "success", "data": burndown_data}
+                return {"status": "success", "data": burndown_data}
 
-                except httpx.HTTPError as e:
-                    return {"status": "error", "message": f"HTTP error: {e}"}
-                except Exception as e:
-                    return {"status": "error", "message": f"Unexpected error: {e}"}
+            except Exception as e:
+                return {"status": "error", "message": f"Unexpected error: {e}"}
 
     async def generate_velocity_report(self, project_id: str, sprints: int = 5) -> dict[str, Any]:
         """Generate a velocity report for recent sprints.
@@ -149,87 +143,85 @@ class ReportManager:
         }
 
         # Get project versions (sprints)
-        async with httpx.AsyncClient() as client:
-            try:
-                with progress_manager.progress_bar("Generating velocity report...", total=None) as tracker:
-                    # First get the project to find versions
-                    tracker.update(description="Fetching project versions...")
-                    project_response = await client.get(
-                        f"{credentials.base_url.rstrip('/')}/api/admin/projects/{project_id}",
+        client_manager = get_client_manager()
+        try:
+            with progress_manager.progress_bar("Generating velocity report...", total=None) as tracker:
+                # First get the project to find versions
+                tracker.update(description="Fetching project versions...")
+                project_response = await client_manager.make_request(
+                    "GET",
+                    f"{credentials.base_url.rstrip('/')}/api/admin/projects/{project_id}",
+                    headers=headers,
+                    params={"fields": "id,name,versions(id,name,released,releaseDate)"},
+                    timeout=10.0,
+                )
+                project_data = project_response.json()
+
+                versions = project_data.get("versions", [])
+                recent_versions = sorted(versions, key=lambda v: v.get("releaseDate", ""), reverse=True)[:sprints]
+
+                velocity_data: dict[str, Any] = {
+                    "project": project_id,
+                    "sprints_analyzed": len(recent_versions),
+                    "sprints": [],
+                }
+
+                # Update progress bar with known total
+                tracker.update(
+                    total=len(recent_versions) + 1,
+                    completed=1,
+                    description="Analyzing sprint data...",
+                )
+
+                for i, version in enumerate(recent_versions):
+                    tracker.update(description=f"Processing sprint: {version['name']}")
+
+                    # Get issues for this sprint/version
+                    query = f"project: {project_id} Fix versions: {version['name']}"
+
+                    issues_response = await client_manager.make_request(
+                        "GET",
+                        f"{credentials.base_url.rstrip('/')}/api/issues",
                         headers=headers,
-                        params={"fields": "id,name,versions(id,name,released,releaseDate)"},
-                        timeout=10.0,
+                        params={
+                            "query": query,
+                            "fields": "id,resolved,spent(value)",
+                            "$top": "1000",
+                        },
+                        timeout=30.0,
                     )
-                    project_response.raise_for_status()
-                    project_data = project_response.json()
+                    sprint_issues = issues_response.json()
 
-                    versions = project_data.get("versions", [])
-                    recent_versions = sorted(versions, key=lambda v: v.get("releaseDate", ""), reverse=True)[:sprints]
+                    resolved_count = len([i for i in sprint_issues if i.get("resolved")])
+                    total_effort = sum(issue.get("spent", {}).get("value", 0) for issue in sprint_issues)
 
-                    velocity_data: dict[str, Any] = {
-                        "project": project_id,
-                        "sprints_analyzed": len(recent_versions),
-                        "sprints": [],
+                    sprint_data = {
+                        "name": version["name"],
+                        "release_date": version.get("releaseDate"),
+                        "total_issues": len(sprint_issues),
+                        "resolved_issues": resolved_count,
+                        "total_effort_hours": (total_effort / 60 if total_effort > 0 else 0),
                     }
+                    velocity_data["sprints"].append(sprint_data)
+                    tracker.advance()
 
-                    # Update progress bar with known total
-                    tracker.update(
-                        total=len(recent_versions) + 1,
-                        completed=1,
-                        description="Analyzing sprint data...",
+                # Calculate average velocity
+                tracker.update(description="Calculating velocity averages...")
+                if velocity_data["sprints"]:
+                    avg_resolved = sum(s["resolved_issues"] for s in velocity_data["sprints"]) / len(
+                        velocity_data["sprints"]
+                    )
+                    avg_effort = sum(s["total_effort_hours"] for s in velocity_data["sprints"]) / len(
+                        velocity_data["sprints"]
                     )
 
-                    for i, version in enumerate(recent_versions):
-                        tracker.update(description=f"Processing sprint: {version['name']}")
+                    velocity_data["average_issues_per_sprint"] = round(avg_resolved, 2)
+                    velocity_data["average_effort_per_sprint"] = round(avg_effort, 2)
 
-                        # Get issues for this sprint/version
-                        query = f"project: {project_id} Fix versions: {version['name']}"
+                return {"status": "success", "data": velocity_data}
 
-                        issues_response = await client.get(
-                            f"{credentials.base_url.rstrip('/')}/api/issues",
-                            headers=headers,
-                            params={
-                                "query": query,
-                                "fields": "id,resolved,spent(value)",
-                                "$top": "1000",
-                            },
-                            timeout=30.0,
-                        )
-                        issues_response.raise_for_status()
-                        sprint_issues = issues_response.json()
-
-                        resolved_count = len([i for i in sprint_issues if i.get("resolved")])
-                        total_effort = sum(issue.get("spent", {}).get("value", 0) for issue in sprint_issues)
-
-                        sprint_data = {
-                            "name": version["name"],
-                            "release_date": version.get("releaseDate"),
-                            "total_issues": len(sprint_issues),
-                            "resolved_issues": resolved_count,
-                            "total_effort_hours": (total_effort / 60 if total_effort > 0 else 0),
-                        }
-                        velocity_data["sprints"].append(sprint_data)
-                        tracker.advance()
-
-                    # Calculate average velocity
-                    tracker.update(description="Calculating velocity averages...")
-                    if velocity_data["sprints"]:
-                        avg_resolved = sum(s["resolved_issues"] for s in velocity_data["sprints"]) / len(
-                            velocity_data["sprints"]
-                        )
-                        avg_effort = sum(s["total_effort_hours"] for s in velocity_data["sprints"]) / len(
-                            velocity_data["sprints"]
-                        )
-
-                        velocity_data["average_issues_per_sprint"] = round(avg_resolved, 2)
-                        velocity_data["average_effort_per_sprint"] = round(avg_effort, 2)
-
-                    return {"status": "success", "data": velocity_data}
-
-            except httpx.HTTPError as e:
-                return {"status": "error", "message": f"HTTP error: {e}"}
-            except Exception as e:
-                return {"status": "error", "message": f"Unexpected error: {e}"}
+        except Exception as e:
+            return {"status": "error", "message": f"Unexpected error: {e}"}
 
     def display_burndown_report(self, burndown_data: dict[str, Any]) -> None:
         """Display burndown report in a formatted table.


### PR DESCRIPTION
## Summary

- Replace direct `httpx.AsyncClient` usage with centralized `HTTPClientManager`
- Ensures SSL verification settings from `--no-verify-ssl` are respected
- Update `generate_burndown_report()` and `generate_velocity_report()` methods  
- Remove unused `httpx` import
- Update tests to mock `get_client_manager` instead of `httpx.AsyncClient`

## Test plan

- [x] All existing tests pass
- [x] Linting and type checking pass
- [x] Reports functionality maintains same interface
- [x] SSL verification setting is now properly respected

## Fixes

Closes #97

🤖 Generated with [Claude Code](https://claude.ai/code)