### PR TITLE
🔧 Fix ty type checker diagnostics and improve test compatibility

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -45,7 +45,8 @@
       "mcp__github__update_issue",
       "WebFetch(domain:youtrack-support.jetbrains.com)",
       "Bash(source:*)",
-      "Bash(curl:*)"
+      "Bash(curl:*)",
+      "WebFetch(domain:docs.astral.sh)"
     ],
     "deny": []
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "structlog>=25.4.0",
     "keyring>=25.0.0",
     "cryptography>=41.0.0",
+    "ty>=0.0.1a14",
 ]
 
 [project.urls]

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -280,33 +280,31 @@ class TestCachedDecorator:
     @pytest.mark.asyncio
     async def test_cached_decorator_basic(self):
         """Test basic cached decorator functionality."""
-        call_count = 0
+        call_count = [0]  # Use list to avoid nonlocal issues
 
         @cached(ttl=300.0)
         async def test_function(arg: str):
-            nonlocal call_count
-            call_count += 1
+            call_count[0] += 1
             return f"result_{arg}"
 
         # First call should execute function
         result1 = await test_function("test")
         assert result1 == "result_test"
-        assert call_count == 1
+        assert call_count[0] == 1
 
         # Second call should return cached result
         result2 = await test_function("test")
         assert result2 == "result_test"
-        assert call_count == 1  # Function not called again
+        assert call_count[0] == 1  # Function not called again
 
     @pytest.mark.asyncio
     async def test_cached_decorator_different_args(self):
         """Test cached decorator with different arguments."""
-        call_count = 0
+        call_count = [0]  # Use list to avoid nonlocal issues
 
         @cached(ttl=300.0)
         async def test_function(arg: str):
-            nonlocal call_count
-            call_count += 1
+            call_count[0] += 1
             return f"result_{arg}"
 
         result1 = await test_function("arg1")
@@ -314,17 +312,16 @@ class TestCachedDecorator:
 
         assert result1 == "result_arg1"
         assert result2 == "result_arg2"
-        assert call_count == 2  # Function called twice for different args
+        assert call_count[0] == 2  # Function called twice for different args
 
     @pytest.mark.asyncio
     async def test_cached_decorator_with_kwargs(self):
         """Test cached decorator with keyword arguments."""
-        call_count = 0
+        call_count = [0]  # Use list to avoid nonlocal issues
 
         @cached(ttl=300.0)
         async def test_function(arg1: str, arg2: str = "default"):
-            nonlocal call_count
-            call_count += 1
+            call_count[0] += 1
             return f"result_{arg1}_{arg2}"
 
         result1 = await test_function("test", arg2="custom")
@@ -332,22 +329,21 @@ class TestCachedDecorator:
 
         assert result1 == "result_test_custom"
         assert result2 == "result_test_custom"
-        assert call_count == 1  # Function called once
+        assert call_count[0] == 1  # Function called once
 
     @pytest.mark.asyncio
     async def test_cached_decorator_with_key_prefix(self):
         """Test cached decorator with key prefix."""
-        call_count = 0
+        call_count = [0]  # Use list to avoid nonlocal issues
 
         @cached(ttl=300.0, key_prefix="test_prefix")
         async def test_function(arg: str):
-            nonlocal call_count
-            call_count += 1
+            call_count[0] += 1
             return f"result_{arg}"
 
         result = await test_function("test")
         assert result == "result_test"
-        assert call_count == 1
+        assert call_count[0] == 1
 
         # Verify cache key has prefix
         cache = get_cache()
@@ -357,17 +353,16 @@ class TestCachedDecorator:
     @pytest.mark.asyncio
     async def test_cached_decorator_ttl_expiration(self):
         """Test cached decorator with TTL expiration."""
-        call_count = 0
+        call_count = [0]  # Use list to avoid nonlocal issues
 
         @cached(ttl=0.01)  # Very short TTL
         async def test_function(arg: str):
-            nonlocal call_count
-            call_count += 1
+            call_count[0] += 1
             return f"result_{arg}"
 
         # First call
         await test_function("test")
-        assert call_count == 1
+        assert call_count[0] == 1
 
         # Wait for cache to expire
         await asyncio.sleep(0.02)
@@ -375,7 +370,7 @@ class TestCachedDecorator:
         # Second call should execute function again
         result2 = await test_function("test")
         assert result2 == "result_test"
-        assert call_count == 2  # Function called again
+        assert call_count[0] == 2  # Function called again
 
 
 class TestPredefinedCacheDecorators:
@@ -384,12 +379,11 @@ class TestPredefinedCacheDecorators:
     @pytest.mark.asyncio
     async def test_cache_projects_decorator(self):
         """Test cache_projects decorator."""
-        call_count = 0
+        call_count = [0]  # Use list to avoid nonlocal issues
 
         @cache_projects(ttl=600.0)
         async def get_projects():
-            nonlocal call_count
-            call_count += 1
+            call_count[0] += 1
             return ["project1", "project2"]
 
         result1 = await get_projects()
@@ -397,17 +391,16 @@ class TestPredefinedCacheDecorators:
 
         assert result1 == ["project1", "project2"]
         assert result2 == ["project1", "project2"]
-        assert call_count == 1
+        assert call_count[0] == 1
 
     @pytest.mark.asyncio
     async def test_cache_users_decorator(self):
         """Test cache_users decorator."""
-        call_count = 0
+        call_count = [0]  # Use list to avoid nonlocal issues
 
         @cache_users(ttl=1800.0)
         async def get_users():
-            nonlocal call_count
-            call_count += 1
+            call_count[0] += 1
             return ["user1", "user2"]
 
         result1 = await get_users()
@@ -415,17 +408,16 @@ class TestPredefinedCacheDecorators:
 
         assert result1 == ["user1", "user2"]
         assert result2 == ["user1", "user2"]
-        assert call_count == 1
+        assert call_count[0] == 1
 
     @pytest.mark.asyncio
     async def test_cache_fields_decorator(self):
         """Test cache_fields decorator."""
-        call_count = 0
+        call_count = [0]  # Use list to avoid nonlocal issues
 
         @cache_fields(ttl=3600.0)
         async def get_fields():
-            nonlocal call_count
-            call_count += 1
+            call_count[0] += 1
             return ["field1", "field2"]
 
         result1 = await get_fields()
@@ -433,17 +425,16 @@ class TestPredefinedCacheDecorators:
 
         assert result1 == ["field1", "field2"]
         assert result2 == ["field1", "field2"]
-        assert call_count == 1
+        assert call_count[0] == 1
 
     @pytest.mark.asyncio
     async def test_cache_boards_decorator(self):
         """Test cache_boards decorator."""
-        call_count = 0
+        call_count = [0]  # Use list to avoid nonlocal issues
 
         @cache_boards(ttl=600.0)
         async def get_boards():
-            nonlocal call_count
-            call_count += 1
+            call_count[0] += 1
             return ["board1", "board2"]
 
         result1 = await get_boards()
@@ -451,4 +442,4 @@ class TestPredefinedCacheDecorators:
 
         assert result1 == ["board1", "board2"]
         assert result2 == ["board1", "board2"]
-        assert call_count == 1
+        assert call_count[0] == 1

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -54,8 +54,13 @@ class TestCachedResponse:
 
     def test_cached_response_extra_fields_allowed(self):
         """Test that extra fields are allowed."""
-        response = CachedResponse(data={"test": "data"}, status_code=201, extra_field="extra_value")
+        # Create with extra fields using dict construction
+        from typing import Any, cast
 
+        response_data = cast(Any, {"data": {"test": "data"}, "status_code": 201, "extra_field": "extra_value"})
+        response = CachedResponse(**response_data)  # type: ignore[misc]
+
+        assert hasattr(response, "extra_field")
         assert response.extra_field == "extra_value"
 
 
@@ -105,16 +110,16 @@ class TestYouTrackUser:
         """Test creating user with all fields."""
         user = YouTrackUser(
             login="testuser",
-            fullName="Test User",
+            fullName="Test User",  # ty: ignore[unknown-argument]
             email="test@example.com",
-            jabberAccountName="test@jabber.com",
-            ringId="ring123",
+            jabberAccountName="test@jabber.com",  # ty: ignore[unknown-argument]
+            ringId="ring123",  # ty: ignore[unknown-argument]
             guest=False,
             online=True,
             banned=False,
             tags=["tag1", "tag2"],
-            savedQueries=["query1", "query2"],
-            avatarUrl="https://example.com/avatar.jpg",
+            savedQueries=["query1", "query2"],  # ty: ignore[unknown-argument]
+            avatarUrl="https://example.com/avatar.jpg",  # ty: ignore[unknown-argument]
             profiles={"github": "testuser"},
         )
 
@@ -131,16 +136,15 @@ class TestYouTrackUser:
 
     def test_user_field_aliases(self):
         """Test that field aliases work correctly."""
-        user_data = {
-            "login": "testuser",
-            "fullName": "Test User",
-            "jabberAccountName": "test@jabber.com",
-            "ringId": "ring123",
-            "savedQueries": ["query1"],
-            "avatarUrl": "https://example.com/avatar.jpg",
-        }
-
-        user = YouTrackUser(**user_data)
+        # Test creating user with API field names (aliases)
+        user = YouTrackUser(
+            login="testuser",
+            fullName="Test User",  # ty: ignore[unknown-argument]
+            jabberAccountName="test@jabber.com",  # ty: ignore[unknown-argument]
+            ringId="ring123",  # ty: ignore[unknown-argument]
+            savedQueries=["query1"],  # ty: ignore[unknown-argument]
+            avatarUrl="https://example.com/avatar.jpg",  # ty: ignore[unknown-argument]
+        )
 
         assert user.full_name == "Test User"
         assert user.jabber_account_name == "test@jabber.com"
@@ -154,7 +158,7 @@ class TestYouTrackProject:
 
     def test_project_minimal_creation(self):
         """Test creating project with minimal required fields."""
-        project = YouTrackProject(id="proj123", name="Test Project", shortName="TP")
+        project = YouTrackProject(id="proj123", name="Test Project", shortName="TP")  # ty: ignore[unknown-argument]
 
         assert project.id == "proj123"
         assert project.name == "Test Project"
@@ -174,14 +178,14 @@ class TestYouTrackProject:
         project = YouTrackProject(
             id="proj123",
             name="Test Project",
-            shortName="TP",
+            shortName="TP",  # ty: ignore[unknown-argument]
             description="A test project",
             leader=leader,
-            createdBy=created_by,
+            createdBy=created_by,  # ty: ignore[unknown-argument]
             created=created_time,
             updated=updated_time,
-            resolvedIssuesCount=10,
-            issuesCount=25,
+            resolvedIssuesCount=10,  # ty: ignore[unknown-argument]
+            issuesCount=25,  # ty: ignore[unknown-argument]
             archived=False,
             template=True,
         )
@@ -198,7 +202,11 @@ class TestYouTrackProject:
     def test_project_validation_error(self):
         """Test project validation with missing required fields."""
         with pytest.raises(ValidationError):
-            YouTrackProject()  # Missing required fields
+            # Test that required fields are validated
+            from typing import Any, cast
+
+            empty_dict = cast(Any, {})
+            YouTrackProject(**empty_dict)  # type: ignore[misc] # Missing required fields
 
 
 class TestYouTrackCustomField:
@@ -245,8 +253,8 @@ class TestYouTrackIssueTag:
             query="Type: Bug",
             color="#ff0000",
             untagged=False,
-            visibleForAuthor=True,
-            visibleForAssignee=True,
+            visible_for_author=True,
+            visible_for_assignee=True,
         )
 
         assert tag.id == "tag123"
@@ -269,10 +277,10 @@ class TestYouTrackComment:
         comment = YouTrackComment(
             id="comment123",
             text="This is a comment",
-            textPreview="This is a...",
+            textPreview="This is a...",  # ty: ignore[unknown-argument]
             created=created_time,
             author=author,
-            issueId="issue123",
+            issueId="issue123",  # ty: ignore[unknown-argument]
         )
 
         assert comment.id == "comment123"
@@ -289,7 +297,7 @@ class TestYouTrackIssue:
 
     def test_issue_minimal_creation(self):
         """Test creating issue with minimal required fields."""
-        issue = YouTrackIssue(id="issue123", entityId="entity456", fieldHash=789, number=1, summary="Test Issue")
+        issue = YouTrackIssue(id="issue123", entityId="entity456", fieldHash=789, number=1, summary="Test Issue")  # ty: ignore[unknown-argument]
 
         assert issue.id == "issue123"
         assert issue.entity_id == "entity456"
@@ -304,7 +312,7 @@ class TestYouTrackIssue:
 
     def test_issue_with_relationships(self):
         """Test issue with related objects."""
-        project = YouTrackProject(id="proj1", name="Project", shortName="P")
+        project = YouTrackProject(id="proj1", name="Project", shortName="P")  # ty: ignore[unknown-argument]
         reporter = YouTrackUser(login="reporter")
         custom_field = YouTrackCustomField(id="cf1", name="Priority")
         tag = YouTrackIssueTag(id="tag1", name="bug")
@@ -312,13 +320,13 @@ class TestYouTrackIssue:
 
         issue = YouTrackIssue(
             id="issue123",
-            entityId="entity456",
-            fieldHash=789,
+            entityId="entity456",  # ty: ignore[unknown-argument]
+            fieldHash=789,  # ty: ignore[unknown-argument]
             number=1,
             summary="Test Issue",
             project=project,
             reporter=reporter,
-            customFields=[custom_field],
+            customFields=[custom_field],  # ty: ignore[unknown-argument]
             tags=[tag],
             comments=[comment],
             description="Issue description",
@@ -396,15 +404,15 @@ class TestYouTrackSearchResult:
     def test_search_result_creation(self):
         """Test creating search result."""
         user = YouTrackUser(login="user1")
-        project = YouTrackProject(id="p1", name="Project", shortName="P")
+        project = YouTrackProject(id="p1", name="Project", shortName="P")  # ty: ignore[unknown-argument]
 
         result = YouTrackSearchResult(
-            totalHits=100,
+            totalHits=100,  # ty: ignore[unknown-argument]
             skip=0,
             top=20,
-            hasAfter=True,
-            hasBefore=False,
-            afterCursor="cursor123",
+            hasAfter=True,  # ty: ignore[unknown-argument]
+            hasBefore=False,  # ty: ignore[unknown-argument]
+            afterCursor="cursor123",  # ty: ignore[unknown-argument]
             results=[user, project],
         )
 
@@ -428,8 +436,8 @@ class TestModelValidation:
 
         issue = YouTrackIssue(
             id="issue123",
-            entityId="entity456",
-            fieldHash=789,
+            entityId="entity456",  # ty: ignore[unknown-argument]
+            fieldHash=789,  # ty: ignore[unknown-argument]
             number=1,
             summary="Test Issue",
             created=now,
@@ -445,8 +453,8 @@ class TestModelValidation:
         """Test optional nested model relationships."""
         issue = YouTrackIssue(
             id="issue123",
-            entityId="entity456",
-            fieldHash=789,
+            entityId="entity456",  # ty: ignore[unknown-argument]
+            fieldHash=789,  # ty: ignore[unknown-argument]
             number=1,
             summary="Test Issue",
             project=None,
@@ -460,7 +468,7 @@ class TestModelValidation:
 
     def test_list_field_defaults(self):
         """Test default empty lists for list fields."""
-        issue = YouTrackIssue(id="issue123", entityId="entity456", fieldHash=789, number=1, summary="Test Issue")
+        issue = YouTrackIssue(id="issue123", entityId="entity456", fieldHash=789, number=1, summary="Test Issue")  # ty: ignore[unknown-argument]
 
         assert issue.custom_fields == []
         assert issue.tags == []
@@ -470,8 +478,14 @@ class TestModelValidation:
 
     def test_extra_fields_allowed(self):
         """Test that extra fields are allowed in models."""
-        user = YouTrackUser(login="testuser", extra_field="extra_value", another_field={"nested": "data"})
+        # Create user with extra fields using dict construction
+        from typing import Any, cast
+
+        user_data = cast(Any, {"login": "testuser", "extra_field": "extra_value", "another_field": {"nested": "data"}})
+        user = YouTrackUser(**user_data)  # type: ignore[misc]
 
         assert user.login == "testuser"
+        assert hasattr(user, "extra_field")
         assert user.extra_field == "extra_value"
+        assert hasattr(user, "another_field")
         assert user.another_field == {"nested": "data"}

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -275,11 +275,10 @@ class TestBenchmarkRequests:
     @pytest.mark.asyncio
     async def test_benchmark_simple_function(self):
         """Test benchmarking a simple async function."""
-        call_count = 0
+        call_count = [0]  # Use list to avoid nonlocal issues
 
         async def test_function():
-            nonlocal call_count
-            call_count += 1
+            call_count[0] += 1
             await asyncio.sleep(0.01)
             return "result"
 
@@ -296,16 +295,15 @@ class TestBenchmarkRequests:
         assert all(d >= 0.01 for d in result.durations)
         assert result.avg_duration >= 0.01
         assert result.operations_per_second > 0
-        assert call_count == 3  # No warmup, so only 3 calls
+        assert call_count[0] == 3  # No warmup, so only 3 calls
 
     @pytest.mark.asyncio
     async def test_benchmark_with_warmup(self):
         """Test benchmarking with warmup iterations."""
-        call_count = 0
+        call_count = [0]  # Use list to avoid nonlocal issues
 
         async def test_function():
-            nonlocal call_count
-            call_count += 1
+            call_count[0] += 1
             await asyncio.sleep(0.001)
 
         result = await benchmark_requests(
@@ -315,17 +313,16 @@ class TestBenchmarkRequests:
         assert result.total_operations == 2
         assert result.successful_operations == 2
         assert len(result.durations) == 2
-        assert call_count == 3  # 1 warmup + 2 actual
+        assert call_count[0] == 3  # 1 warmup + 2 actual
 
     @pytest.mark.asyncio
     async def test_benchmark_with_failures(self):
         """Test benchmarking function that sometimes fails."""
-        call_count = 0
+        call_count = [0]  # Use list to avoid nonlocal issues
 
         async def failing_function():
-            nonlocal call_count
-            call_count += 1
-            if call_count % 2 == 0:  # Fail every second call
+            call_count[0] += 1
+            if call_count[0] % 2 == 0:  # Fail every second call
                 raise ValueError("Test error")
             await asyncio.sleep(0.001)
 
@@ -345,11 +342,10 @@ class TestBenchmarkRequests:
     @pytest.mark.asyncio
     async def test_benchmark_concurrent_requests(self):
         """Test benchmarking with concurrent requests."""
-        call_count = 0
+        call_count = [0]  # Use list to avoid nonlocal issues
 
         async def test_function():
-            nonlocal call_count
-            call_count += 1
+            call_count[0] += 1
             await asyncio.sleep(0.01)
 
         result = await benchmark_requests(
@@ -363,7 +359,7 @@ class TestBenchmarkRequests:
         assert result.total_operations == 2
         assert result.successful_operations == 2
         assert len(result.durations) == 2
-        assert call_count == 6  # 2 iterations * 3 concurrent = 6 calls
+        assert call_count[0] == 6  # 2 iterations * 3 concurrent = 6 calls
 
     @pytest.mark.asyncio
     async def test_benchmark_statistics_calculation(self):

--- a/uv.lock
+++ b/uv.lock
@@ -1470,27 +1470,27 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.1a13"
+version = "0.0.1a14"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a0/b3/09d622729551bc5071e41ce13cc6c57a71eae0a100c993d8a6024c60ce2d/ty-0.0.1a13.tar.gz", hash = "sha256:2a0a96146540e66264dd8ead9530cc77f4283256b97f2c25588283572e012717", size = 3146596 }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/c2/743ef78f8ddcdd8a8e074b6ad6eb01fa5d8c110f5e25e0142087b175b212/ty-0.0.1a14.tar.gz", hash = "sha256:a9ecac10c63a7c193c78ef1a01956c7c579e4d8498d3ec77543fe31a5a9e3912", size = 3176178 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/5e/eadff1754c3b59797077b069202d12b9187b32f6fcd529bebcac54c6f299/ty-0.0.1a13-py3-none-linux_armv6l.whl", hash = "sha256:9c35d6782d88231c72be8fd525183a63e10b3eaae70d425c9697f06a2beaa08b", size = 6900007 },
-    { url = "https://files.pythonhosted.org/packages/5a/06/a4b21058fc7b2671641ffd51f8bdc37334de0e85b80433ce664afc6dbcac/ty-0.0.1a13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:abd2e52b66b6f30ebb645b26232bd80ef6cb5a06ce71f0ff55aeb7a038491116", size = 7018543 },
-    { url = "https://files.pythonhosted.org/packages/7e/37/4345064293bd6543242ba9e627763ab3b2b13fc17d360a9aebc58189b6e4/ty-0.0.1a13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c824899c45377af42c46a798c19d0dac00b91e5155f8766c701df4fd98a043fd", size = 6645758 },
-    { url = "https://files.pythonhosted.org/packages/b5/9e/d0b2d3bb147704effeb3ad06276708c90038af709e7fa30f3bac1729c267/ty-0.0.1a13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:186ac4ec02746ac46f39651dec2b65ebc5bc026650452e28c55d8b58422ed649", size = 6783008 },
-    { url = "https://files.pythonhosted.org/packages/96/74/062881a4eb2009702d46c75dafe3f7ba275ff97bdb8a3e6b68ba19c1a049/ty-0.0.1a13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a9f398130e9db4be33d162c7a2ddcaf2e7ec6a4c3db895be419857d30960f14a", size = 6753432 },
-    { url = "https://files.pythonhosted.org/packages/d3/ef/31d4f3ca9eac47ad32b8f245af3f944f0f2cf08fb91d2977c5b1a5fda243/ty-0.0.1a13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ee3278edffbf1f4ad2abbd679fa31d2f6f39ab6fb652effc17866441559b77f", size = 7560344 },
-    { url = "https://files.pythonhosted.org/packages/72/3c/b4260108b51f9e1212e06f82fbe5134546159f90239207ef6ebe5746533c/ty-0.0.1a13-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:0f8d957620c1bc7dba6a996915a4527ae6b252b552bee71b2fd85cecc2b62e69", size = 7997046 },
-    { url = "https://files.pythonhosted.org/packages/e1/3f/00eefb65b61574816efaecb4779b2f7b8e81de1a90b890aea5d3c9a989dc/ty-0.0.1a13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e58e41fdaf4e8c4639718e29945322070c2c70eea2daa33800d8b2e677b4582", size = 7659362 },
-    { url = "https://files.pythonhosted.org/packages/8a/c4/d6d9e5f53ae3f3ce82eafb68ab053758a604cabedb29122f1d3f4bcbbb80/ty-0.0.1a13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:58836d12a8238550dcad0e9258af646c8d83e07485b97213ec0cdad0b6afc108", size = 7502769 },
-    { url = "https://files.pythonhosted.org/packages/6d/fb/85fd217563c68c6e4db419a4e8c4db4b5cdcdc29af4ba736123d6a2224dc/ty-0.0.1a13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d0f36beac8c8833e4fb9dcba47c7028a2be25736c10f9c8836e46981b93c030b", size = 7313939 },
-    { url = "https://files.pythonhosted.org/packages/47/18/c72ff3354022b8918f6cd0e169b64e1e85f7ccb739343985fefb4ecf09f5/ty-0.0.1a13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:082d430c12b6c8fd58774cd1f5a9e7337d5900ef3cb56a567f21915e975ea02c", size = 6678662 },
-    { url = "https://files.pythonhosted.org/packages/b9/39/8f81eb2b01623725c838437ccdf2733502de8c28a2302a3705d04f6cb681/ty-0.0.1a13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d4dd460a78d2931415fdbe114a91533a811b83e02b57960486ccb7e9d038bd55", size = 6782460 },
-    { url = "https://files.pythonhosted.org/packages/a2/da/107a3beb2768a9591b6753f630dcb64b336eb9e44379e9cca22635fb5706/ty-0.0.1a13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:64d7239718a3bb7bc771c51da1d7d7f3239eead03903a97bc689fff10f4ae9e4", size = 7210683 },
-    { url = "https://files.pythonhosted.org/packages/21/31/392fc16133ce393b2271248ac8505c29bd682aacaf1dc9067b02a5c332b0/ty-0.0.1a13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2e86c4348961bbc23543c59a642aad324d7735dc4a3abdce9e7f828bf566b49b", size = 7380187 },
-    { url = "https://files.pythonhosted.org/packages/b4/f1/7d2afa92c10e57e3a5cd106fb13b0b327d3518cc45e62088c005786e2cdb/ty-0.0.1a13-py3-none-win32.whl", hash = "sha256:18234d30b30ab6df9a5c1891051cf137184ea5bc446172200c25f497cd49eb2a", size = 6514867 },
-    { url = "https://files.pythonhosted.org/packages/6e/91/93df4ef3b0368cbd59a20c5d72c4806169d0c0f125241148ededdc712896/ty-0.0.1a13-py3-none-win_amd64.whl", hash = "sha256:6e0dc212853166c4083fc2d5d9253f32d97f94b8afd90224dfea78bceffc2569", size = 7120290 },
-    { url = "https://files.pythonhosted.org/packages/c7/62/fe6cc92db2aa1a344937e5313ba3bbdaed24e54332b8a12fe28a92d314ce/ty-0.0.1a13-py3-none-win_arm64.whl", hash = "sha256:5f2237bb301078d51d006170992abb1e5f3b37cec47a11e6db416a76346f60b5", size = 6727050 },
+    { url = "https://files.pythonhosted.org/packages/66/10/4c29110e6571b00206962b219afa38e661001011bfc1b36bec4f74fdf51d/ty-0.0.1a14-py3-none-linux_armv6l.whl", hash = "sha256:165acd7a7c49d9cbd20b8fa72a7dab0ccceae935593618aba9218950fdbb0e08", size = 6969793 },
+    { url = "https://files.pythonhosted.org/packages/1b/bc/1d64ef953a53474725847a8bd3418e422218ed7024fe2bd9e3c9c2c859ce/ty-0.0.1a14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:54c357059f0c0d27f1efc544c0c9475f918d5cd579e7fa38365c5e2e4ef5868a", size = 7076030 },
+    { url = "https://files.pythonhosted.org/packages/de/b6/672bac4f24fab47def3c672a0a97d1eafbd6baef61b99ebefb805944c2a9/ty-0.0.1a14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c729efdddcfc7fe66df284a321cb2b8ea8c36f7e0a322176f0b5ffd3ca45db90", size = 6699358 },
+    { url = "https://files.pythonhosted.org/packages/99/1e/0a8d7a49c324584451309f96fc85f462e2b2052c216e82a2f689f9e477c0/ty-0.0.1a14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e593d549118e3794e11ab09e610520654a4c91a8c2ffaff8c31845067c2cf883", size = 6834240 },
+    { url = "https://files.pythonhosted.org/packages/5b/97/e57c49e7d5216af907ca83e4e4ede7471cef53284f90f8fe11f6051031d8/ty-0.0.1a14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:679f715d9d4b5558231eafe6c4441a0a53c245a669ac2ba049c0996e538f7e88", size = 6810434 },
+    { url = "https://files.pythonhosted.org/packages/1b/0f/293680a83e7c86354b97a7e8cb08896338370eb169383c7b687aa3311f96/ty-0.0.1a14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:541487c8b896c0094a32e91f96b2d6ee9bc3c1f1c0a9c5c781eef0002ca437a4", size = 7622086 },
+    { url = "https://files.pythonhosted.org/packages/2a/9c/f5d730903d65a0eb989d793a1d7e5a62f765841c45bef325403edf342810/ty-0.0.1a14-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:aa9ffb8a518762e78b0c6780475e89bfc8e040fb9832918b6bf79c5e8e96da92", size = 8073710 },
+    { url = "https://files.pythonhosted.org/packages/0e/09/f39d0f626df4841d39bdc8ae9052f91f65b45beff281bdf29a53efea79bf/ty-0.0.1a14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3bae3288461e3db28dd19f12d4f71d88f5be201283f6d8790d467cb87d9717bd", size = 7716213 },
+    { url = "https://files.pythonhosted.org/packages/68/5a/afdab1afec623ecede8108733228703bb4cb25fa8210ba16427fcd1c0429/ty-0.0.1a14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:032ff6d43272c5a87ef2cf56773a4e44c370d98cdd129bc4b352d6c63c5348c7", size = 7559696 },
+    { url = "https://files.pythonhosted.org/packages/a7/26/e422f8ed5ca63b50bf87de5b4bc8fd15cb203a8d2690b2f447ccff0c74fb/ty-0.0.1a14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1cd7739be014ff5dee50b3a83252c7953cf278567079bde0e33c5203ff576d9b", size = 7375483 },
+    { url = "https://files.pythonhosted.org/packages/ea/f2/bb88da6ba64bfe5edff636738861a6b78050611da9540e372635e599ee4c/ty-0.0.1a14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5776cf7ea1000be79cd70d44fafe15b3695bac1a115806421402dfa79ba9953e", size = 6726122 },
+    { url = "https://files.pythonhosted.org/packages/93/96/62566786e9124b8f0f2fbced5e57046534e5835af83f9efb4a0c861f6a61/ty-0.0.1a14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:10d62346a56a0d21c809ae885ca7513a1c54da8c94029664eeb68fbdd3effc02", size = 6839605 },
+    { url = "https://files.pythonhosted.org/packages/12/26/40b7e7388a5308cc53dd440cb24d1a95b3efd07c4a374fce9cd0fe777049/ty-0.0.1a14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7a5bb97658bf3fa054833bf3511499e1422a27dee7a3c10aff56d4daa3821d6d", size = 7268362 },
+    { url = "https://files.pythonhosted.org/packages/14/50/11f275d7cb413104dea1360a997ad373839ed0108980912605e59188afba/ty-0.0.1a14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a89c075ae1238d215de2343909952e872306791fbad96a8ffd119a83a3e0a914", size = 7435560 },
+    { url = "https://files.pythonhosted.org/packages/11/b6/468c98f9520515fd9a65ce5a51c9aa39f7f944cb8f320328839cef65d1f1/ty-0.0.1a14-py3-none-win32.whl", hash = "sha256:6c3e87f4549a1bf7524df074a4fe9a5815aff25e536c5fc6f1518b72e74a17cf", size = 6573723 },
+    { url = "https://files.pythonhosted.org/packages/1c/82/a771661d3d64e17688063dc5573e8eebc0683f581c843b840f5b03d108f7/ty-0.0.1a14-py3-none-win_amd64.whl", hash = "sha256:0ed6145dae24b68638037d7c82f094b22adfb48114678120cf392092973fad96", size = 7181298 },
+    { url = "https://files.pythonhosted.org/packages/9d/d0/68b106ddc25239d4a7114e64211aa5ad5d27488c1a318ab8ad057b88b4a7/ty-0.0.1a14-py3-none-win_arm64.whl", hash = "sha256:67717fbbb501c9deb11141662688804513082992aaeb5fdc6a3b7cd8e77eea8e", size = 6788031 },
 ]
 
 [[package]]
@@ -1748,6 +1748,7 @@ dependencies = [
     { name = "structlog" },
     { name = "textual" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "ty" },
 ]
 
 [package.dependency-groups]
@@ -1782,6 +1783,7 @@ requires-dist = [
     { name = "structlog", specifier = ">=25.4.0" },
     { name = "textual", specifier = ">=0.40.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=1.2.0" },
+    { name = "ty", specifier = ">=0.0.1a14" },
 ]
 
 [package.metadata.dependency-groups]


### PR DESCRIPTION
## Summary
- Upgrade ty from 0.0.1a13 to 0.0.1a14 to resolve nonlocal variable scoping issues
- Replace nonlocal call_count pattern with list-based approach in cache and performance tests  
- Add ty suppression comments for Pydantic field aliases that ty doesn't recognize
- Update Claude Code permissions to access ty documentation

## Test plan
- [x] All ty type checks pass (reduced from 52 diagnostics to 0)
- [x] All model tests pass (29/29)
- [x] All cache tests pass (30/30) 
- [x] All performance tests pass (28/28)
- [x] Ruff linting passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)