### PR TITLE
✨ Add internationalization/locale settings commands (Fixes #201)

### DIFF
--- a/youtrack_cli/main.py
+++ b/youtrack_cli/main.py
@@ -1328,5 +1328,148 @@ def list_fields(ctx: click.Context) -> None:
     asyncio.run(run_list_fields())
 
 
+@admin.group()
+def locale() -> None:
+    """Manage YouTrack locale and language settings."""
+    pass
+
+
+@locale.command(name="get")
+@click.pass_context
+def get_locale(ctx: click.Context) -> None:
+    """View current locale settings."""
+    auth_manager = AuthManager(ctx.obj.get("config"))
+    admin_manager = AdminManager(auth_manager)
+    console = get_console()
+
+    async def run_get_locale() -> None:
+        result = await admin_manager.get_locale_settings()
+
+        if result["status"] == "error":
+            console.print(f"[red]Error:[/red] {result['message']}")
+            return
+
+        admin_manager.display_locale_settings(result["data"])
+
+    asyncio.run(run_get_locale())
+
+
+@locale.command(name="set")
+@click.option(
+    "--language",
+    "-l",
+    required=True,
+    help="Locale ID to set (e.g., en_US, de_DE, fr_FR)",
+)
+@click.pass_context
+def set_locale(ctx: click.Context, language: str) -> None:
+    """Set system language locale."""
+    auth_manager = AuthManager(ctx.obj.get("config"))
+    admin_manager = AdminManager(auth_manager)
+    console = get_console()
+
+    async def run_set_locale() -> None:
+        result = await admin_manager.set_locale_settings(language)
+
+        if result["status"] == "error":
+            console.print(f"[red]Error:[/red] {result['message']}")
+            return
+
+        console.print(f"[green]Success:[/green] {result['message']}")
+
+    asyncio.run(run_set_locale())
+
+
+@locale.command(name="list")
+@click.pass_context
+def list_locales(ctx: click.Context) -> None:
+    """List available locales."""
+    auth_manager = AuthManager(ctx.obj.get("config"))
+    admin_manager = AdminManager(auth_manager)
+    console = get_console()
+
+    async def run_list_locales() -> None:
+        result = await admin_manager.get_available_locales()
+
+        if result["status"] == "error":
+            console.print(f"[red]Error:[/red] {result['message']}")
+            return
+
+        admin_manager.display_available_locales(result["data"], result.get("message"))
+
+    asyncio.run(run_list_locales())
+
+
+@admin.group()
+def i18n() -> None:
+    """Manage internationalization settings (alias for locale)."""
+    pass
+
+
+@i18n.command(name="get")
+@click.pass_context
+def get_i18n(ctx: click.Context) -> None:
+    """View all internationalization settings (same as locale get)."""
+    auth_manager = AuthManager(ctx.obj.get("config"))
+    admin_manager = AdminManager(auth_manager)
+    console = get_console()
+
+    async def run_get_i18n() -> None:
+        result = await admin_manager.get_locale_settings()
+
+        if result["status"] == "error":
+            console.print(f"[red]Error:[/red] {result['message']}")
+            return
+
+        admin_manager.display_locale_settings(result["data"])
+
+    asyncio.run(run_get_i18n())
+
+
+@i18n.command(name="set")
+@click.option(
+    "--language",
+    "-l",
+    help="Locale ID to set (e.g., en_US, de_DE, fr_FR)",
+)
+@click.option(
+    "--timezone",
+    "-tz",
+    help="Timezone to set (Note: Not implemented in this version)",
+)
+@click.option(
+    "--date-format",
+    "-df",
+    help="Date format to set (Note: Not implemented in this version)",
+)
+@click.pass_context
+def set_i18n(ctx: click.Context, language: Optional[str], timezone: Optional[str], date_format: Optional[str]) -> None:
+    """Set internationalization settings."""
+    auth_manager = AuthManager(ctx.obj.get("config"))
+    admin_manager = AdminManager(auth_manager)
+    console = get_console()
+
+    if not any([language, timezone, date_format]):
+        console.print("[red]Error:[/red] At least one option must be specified.")
+        console.print("Use --language to set locale, --timezone for timezone, or --date-format for date format.")
+        return
+
+    async def run_set_i18n() -> None:
+        if language:
+            result = await admin_manager.set_locale_settings(language)
+            if result["status"] == "error":
+                console.print(f"[red]Error:[/red] {result['message']}")
+                return
+            console.print(f"[green]Success:[/green] {result['message']}")
+
+        if timezone:
+            console.print("[yellow]Note:[/yellow] Timezone setting is not yet implemented.")
+
+        if date_format:
+            console.print("[yellow]Note:[/yellow] Date format setting is not yet implemented.")
+
+    asyncio.run(run_set_i18n())
+
+
 if __name__ == "__main__":
     main()

--- a/youtrack_cli/models.py
+++ b/youtrack_cli/models.py
@@ -411,3 +411,24 @@ class CredentialVerificationResult(BaseModel):
     full_name: Optional[str] = None
     email: Optional[str] = None
     message: Optional[str] = None
+
+
+class YouTrackLocale(BaseModel):
+    """YouTrack locale information model."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    name: str
+    locale: str
+    language: str
+    community: bool = False
+
+
+class YouTrackLocaleSettings(BaseModel):
+    """YouTrack locale settings model."""
+
+    model_config = ConfigDict(extra="allow")
+
+    locale: YouTrackLocale
+    is_rtl: bool = Field(False, alias="isRTL")


### PR DESCRIPTION
## Summary

This PR implements dedicated commands for managing YouTrack's internationalization and locale settings, addressing the limitations of the current generic global settings commands that cannot properly handle nested object structures.

## Changes Made

### New Commands Added
- **`yt admin locale get`** - View current locale settings with detailed information
- **`yt admin locale set --language <locale_id>`** - Set system language (e.g., en_US, de_DE)
- **`yt admin locale list`** - List available locales with names and language codes
- **`yt admin i18n get`** - Alias for locale get command
- **`yt admin i18n set --language <locale_id>`** - Alias for locale set command

### Technical Implementation
- **AdminManager enhancements**: Added `get_locale_settings()`, `set_locale_settings()`, and `get_available_locales()` methods
- **New Pydantic models**: `YouTrackLocale` and `YouTrackLocaleSettings` for type safety
- **Rich console output**: Formatted tables with color coding for better UX
- **Comprehensive error handling**: Proper authentication, permission, and validation errors
- **API integration**: Uses `/api/admin/globalSettings/localeSettings` endpoint

### Testing
- **Unit tests**: Complete test coverage for new AdminManager methods
- **CLI tests**: Tests for command help and basic functionality 
- **Integration tests**: Mock API interactions and error scenarios
- **Type checking**: Full type safety with ty
- **Linting**: Passes all ruff checks

## Testing

### Manual Testing
```bash
# List available locales
yt admin locale list

# View current locale settings (requires auth)
yt admin locale get

# Set language (requires admin permissions)
yt admin locale set --language de_DE

# i18n alias commands work identically
yt admin i18n get
yt admin i18n set --language fr_FR
```

### Automated Testing
- All existing tests continue to pass
- New locale functionality has 100% test coverage
- Pre-commit hooks pass (ruff, ty, pytest, etc.)

## API Endpoints Used
- **GET** `/api/admin/globalSettings/localeSettings` - Retrieve current locale settings
- **POST** `/api/admin/globalSettings/localeSettings` - Update locale settings

## Permissions Required
- **Read operations**: Standard admin read permissions
- **Write operations**: "Low-level Admin Write" permissions for locale updates

## Benefits
- ✅ Intuitive, dedicated commands for common admin tasks
- ✅ Proper handling of nested locale object structure (which generic set command cannot handle)
- ✅ Better user experience with formatted output and clear error messages
- ✅ Consistency with existing CLI patterns and conventions
- ✅ Type safety and comprehensive error handling

## Documentation Updated
- Implementation plan documented in `scratch/issue-201.md`
- Inline code documentation for all new methods
- Help text for all new commands

Fixes #201

🤖 Generated with [Claude Code](https://claude.ai/code)