### PR TITLE
Fix global settings display - handle nested API response structure (Fixes #200)

### DIFF
--- a/docs/commands/admin.rst
+++ b/docs/commands/admin.rst
@@ -305,10 +305,10 @@ List all custom fields configured across YouTrack projects.
    yt admin fields list
 
    # List fields with specific information
-   yt admin fields list --fields "id,name,fieldType,isPrivate"
+   yt admin fields list --fields "id,name,fieldType(presentation),isPrivate"
 
    # List field types and usage
-   yt admin fields list --fields "name,fieldType,projects(name)"
+   yt admin fields list --fields "name,fieldType(presentation),projects(name)"
 
 Administrative Features
 ----------------------

--- a/youtrack_cli/main.py
+++ b/youtrack_cli/main.py
@@ -1080,7 +1080,7 @@ def get_settings(ctx: click.Context, name: Optional[str]) -> None:
     console = get_console()
 
     async def run_get_settings() -> None:
-        result = await admin_manager.get_global_settings()
+        result = await admin_manager.get_global_settings(name)
 
         if result["status"] == "error":
             console.print(f"[red]Error:[/red] {result['message']}")
@@ -1088,12 +1088,8 @@ def get_settings(ctx: click.Context, name: Optional[str]) -> None:
 
         settings = result["data"]
         if name:
-            # Filter for specific setting
-            filtered_settings = [s for s in settings if s.get("name") == name]
-            if filtered_settings:
-                admin_manager.display_global_settings(filtered_settings[0])
-            else:
-                console.print(f"[yellow]Setting '{name}' not found[/yellow]")
+            # For specific setting requests, the data should be the setting itself
+            admin_manager.display_global_settings(settings)
         else:
             admin_manager.display_global_settings(settings)
 


### PR DESCRIPTION
## Summary

Fixes the `yt admin global-settings list` command to properly display YouTrack global settings instead of showing "N/A" values.

## Problem

The command was displaying "N/A" for all settings because:
- The YouTrack API returns nested objects with categories (systemSettings, license, etc.)
- The display method expected a simple list or single object format 
- API calls weren't including required `fields` parameters to get meaningful data

## Changes Made

### 🔧 API Data Retrieval
- Updated `get_global_settings()` to query specific endpoints with proper `fields` parameters
- Added support for: systemSettings, license, appearanceSettings, notificationSettings
- Each endpoint includes relevant fields to retrieve actual data instead of metadata

### 🎨 Enhanced Display Logic  
- Completely rewrote `display_global_settings()` to handle both legacy and nested formats
- Added categorized table display with proper formatting
- Boolean values show as ✓/✗ symbols
- Nested objects display type information in brackets
- camelCase keys converted to readable Title Case

### 🔧 Fixed Command Logic
- Fixed single setting retrieval by properly passing `name` parameter
- Enhanced error handling for non-existent settings and permissions
- Maintained backward compatibility with legacy API responses

### 🧪 Updated Tests
- Modified tests to match new nested data structure
- Added comprehensive test for nested format display
- Updated permission error handling test for multiple endpoint approach

## Testing
- [x] Unit tests pass
- [x] Integration tests with live YouTrack instance
- [x] Error handling for non-existent categories 
- [x] Permission error handling
- [x] Both `list` and `get --name <category>` commands work correctly

## Result

**Before:**
```
Setting: N/A
Value: N/A
```

**After:**
```
                                Global Settings                                 
┏━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Category              ┃ Setting                     ┃ Value                  ┃
┡━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
│ System Settings       │ Max Export Items            │ 500                    │
│                       │ Max Upload File Size        │ 10485760               │
│                       │ Allow Statistics Collection │ ✗                      │
│                       │ Is Application Read Only    │ ✗                      │
│                       │ Base Url                    │ http://youtrack.url    │
│ License               │ License                     │ [License Key]          │
│                       │ Username                    │ YouTrack Default       │
│ Appearance Settings   │ Logo                        │ [Logo]                 │
│ Notification Settings │ Email Settings              │ [EmailSettings]        │
└───────────────────────┴─────────────────────────────┴────────────────────────┘
```

Fixes #200

🤖 Generated with [Claude Code](https://claude.ai/code)