### PR TITLE
🐛 Fix links create command - HTTP 405 Method Not Allowed (Fixes #150)

### DIFF
--- a/docs/commands/issues.rst
+++ b/docs/commands/issues.rst
@@ -356,11 +356,28 @@ Create Links
 
    yt issues links create SOURCE_ISSUE_ID TARGET_ISSUE_ID LINK_TYPE
 
-**Example:**
+**Arguments:**
+  * ``SOURCE_ISSUE_ID`` - The ID of the source issue
+  * ``TARGET_ISSUE_ID`` - The ID of the target issue
+  * ``LINK_TYPE`` - Type of link (e.g., "relates", "depends on", "duplicates", "subtask of")
+
+**Examples:**
 
 .. code-block:: bash
 
+   # Create a dependency link
    yt issues links create PROJ-123 PROJ-124 "depends on"
+
+   # Create a relation link
+   yt issues links create PROJ-123 PROJ-125 relates
+
+   # Create a duplicate link
+   yt issues links create PROJ-123 PROJ-126 duplicates
+
+.. note::
+   The CLI automatically resolves link type names to their internal IDs and handles
+   directed vs undirected link types. Use ``yt issues links types`` to see all
+   available link types in your YouTrack instance.
 
 List Links
 ~~~~~~~~~~


### PR DESCRIPTION
## Summary
- Fixed the `yt issues links create` command which was failing with HTTP 405 Method Not Allowed error
- Updated the API endpoint format to match YouTrack's REST API requirements
- Added proper link type resolution and database ID resolution

## Changes Made
- Updated `create_link` method to use correct YouTrack REST API endpoint format `/api/issues/{id}/links/{linkTypeId}/issues`
- Added `_resolve_link_type` method to resolve link type names to their internal IDs
- Added `_get_issue_database_id` method to get database IDs for issues
- Fixed request body to only send target issue database ID
- Added handling for directed vs undirected link types with appropriate suffixes (s/t)
- Updated tests to mock the new API calls properly
- Enhanced documentation with examples and notes about link types

## Technical Details
The issue was that the YouTrack API for creating links requires:
1. The link type ID (not name) in the URL path
2. Only the target issue database ID in the request body (not the full link type object)
3. Special suffixes for directed links ('s' for outward, 't' for inward)

## Testing
- [x] Unit tests added/updated
- [x] Integration tests passing
- [x] Manual testing completed - successfully created links between issues
- [x] Security review completed (if applicable)

## Documentation
- [x] Code comments added where needed
- [x] Documentation updated with examples and notes
- [x] Changelog updated (if applicable)

Fixes #150

🤖 Generated with [Claude Code](https://claude.ai/code)