### PR TITLE
🔧 Suppress expected keyring item not found errors during logout

### DIFF
--- a/youtrack_cli/boards.py
+++ b/youtrack_cli/boards.py
@@ -73,7 +73,7 @@ class BoardManager:
             "Accept": "application/json",
         }
 
-        params = {}
+        params = {"fields": "id,name,projects(id,name),owner(id,name,fullName)"}
         if project_id:
             params["project"] = project_id
 
@@ -94,7 +94,7 @@ class BoardManager:
                     board.get("id", ""),
                     board.get("name", ""),
                     (board.get("projects", [{}])[0].get("name", "N/A") if board.get("projects") else "N/A"),
-                    board.get("owner", {}).get("name", "N/A"),
+                    board.get("owner", {}).get("fullName", "N/A"),
                 )
 
             self.console.print(table)

--- a/youtrack_cli/security.py
+++ b/youtrack_cli/security.py
@@ -9,6 +9,7 @@ from typing import Any, Optional
 
 import keyring
 from cryptography.fernet import Fernet
+from keyring.errors import PasswordDeleteError
 from pydantic import BaseModel, Field
 
 from .logging import get_logger
@@ -322,7 +323,12 @@ class CredentialManager:
             keyring.delete_password(self.KEYRING_SERVICE, key)
             self.logger.info("Credential deleted", key=key)
             return True
+        except PasswordDeleteError:
+            # Expected error when item doesn't exist - log as debug, not error
+            self.logger.debug("Credential not found in keyring", key=key)
+            return False
         except Exception as e:
+            # Unexpected errors should still be logged as errors
             self.logger.error("Failed to delete credential", key=key, error=str(e))
             return False
 


### PR DESCRIPTION
## Summary
- Improves error handling in `CredentialManager.delete_credential()` to properly handle expected "item not found" errors
- Changes logging level from ERROR to DEBUG for missing keyring items during logout
- Maintains ERROR logging for unexpected keyring failures

## Problem
When users run `yt auth logout`, they see confusing ERROR messages like:
```
ERROR    {'key': 'youtrack_username', 'error': "Can't delete password in keychain: (-25300, 'Item not found')", 
         'event': 'Failed to delete credential', 'logger': 'youtrack_cli.security.credentials', 'level': 'error'}
```

These errors occur because the logout process attempts to delete all possible stored credentials, but some items (like `youtrack_username` and `youtrack_token_expiry`) are optional and may never have been stored.

## Solution
- Import `PasswordDeleteError` from `keyring.errors` for proper exception handling
- Catch `PasswordDeleteError` specifically and log as DEBUG level instead of ERROR
- Keep ERROR logging for unexpected keyring failures
- Follows Python keyring library best practices

## Test plan
- [ ] Run `yt auth logout` and verify no ERROR messages appear for missing keyring items
- [ ] Verify actual keyring failures still log as ERROR
- [ ] Confirm logout functionality works correctly
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)