### PR TITLE
🐛 Fix Docker tutorial: YouTrack image pull fails with 404 error (Fixes #226)

### DIFF
--- a/tests/test_docker_tutorial.py
+++ b/tests/test_docker_tutorial.py
@@ -75,7 +75,7 @@ class TestDockerUtils:
 
         pull_youtrack_image()
 
-        mock_client.images.pull.assert_called_once_with("jetbrains/youtrack:latest")
+        mock_client.images.pull.assert_called_once_with("jetbrains/youtrack:2025.1.66652")
 
     @patch("youtrack_cli.tutorial.docker_utils.docker.from_env")
     def test_pull_youtrack_image_failure(self, mock_docker):

--- a/youtrack_cli/tutorial/docker_utils.py
+++ b/youtrack_cli/tutorial/docker_utils.py
@@ -10,7 +10,7 @@ from rich.console import Console
 
 console = Console()
 
-YOUTRACK_IMAGE = "jetbrains/youtrack:latest"
+YOUTRACK_IMAGE = "jetbrains/youtrack:2025.1.66652"
 CONTAINER_NAME = "youtrack-tutorial"
 VOLUME_NAME = "youtrack-tutorial-data"
 DEFAULT_PORT = 8080

--- a/youtrack_cli/tutorial/modules.py
+++ b/youtrack_cli/tutorial/modules.py
@@ -608,7 +608,7 @@ class DockerTutorial(TutorialModule):
             import docker
 
             client = docker.from_env()
-            client.images.get("jetbrains/youtrack:latest")
+            client.images.get("jetbrains/youtrack:2025.1.66652")
             return True
         except Exception:
             return False


### PR DESCRIPTION
## Summary

Fixes the Docker tutorial failure when pulling the YouTrack image. The issue was caused by using `jetbrains/youtrack:latest` which doesn't exist - JetBrains uses specific version tags instead of `latest`.

## Changes Made
- Updated `YOUTRACK_IMAGE` constant from `jetbrains/youtrack:latest` to `jetbrains/youtrack:2025.1.66652`
- Updated corresponding test assertions in `test_docker_tutorial.py`
- Updated image validation in tutorial modules
- Verified the new image tag exists and can be pulled successfully

## Testing
- [x] Unit tests added/updated
- [x] Integration tests passing
- [x] Manual testing completed - verified Docker image can be pulled
- [x] Pre-commit checks passing

## Documentation
- [x] Implementation plan documented in `scratch/issue-226.md`
- [x] Code changes are self-documenting with updated constants

Fixes #226

🤖 Generated with [Claude Code](https://claude.ai/code)