### PR TITLE
🐛 Fix custom fields Type column showing N/A instead of actual field types (Fixes #199)

### DIFF
--- a/docs/commands/admin.rst
+++ b/docs/commands/admin.rst
@@ -305,10 +305,10 @@ List all custom fields configured across YouTrack projects.
    yt admin fields list
 
    # List fields with specific information
-   yt admin fields list --fields "id,name,fieldType,isPrivate"
+   yt admin fields list --fields "id,name,fieldType(presentation),isPrivate"
 
    # List field types and usage
-   yt admin fields list --fields "name,fieldType,projects(name)"
+   yt admin fields list --fields "name,fieldType(presentation),projects(name)"
 
 Administrative Features
 ----------------------

--- a/youtrack_cli/admin.py
+++ b/youtrack_cli/admin.py
@@ -472,7 +472,7 @@ class AdminManager:
             }
 
         if not fields:
-            fields = "id,name,fieldType,isPrivate,hasStateMachine"
+            fields = "id,name,fieldType(presentation),isPrivate,hasStateMachine"
 
         headers = {
             "Authorization": f"Bearer {credentials.token}",


### PR DESCRIPTION
## Summary

Fixed the bug where `yt admin fields list` displayed "N/A" in the Type column for all custom fields instead of showing actual field types like "enum[1]", "state[1]", etc.

## Root Cause

The YouTrack API call was requesting just `fieldType` instead of `fieldType(presentation)`, which only returned the type metadata without the human-readable presentation string.

## Changes Made

- **youtrack_cli/admin.py:475**: Updated API field specification from `fieldType` to `fieldType(presentation)`
- **docs/commands/admin.rst**: Updated documentation examples to show correct usage
- Verified fix with manual testing showing proper field types

## Before Fix
```
┃ Name      ┃ Type ┃ Private ┃ State Machine ┃
│ Priority  │ N/A  │ No      │ No            │
│ Type      │ N/A  │ No      │ No            │
│ State     │ N/A  │ No      │ No            │
```

## After Fix
```
┃ Name      ┃ Type     ┃ Private ┃ State Machine ┃
│ Priority  │ enum[1]  │ No      │ No            │
│ Type      │ enum[1]  │ No      │ No            │
│ State     │ state[1] │ No      │ No            │
```

## Testing

- [x] Manual testing with live YouTrack API confirmed fix
- [x] All admin tests pass (39/39)
- [x] Linting and formatting checks pass
- [x] Documentation updated with correct examples

Fixes #199

🤖 Generated with [Claude Code](https://claude.ai/code)