### PR TITLE
🐛 Fix time logging date property type mismatch error (Fixes #231)

### DIFF
--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -190,21 +190,40 @@ class TestTimeManager:
 
     def test_parse_date_formats(self, time_manager):
         """Test parsing various date formats."""
+        from datetime import datetime
+
+        # Test specific date formats return correct timestamps
         test_cases = [
-            ("2024-01-01", "2024-01-01T00:00:00"),
-            ("01/01/2024", "2024-01-01T00:00:00"),
-            ("01.01.2024", "2024-01-01T00:00:00"),
-            ("today", None),  # Will be current date
-            ("yesterday", None),  # Will be yesterday
+            ("2024-01-01", datetime(2024, 1, 1).timestamp() * 1000),
+            ("01/01/2024", datetime(2024, 1, 1).timestamp() * 1000),
+            ("01.01.2024", datetime(2024, 1, 1).timestamp() * 1000),
         ]
 
-        for date_str, expected_prefix in test_cases:
+        for date_str, expected_timestamp in test_cases:
             result = time_manager._parse_date(date_str)
-            if expected_prefix:
-                assert result == expected_prefix
-            else:
-                # For relative dates, just check they return a valid ISO string
-                assert "T" in result or result == date_str
+            assert result == int(expected_timestamp), f"Failed for {date_str}"
+
+        # Test relative dates return valid timestamps
+        today_result = time_manager._parse_date("today")
+        yesterday_result = time_manager._parse_date("yesterday")
+
+        assert isinstance(today_result, int)
+        assert isinstance(yesterday_result, int)
+        assert today_result > yesterday_result  # today should be later than yesterday
+
+    def test_parse_date_returns_timestamp(self, time_manager):
+        """Test that _parse_date returns timestamps in milliseconds."""
+        # Test with a known date
+        result = time_manager._parse_date("2024-01-01")
+
+        # Should be a timestamp in milliseconds (13-digit number for dates around 2024)
+        assert isinstance(result, int)
+        assert len(str(result)) == 13  # milliseconds since epoch should be 13 digits in 2024
+
+        # Test with invalid date - should still return a valid timestamp
+        invalid_result = time_manager._parse_date("invalid-date")
+        assert isinstance(invalid_result, int)
+        assert len(str(invalid_result)) == 13
 
     def test_aggregate_time_data_by_user(self, time_manager):
         """Test aggregating time data by user."""

--- a/youtrack_cli/time.py
+++ b/youtrack_cli/time.py
@@ -55,8 +55,8 @@ class TimeManager:
         if duration_minutes is None:
             return {"status": "error", "message": "Invalid duration format"}
 
-        # Parse date or use current date
-        work_date = self._parse_date(date) if date else datetime.now().isoformat()
+        # Parse date or use current timestamp
+        work_date = self._parse_date(date) if date else int(datetime.now().timestamp() * 1000)
 
         work_item_data = {
             "duration": {"minutes": duration_minutes},
@@ -226,8 +226,8 @@ class TimeManager:
 
         return total_minutes if total_minutes > 0 else None
 
-    def _parse_date(self, date_str: str) -> str:
-        """Parse date string to ISO format."""
+    def _parse_date(self, date_str: str) -> int:
+        """Parse date string to timestamp in milliseconds."""
         try:
             # Try different date formats
             formats = ["%Y-%m-%d", "%m/%d/%Y", "%d.%m.%Y", "%Y-%m-%d %H:%M:%S"]
@@ -235,19 +235,22 @@ class TimeManager:
             for fmt in formats:
                 try:
                     parsed_date = datetime.strptime(date_str, fmt)
-                    return parsed_date.isoformat()
+                    return int(parsed_date.timestamp() * 1000)
                 except ValueError:
                     continue
 
             # If no format matches, try relative dates
             if date_str.lower() == "today":
-                return datetime.now().isoformat()
+                return int(datetime.now().timestamp() * 1000)
             elif date_str.lower() == "yesterday":
-                return (datetime.now() - timedelta(days=1)).isoformat()
+                return int((datetime.now() - timedelta(days=1)).timestamp() * 1000)
 
-            return date_str
+            # If all else fails, try to parse as ISO format
+            parsed_date = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+            return int(parsed_date.timestamp() * 1000)
         except Exception:
-            return date_str
+            # Default to current timestamp if parsing fails
+            return int(datetime.now().timestamp() * 1000)
 
     def _aggregate_time_data(self, time_entries: list[dict[str, Any]], group_by: str) -> dict[str, Any]:
         """Aggregate time data by specified grouping."""


### PR DESCRIPTION
## Summary

Fixes the time logging functionality that was failing with a date property type mismatch error. The YouTrack API expects timestamps in milliseconds (kotlin.Long) but we were sending ISO date strings.

## Related Issues
This PR addresses:
- #231

## Changes Made
- **Updated `_parse_date` method**: Now returns timestamp in milliseconds instead of ISO string format
- **Fixed `log_time` method**: Uses timestamp for the date field when creating work items
- **Enhanced error handling**: Graceful fallback to current timestamp if date parsing fails
- **Comprehensive test coverage**: Added tests for timestamp conversion and various date formats
- **Maintained backward compatibility**: All existing date formats continue to work

## Technical Details
- YouTrack API `/api/issues/{issueId}/timeTracking/workItems` expects `date` field as kotlin.Long (milliseconds since epoch)
- Previously sent: `"date": "2024-01-01T00:00:00"`
- Now sends: `"date": 1704067200000` (timestamp in milliseconds)

## Testing
- [x] Unit tests added/updated
- [x] Integration tests passing 
- [x] Manual testing completed with live YouTrack instance
- [x] All date formats tested: YYYY-MM-DD, MM/DD/YYYY, DD.MM.YYYY, "today", "yesterday"
- [x] Security review completed

## Verification
Successfully tested time logging with:
```bash
yt time log DEMO-2 "1h" --description "Testing timestamp fix"
yt time log DEMO-4 "2h" --date "2024-01-15" --description "Testing date parsing"
```

Both commands now work without the previous 400 error.

## Documentation
- [x] Code comments added where needed
- [x] Function signatures updated to reflect new return types
- [x] Test documentation enhanced

Fixes #231

🤖 Generated with [Claude Code](https://claude.ai/code)