### PR TITLE
🐛 Fix boards list showing empty Name and N/A for Project/Owner fields (Fixes #196)

### DIFF
--- a/youtrack_cli/boards.py
+++ b/youtrack_cli/boards.py
@@ -73,7 +73,7 @@ class BoardManager:
             "Accept": "application/json",
         }
 
-        params = {}
+        params = {"fields": "id,name,projects(id,name),owner(id,name,fullName)"}
         if project_id:
             params["project"] = project_id
 
@@ -94,7 +94,7 @@ class BoardManager:
                     board.get("id", ""),
                     board.get("name", ""),
                     (board.get("projects", [{}])[0].get("name", "N/A") if board.get("projects") else "N/A"),
-                    board.get("owner", {}).get("name", "N/A"),
+                    board.get("owner", {}).get("fullName", "N/A"),
                 )
 
             self.console.print(table)


### PR DESCRIPTION
## Summary

Fixed the `yt boards list` command to properly display board names, projects, and owners instead of showing empty fields and "N/A" values.

## Problem

The `yt boards list` command was displaying:
- Empty Name fields 
- "N/A" for Project and Owner columns
- Only the ID was showing correctly

## Root Cause

The YouTrack REST API requires explicit field selection via the `fields` parameter to return board metadata beyond just the basic ID and type information.

## Changes Made

- Added `fields` parameter to the API request: `"id,name,projects(id,name),owner(id,name,fullName)"`
- Updated owner field access to use `fullName` instead of `name` for better display
- Verified all existing functionality remains intact

## Testing

- [x] Manual testing shows board names, projects, and owners now display correctly
- [x] JSON format output working properly  
- [x] All existing board tests pass
- [x] Pre-commit checks pass
- [x] Linting and type checking pass

## Before/After

**Before:**
```
           Agile Boards           
┏━━━━━━━┳━━━━━━┳━━━━━━━━━┳━━━━━━━┓
┃ ID    ┃ Name ┃ Project ┃ Owner ┃
┡━━━━━━━╇━━━━━━╇━━━━━━━━━╇━━━━━━━┩
│ 173-3 │      │ N/A     │ N/A   │
│ 173-4 │      │ N/A     │ N/A   │
│ 173-5 │      │ N/A     │ N/A   │
└───────┴──────┴─────────┴───────┘
```

**After:**
```
                                  Agile Boards                                  
┏━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
┃ ID    ┃ Name                       ┃ Project                   ┃ Owner       ┃
┡━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
│ 173-3 │ Home Improvement Projects  │ Home Improvement Projects │ admin       │
│       │ Kanban Board               │                           │             │
│ 173-4 │ Interior House Painting    │ Home Improvement Projects │ Ryan Cheley │
│ 173-5 │ Test Project Kanban Board  │ Test Project              │ Ryan Cheley │
└───────┴────────────────────────────┴───────────────────────────┴─────────────┘
```

Fixes #196

🤖 Generated with [Claude Code](https://claude.ai/code)