### PR TITLE
📚 Fix incorrect command in 'yt tutorial issues' interactive guide (Fixes #270)

### DIFF
--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -366,13 +366,13 @@ Rate Limiting
    .. code-block:: bash
 
       # Use in scripts
-      yt issues list --limit 10
+      yt issues list --top 10
       sleep 1
-      yt issues list --limit 10 --offset 10
+      yt issues list --top 10 --offset 10
 
 2. **Reduce request frequency**:
 
-   - Use ``--limit`` options to fetch smaller batches
+   - Use ``--top`` options to fetch smaller batches
    - Implement exponential backoff in scripts
 
 Data and Output Issues
@@ -397,7 +397,7 @@ Empty Results
    .. code-block:: bash
 
       # Start with broader searches
-      yt issues list --limit 5
+      yt issues list --top 5
       yt issues search "created: today"
 
 3. **Check project context**:
@@ -459,7 +459,7 @@ Issue Creation Fails
 
       # Check valid values first:
       yt projects list  # For project keys
-      yt issues list --limit 1  # To see valid field examples
+      yt issues list --top 1  # To see valid field examples
 
 3. **Special characters in summary**:
 
@@ -608,8 +608,8 @@ Verify your setup is working:
    yt auth login --test
 
    # Test basic operations
-   yt projects list --limit 1
-   yt issues list --limit 1
+   yt projects list --top 1
+   yt issues list --top 1
 
 Common Error Messages
 ---------------------

--- a/youtrack_cli/tutorial/modules.py
+++ b/youtrack_cli/tutorial/modules.py
@@ -131,7 +131,7 @@ class IssuesTutorial(TutorialModule):
                     "Try filtering by assignee, state, or project",
                     "Notice the different output formats available",
                 ],
-                command_example="yt issues list --limit 10",
+                command_example="yt issues list --top 10",
                 tips=[
                     "Use --assignee me to see issues assigned to you",
                     "Filter by state with --state Open or --state Resolved",


### PR DESCRIPTION
## Summary

- Fixed incorrect command example in the issues tutorial that showed `--limit` instead of `--top`
- Updated documentation in troubleshooting.rst to use the correct `--top` flag

## Changes Made
- Updated tutorial module (`youtrack_cli/tutorial/modules.py`) to use correct command: `yt issues list --top 10`
- Fixed 6 instances in troubleshooting documentation where `--limit` was incorrectly used
- Also fixed `yt projects list` to use `--top` for consistency

## Testing
- [x] Pre-commit hooks passed
- [x] Tutorial now shows the correct command syntax
- [x] Documentation examples are consistent with actual CLI behavior

## Documentation
- [x] Tutorial interactive guide updated
- [x] Troubleshooting documentation updated
- [x] No CHANGELOG.md update needed (bug fix)

Fixes #270