### PR TITLE
🔧 Fix missing Sphinx extensions for documentation build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,5 @@
 sphinx>=7.0.0
 sphinx-rtd-theme>=2.0.0
 sphinx-autobuild>=2021.3.14
+sphinx-autodoc-typehints>=1.20.0
+sphinx-click>=4.0.0


### PR DESCRIPTION
## Summary
- Add missing `sphinx-autodoc-typehints` and `sphinx-click` extensions to `docs/requirements.txt`
- Resolves `ModuleNotFoundError` during documentation builds on ReadTheDocs

## Test plan
- [ ] Verify documentation builds successfully locally
- [ ] Confirm ReadTheDocs build passes with these dependencies

🤖 Generated with [Claude Code](https://claude.ai/code)