### PR TITLE
🐛 Fix article list project filtering by using correct API endpoint (Fixes #192)

### DIFF
--- a/youtrack_cli/articles.py
+++ b/youtrack_cli/articles.py
@@ -124,14 +124,16 @@ class ArticleManager:
         params = {"fields": fields}
         if top:
             params["$top"] = str(top)
-        if project_id:
-            params["project"] = project_id
         if parent_id:
             params["parentArticle"] = parent_id
         if query:
             params["query"] = query
 
-        url = f"{credentials.base_url.rstrip('/')}/api/articles"
+        # Use project-specific endpoint when project_id is provided
+        if project_id:
+            url = f"{credentials.base_url.rstrip('/')}/api/admin/projects/{project_id}/articles"
+        else:
+            url = f"{credentials.base_url.rstrip('/')}/api/articles"
         headers = {
             "Authorization": f"Bearer {credentials.token}",
             "Accept": "application/json",
@@ -309,12 +311,14 @@ class ArticleManager:
                 "reporter(fullName),visibility(type),project(name,shortName)"
             ),
         }
-        if project_id:
-            params["project"] = project_id
         if top:
             params["$top"] = str(top)
 
-        url = f"{credentials.base_url.rstrip('/')}/api/articles"
+        # Use project-specific endpoint when project_id is provided
+        if project_id:
+            url = f"{credentials.base_url.rstrip('/')}/api/admin/projects/{project_id}/articles"
+        else:
+            url = f"{credentials.base_url.rstrip('/')}/api/articles"
         headers = {
             "Authorization": f"Bearer {credentials.token}",
             "Accept": "application/json",


### PR DESCRIPTION
## Summary

This PR fixes the bug where the `yt articles list --project-id <PROJECT>` command was not properly filtering articles by the specified project ID. Instead of showing only articles from the requested project, it was displaying articles from all projects.

## Root Cause

The issue was in the `ArticleManager.list_articles()` and `ArticleManager.search_articles()` methods in `/Users/ryan/Documents/github/yt-cli/youtrack_cli/articles.py`. The code was incorrectly using `params["project"] = project_id`, but the YouTrack REST API `/api/articles` endpoint does not support a `project` query parameter for filtering.

## Solution

Updated both methods to use the project-specific API endpoint when a `project_id` is provided:
- **Before**: `{base_url}/api/articles` with invalid `project` parameter
- **After**: `{base_url}/api/admin/projects/{project_id}/articles` when `project_id` is provided

## Changes Made

- **Fixed `list_articles()` method**: Removed invalid `params["project"] = project_id` and updated URL construction to use project-specific endpoint
- **Fixed `search_articles()` method**: Applied the same fix for consistency
- **Added implementation plan**: Created `scratch/issue-192.md` documenting the analysis and solution approach

## Testing

✅ **Manual Testing Performed**:
- `yt articles list --project-id TP` → Shows only TP-A-1 (correctly filtered)
- `yt articles list --project-id HIP` → Shows only HIP-A-1, HIP-A-7 (correctly filtered) 
- `yt articles list` → Shows all articles from all projects (no filtering, as expected)

✅ **Quality Checks**:
- [x] Pre-commit hooks pass
- [x] Type checking passes (`ty`)
- [x] Linting passes (`ruff`)
- [x] All tests pass (`pytest`)
- [x] Manual testing completed with FPU project
- [x] Security review completed (no security implications)

## Documentation

- [x] Implementation plan documented in `scratch/issue-192.md`
- [x] Code changes are self-documenting with clear variable names

## Related Issues

Fixes #192

🤖 Generated with [Claude Code](https://claude.ai/code)