### PR TITLE
🐛 Fix auth login not persisting config data and API key masking (Fixes #127)

### DIFF
--- a/docs/commands/auth.rst
+++ b/docs/commands/auth.rst
@@ -83,7 +83,8 @@ Authenticate with YouTrack and save credentials for subsequent CLI usage.
 **Security Notes:**
 
 * API tokens are prompted securely and hidden during input
-* Credentials are stored locally in encrypted format
+* Sensitive credentials (tokens) are stored in system keyring with encryption
+* Non-sensitive configuration (base URL, username, SSL preference) is stored in .env file
 * Never include tokens in command history or scripts
 * Use environment variables or secure prompts for automation
 
@@ -213,17 +214,18 @@ Security Features
 Credential Storage
 ~~~~~~~~~~~~~~~~~
 
-* **Local Storage**: Credentials stored in ``~/.config/youtrack-cli/.env``
-* **Encryption**: Sensitive data is encrypted at rest
-* **Access Control**: Files have restricted permissions
-* **No Plaintext**: Tokens never stored in plaintext
+* **Dual Storage**: Sensitive tokens stored in system keyring, configuration in ``~/.config/youtrack-cli/.env``
+* **Encryption**: Tokens encrypted in keyring using Fernet symmetric encryption
+* **Access Control**: Files have restricted permissions, keyring uses OS security
+* **No Plaintext**: Tokens never stored in plaintext, .env file shows "[Stored in keyring]" placeholder
 
 Token Masking
 ~~~~~~~~~~~~
 
-* **Display Security**: Tokens masked when displayed (``abc123...xyz789``)
+* **Display Security**: Tokens and API keys masked when displayed (``abc123...xyz789``)
 * **Log Safety**: Tokens not exposed in command output or logs
 * **History Protection**: Tokens not stored in shell history
+* **Config List Safety**: API keys shown as masked or "[Stored in keyring]" in config list
 
 Session Management
 ~~~~~~~~~~~~~~~~~
@@ -411,13 +413,13 @@ Credential Storage Location
 Configuration Format
 ~~~~~~~~~~~~~~~~~~~
 
-The configuration file contains encrypted authentication data:
+The configuration file contains non-sensitive authentication data:
 
 .. code-block:: bash
 
-   # Example structure (actual values are encrypted)
+   # Example structure (token stored separately in keyring)
    YOUTRACK_BASE_URL=https://company.youtrack.cloud
-   YOUTRACK_TOKEN=perm:encrypted_token_data
+   YOUTRACK_API_KEY=[Stored in keyring]
    YOUTRACK_USERNAME=john.doe
    YOUTRACK_VERIFY_SSL=true
 

--- a/youtrack_cli/main.py
+++ b/youtrack_cli/main.py
@@ -784,9 +784,12 @@ def list_config(ctx: click.Context) -> None:
             console.print("📋 Configuration values:", style="blue bold")
             for key, value in sorted(config_values.items()):
                 # Mask sensitive values
-                sensitive_keys = ["token", "password", "secret"]
+                sensitive_keys = ["token", "password", "secret", "api_key"]
                 if any(sensitive in key.lower() for sensitive in sensitive_keys):
-                    if len(value) > 12:
+                    # Special handling for placeholder values
+                    if value == "[Stored in keyring]":
+                        masked_value = value
+                    elif len(value) > 12:
                         masked_value = value[:8] + "..." + value[-4:]
                     else:
                         masked_value = "***"


### PR DESCRIPTION
## Summary

Fixes the auth function not persisting configuration data and improves API key masking in config list output.

## Changes Made

### Auth Login Persistence
- **Fixed keyring mode**: When using keyring storage, non-sensitive config (base URL, username, SSL preference) is now also saved to `.env` file for visibility
- **Improved file mode**: Uses ConfigManager consistently instead of direct file writing for better reliability
- **SSL preference persistence**: `--no-verify-ssl` flag setting is now properly saved and restored

### API Key Masking
- **Enhanced masking**: Added "api_key" to sensitive patterns in config list output
- **Special handling**: Keyring placeholder "[Stored in keyring]" is displayed without masking
- **Consistent security**: All token-like values are now properly masked

### Code Improvements
- **Consistent approach**: Both keyring and file storage modes now use ConfigManager for non-sensitive data
- **Selective clearing**: `clear_credentials` now removes only auth-related keys, preserving other config
- **Better error handling**: More robust handling of missing config files

## Testing
- ✅ Added tests for keyring persistence to .env file
- ✅ Added tests for SSL verification preference persistence  
- ✅ Added tests for API key masking in config list
- ✅ Added tests for selective credential clearing
- ✅ Updated existing tests to work with new ConfigManager approach
- ✅ All existing tests pass

## Documentation
- Updated auth documentation to reflect dual storage approach
- Clarified that sensitive tokens are stored in keyring while config is in .env
- Updated security sections to explain the new masking behavior

## Testing Instructions

1. **Test auth persistence**:
   ```bash
   yt auth login --no-verify-ssl
   yt config list  # Should now show config values
   ```

2. **Test API key masking**:
   ```bash
   yt config set YOUTRACK_API_KEY "secret-key-12345"
   yt config list  # Should show masked value
   ```

3. **Test SSL preference persistence**:
   ```bash
   yt auth login --no-verify-ssl  # SSL disabled
   yt config list  # Should show YOUTRACK_VERIFY_SSL=false
   ```

Fixes #127

🤖 Generated with [Claude Code](https://claude.ai/code)