### PR TITLE
🔧 Fix BoardManager SSL verification - Update to use centralized HTTPClientManager

### DIFF
--- a/tests/test_boards.py
+++ b/tests/test_boards.py
@@ -1,6 +1,6 @@
 """Tests for board management functionality."""
 
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -47,15 +47,16 @@ class TestBoardManager:
             }
         ]
 
-        with patch("httpx.AsyncClient") as mock_client:
+        with patch("youtrack_cli.boards.get_client_manager") as mock_get_client_manager:
             mock_resp = Mock()
             mock_resp.status_code = 200
             mock_resp.json.return_value = mock_response
             mock_resp.text = '{"mock": "response"}'
             mock_resp.headers = {"content-type": "application/json"}
-            mock_resp.raise_for_status.return_value = None
 
-            mock_client.return_value.__aenter__.return_value.get.return_value = mock_resp
+            mock_client_manager = Mock()
+            mock_client_manager.make_request = AsyncMock(return_value=mock_resp)
+            mock_get_client_manager.return_value = mock_client_manager
 
             result = await board_manager.list_boards()
 
@@ -74,15 +75,16 @@ class TestBoardManager:
             }
         ]
 
-        with patch("httpx.AsyncClient") as mock_client:
+        with patch("youtrack_cli.boards.get_client_manager") as mock_get_client_manager:
             mock_resp = Mock()
             mock_resp.status_code = 200
             mock_resp.json.return_value = mock_response
             mock_resp.text = '{"mock": "response"}'
             mock_resp.headers = {"content-type": "application/json"}
-            mock_resp.raise_for_status.return_value = None
 
-            mock_client.return_value.__aenter__.return_value.get.return_value = mock_resp
+            mock_client_manager = Mock()
+            mock_client_manager.make_request = AsyncMock(return_value=mock_resp)
+            mock_get_client_manager.return_value = mock_client_manager
 
             result = await board_manager.list_boards(project_id="TEST")
 
@@ -112,15 +114,16 @@ class TestBoardManager:
             "sprints": [{"name": "Sprint 1"}],
         }
 
-        with patch("httpx.AsyncClient") as mock_client:
+        with patch("youtrack_cli.boards.get_client_manager") as mock_get_client_manager:
             mock_resp = Mock()
             mock_resp.status_code = 200
             mock_resp.json.return_value = mock_response
             mock_resp.text = '{"mock": "response"}'
             mock_resp.headers = {"content-type": "application/json"}
-            mock_resp.raise_for_status.return_value = None
 
-            mock_client.return_value.__aenter__.return_value.get.return_value = mock_resp
+            mock_client_manager = Mock()
+            mock_client_manager.make_request = AsyncMock(return_value=mock_resp)
+            mock_get_client_manager.return_value = mock_client_manager
 
             result = await board_manager.view_board("123")
 
@@ -147,15 +150,16 @@ class TestBoardManager:
             "owner": {"name": "Test User"},
         }
 
-        with patch("httpx.AsyncClient") as mock_client:
+        with patch("youtrack_cli.boards.get_client_manager") as mock_get_client_manager:
             mock_resp = Mock()
             mock_resp.status_code = 200
             mock_resp.json.return_value = mock_response
             mock_resp.text = '{"mock": "response"}'
             mock_resp.headers = {"content-type": "application/json"}
-            mock_resp.raise_for_status.return_value = None
 
-            mock_client.return_value.__aenter__.return_value.post.return_value = mock_resp
+            mock_client_manager = Mock()
+            mock_client_manager.make_request = AsyncMock(return_value=mock_resp)
+            mock_get_client_manager.return_value = mock_client_manager
 
             result = await board_manager.update_board("123", name="Updated Board Name")
 
@@ -184,8 +188,10 @@ class TestBoardManager:
     @pytest.mark.asyncio
     async def test_list_boards_general_error(self, board_manager):
         """Test board listing with general error."""
-        with patch("httpx.AsyncClient") as mock_client:
-            mock_client.return_value.__aenter__.return_value.get.side_effect = Exception("Connection error")
+        with patch("youtrack_cli.boards.get_client_manager") as mock_get_client_manager:
+            mock_client_manager = Mock()
+            mock_client_manager.make_request = AsyncMock(side_effect=Exception("Connection error"))
+            mock_get_client_manager.return_value = mock_client_manager
 
             result = await board_manager.list_boards()
 
@@ -195,8 +201,10 @@ class TestBoardManager:
     @pytest.mark.asyncio
     async def test_view_board_general_error(self, board_manager):
         """Test board viewing with general error."""
-        with patch("httpx.AsyncClient") as mock_client:
-            mock_client.return_value.__aenter__.return_value.get.side_effect = Exception("Connection error")
+        with patch("youtrack_cli.boards.get_client_manager") as mock_get_client_manager:
+            mock_client_manager = Mock()
+            mock_client_manager.make_request = AsyncMock(side_effect=Exception("Connection error"))
+            mock_get_client_manager.return_value = mock_client_manager
 
             result = await board_manager.view_board("123")
 
@@ -206,8 +214,10 @@ class TestBoardManager:
     @pytest.mark.asyncio
     async def test_update_board_general_error(self, board_manager):
         """Test board updating with general error."""
-        with patch("httpx.AsyncClient") as mock_client:
-            mock_client.return_value.__aenter__.return_value.post.side_effect = Exception("Connection error")
+        with patch("youtrack_cli.boards.get_client_manager") as mock_get_client_manager:
+            mock_client_manager = Mock()
+            mock_client_manager.make_request = AsyncMock(side_effect=Exception("Connection error"))
+            mock_get_client_manager.return_value = mock_client_manager
 
             result = await board_manager.update_board("123", name="New Name")
 


### PR DESCRIPTION
## Summary
- Updated BoardManager to use centralized HTTPClientManager instead of creating direct httpx.AsyncClient instances
- Modified all HTTP calls in boards.py to use client_manager.make_request() method  
- Updated test mocks to properly test the new HTTPClientManager integration
- Ensures SSL verification setting from --no-verify-ssl is respected in boards commands

## Test plan
- [x] Run all board tests - all pass
- [x] Run linting and type checking - all pass
- [x] Updated test mocks to work with new HTTPClientManager pattern
- [x] Verified SSL verification setting integration

🤖 Generated with [Claude Code](https://claude.ai/code)