### PR TITLE
🔧 Fix ReadTheDocs build by using docs dependency group

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,7 @@ build:
       - pip install uv
     post_install:
       # Install dependencies using uv
-      - uv sync --dev
+      - uv sync --group docs
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:


### PR DESCRIPTION
- Changed uv sync --dev to uv sync --group docs in .readthedocs.yaml
- This ensures myst-parser and other documentation dependencies are installed
- Resolves build failure with missing myst_parser module

🤖 Generated with [Claude Code](https://claude.ai/code)