### PR TITLE
🐛 Fix: Error generating projects list (Fixes #129)

### DIFF
--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -53,6 +53,9 @@ class TestProjectManager:
         with patch("youtrack_cli.projects.get_client_manager") as mock_get_client_manager:
             mock_response = Mock()
             mock_response.json.return_value = mock_projects
+            mock_response.headers = {"content-type": "application/json"}
+            mock_response.text = "mock response body"
+            mock_response.status_code = 200
             mock_response.raise_for_status.return_value = None
 
             mock_client_manager = Mock()
@@ -89,6 +92,9 @@ class TestProjectManager:
         with patch("youtrack_cli.projects.get_client_manager") as mock_get_client_manager:
             mock_response = Mock()
             mock_response.json.return_value = mock_projects
+            mock_response.headers = {"content-type": "application/json"}
+            mock_response.text = "mock response body"
+            mock_response.status_code = 200
             mock_response.raise_for_status.return_value = None
 
             mock_client_manager = Mock()


### PR DESCRIPTION
## Summary
- Fixed "object of type 'NoneType' has no len()" error when generating projects list
- Added safe JSON parsing method to handle empty or invalid responses
- Added null checking for projects list response

## Changes Made
- Modified `youtrack_cli/projects.py` to add safe JSON parsing method `_parse_json_response`
- Added null checking for API responses to prevent errors with empty responses
- Updated error handling to provide more context about parsing failures
- Enhanced tests to properly mock response properties (headers, text)

## Test Plan
- [x] Run all existing tests to ensure no regression
- [x] Test projects list command with empty/null responses
- [x] Verify error messages provide helpful context
- [x] Test with various response types (empty, invalid JSON, etc.)

🤖 Generated with [Claude Code](https://claude.ai/code)