### PR TITLE
🔧 Improve test recipe flexibility and reduce output verbosity

### DIFF
--- a/justfile
+++ b/justfile
@@ -65,10 +65,10 @@ security:
 
 # Testing
 [group('test')]
-test:
+test *args:
     #!/usr/bin/env bash
     echo "Running pytest..."
-    uv run pytest
+    uv run pytest {{ args }}
     echo "✅ Tests complete"
 
 [group('test')]
@@ -93,7 +93,7 @@ check:
     just lint
     just format-check
     just typecheck
-    just test
+    just test -q --tb=no --no-header --disable-warnings
     just security
     echo "✅ All checks passed!"
 


### PR DESCRIPTION
## Summary
- Add optional arguments support to test recipe using *args parameter
- Minimize pytest output in check recipe with -q --tb=no --no-header --disable-warnings
- Allows for more flexible testing workflows while keeping check output clean

## Test plan
- [x] Verify test recipe accepts optional arguments: `just test --help`
- [x] Verify check recipe produces minimal output: `just check`
- [x] Ensure all existing functionality still works

🤖 Generated with [Claude Code](https://claude.ai/code)