### PR TITLE
🐛 Fix SSL verification not being respected in API calls

### DIFF
--- a/youtrack_cli/auth.py
+++ b/youtrack_cli/auth.py
@@ -10,6 +10,7 @@ from dotenv import load_dotenv
 from pydantic import BaseModel, Field, ValidationError
 from rich.console import Console
 
+from .client import reset_client_manager
 from .security import CredentialManager, SecurityConfig, TokenManager
 
 __all__ = ["AuthConfig", "AuthManager"]
@@ -101,6 +102,9 @@ class AuthManager:
                 "[yellow]⚠[/yellow] Credentials stored in plain text file. Consider using keyring for better security."
             )
 
+        # Reset the client manager to pick up new SSL settings
+        reset_client_manager()
+
     def load_credentials(self) -> Optional[AuthConfig]:
         """Load authentication credentials from keyring or config file.
 
@@ -170,10 +174,14 @@ class AuthManager:
             self.credential_manager.delete_credential("youtrack_token")
             self.credential_manager.delete_credential("youtrack_username")
             self.credential_manager.delete_credential("youtrack_token_expiry")
+            self.credential_manager.delete_credential("youtrack_verify_ssl")
 
         # Clear from file
         if os.path.exists(self.config_path):
             os.remove(self.config_path)
+
+        # Reset the client manager to pick up new SSL settings
+        reset_client_manager()
 
     def _check_token_expiration(self, config: AuthConfig) -> None:
         """Check token expiration and warn user if needed."""


### PR DESCRIPTION
## Summary
- Fixes SSL verification setting not being propagated from authentication to API calls
- Resolves issue where --no-verify-ssl flag during auth login was ignored by subsequent commands
- Improves SSL verification logic to handle various falsy values properly

## Changes Made
- Fixed `get_client_manager()` SSL verification logic to properly handle `false`, `False`, `0`, `no`, `off`
- Added `reset_client_manager()` function to reset global client when credentials change
- Updated `AuthManager.save_credentials()` to reset client manager after saving SSL settings
- Updated `AuthManager.clear_credentials()` to reset client manager and clean up SSL settings

## Test Plan
- [x] Verified SSL verification logic handles various falsy values correctly
- [x] All existing tests pass
- [x] Linting and type checking pass
- [x] Pre-commit hooks pass

## Fixes
Closes #111

🤖 Generated with [Claude Code](https://claude.ai/code)