### PR TITLE
✨ Add missing 'yt time list' command referenced in documentation (Fixes #276)

### DIFF
--- a/docs/commands/time.rst
+++ b/docs/commands/time.rst
@@ -13,6 +13,7 @@ Overview
 YouTrack time tracking helps teams monitor effort, generate reports, and understand project progress. The time command group allows you to:
 
 * Log work time on issues with flexible duration formats
+* List time entries with filtering options
 * Track different types of work (Development, Testing, etc.)
 * Generate detailed time reports with filtering
 * View time summaries grouped by various criteria
@@ -80,6 +81,59 @@ Log work time to a specific issue.
 
    # Log time with combined duration format
    yt time log ISSUE-456 "2h 30m" --work-type "Documentation" --description "API docs"
+
+list
+~~~~
+
+List time entries with filtering options.
+
+.. code-block:: bash
+
+   yt time list [OPTIONS]
+
+**Options:**
+
+.. list-table::
+   :widths: 20 20 60
+   :header-rows: 1
+
+   * - Option
+     - Type
+     - Description
+   * - ``--issue``
+     - string
+     - Filter by specific issue ID
+   * - ``--user-id, -u``
+     - string
+     - Filter by specific user ID
+   * - ``--start-date, -s``
+     - string
+     - Start date for filtering (YYYY-MM-DD)
+   * - ``--end-date, -e``
+     - string
+     - End date for filtering (YYYY-MM-DD)
+   * - ``--format, -f``
+     - choice
+     - Output format: table, json (default: table)
+
+**Examples:**
+
+.. code-block:: bash
+
+   # List time entries for a specific issue
+   yt time list --issue ISSUE-123
+
+   # List time entries for a user
+   yt time list --user-id USER-456
+
+   # List time entries for a date range
+   yt time list --start-date "2024-01-01" --end-date "2024-01-31"
+
+   # List all time entries
+   yt time list
+
+   # Export time entries in JSON format
+   yt time list --format json --issue ISSUE-123
 
 report
 ~~~~~~

--- a/youtrack_cli/commands/time_tracking.py
+++ b/youtrack_cli/commands/time_tracking.py
@@ -53,6 +53,61 @@ def log(
 
 
 @time.command()
+@click.option("--issue", help="Filter by specific issue ID")
+@click.option("--user-id", "-u", help="Filter by specific user ID")
+@click.option("--start-date", "-s", help="Start date for filtering (YYYY-MM-DD)")
+@click.option("--end-date", "-e", help="End date for filtering (YYYY-MM-DD)")
+@click.option(
+    "--format",
+    "-f",
+    type=click.Choice(["table", "json"]),
+    default="table",
+    help="Output format",
+)
+@click.pass_context
+def list(
+    ctx: click.Context,
+    issue: Optional[str],
+    user_id: Optional[str],
+    start_date: Optional[str],
+    end_date: Optional[str],
+    format: str,
+) -> None:
+    """List time entries with filtering options."""
+    from ..time import TimeManager
+
+    console = get_console()
+    auth_manager = AuthManager(ctx.obj.get("config"))
+    time_manager = TimeManager(auth_manager)
+
+    console.print("📋 Listing time entries...", style="blue")
+
+    try:
+        result = asyncio.run(
+            time_manager.get_time_entries(
+                issue_id=issue,
+                user_id=user_id,
+                start_date=start_date,
+                end_date=end_date,
+                fields="id,duration,date,description,author(id,fullName),issue(id,summary),type(name)",
+            )
+        )
+
+        if result["status"] == "success":
+            if format == "json":
+                console.print_json(data=result["data"])
+            else:
+                time_manager.display_time_entries(result["data"])
+                console.print(f"\n📊 Total entries: {result['count']}", style="green")
+        else:
+            console.print(f"❌ {result['message']}", style="red")
+            raise click.ClickException(result["message"])
+    except Exception as e:
+        console.print(f"❌ Error: {str(e)}", style="red")
+        raise click.ClickException("Failed to list time entries") from e
+
+
+@time.command()
 @click.option("--issue-id", "-i", help="Filter by specific issue ID")
 @click.option("--user-id", "-u", help="Filter by specific user ID")
 @click.option("--start-date", "-s", help="Start date for filtering (YYYY-MM-DD)")


### PR DESCRIPTION
## Summary

This PR implements the missing `yt time list` command that was referenced in the tutorial documentation but didn't exist in the CLI, causing an error when users tried to use it.

## Changes Made
- Added new `list` command to the `yt time` command group in `time_tracking.py`
- Implemented filtering options: `--issue`, `--user-id`, `--start-date`, `--end-date`, `--format`
- Reused existing `TimeManager.get_time_entries()` and `TimeManager.display_time_entries()` methods
- Added comprehensive test coverage for the new command in `test_time.py`
- Updated documentation in `docs/commands/time.rst` with command details and examples
- Added the new functionality to the overview section of the time tracking documentation

## Testing
- [x] Unit tests added for all command scenarios (success, error, JSON format, no filters)
- [x] Integration testing completed using local YouTrack instance with FPU project
- [x] Manual testing confirmed `yt time list --issue ISSUE-ID` now works without errors
- [x] All filtering options tested and functional
- [x] Both table and JSON output formats verified

## Documentation
- [x] Added complete documentation for the `list` command in `docs/commands/time.rst`
- [x] Updated overview section to include time entry listing functionality
- [x] Added examples for all filtering options and output formats
- [x] Tutorial command `yt time list --issue ISSUE-ID` now works as documented

## Before/After

**Before:**
```bash
$ yt time list --issue ISSUE-ID
Usage: yt time [OPTIONS] COMMAND [ARGS]...
Try 'yt time -h' for help.

Error: No such command 'list'.
```

**After:**
```bash
$ yt time list --issue ISSUE-ID
📋 Listing time entries...
[Table with time entries displayed]
📊 Total entries: N
```

Fixes #276

🤖 Generated with [Claude Code](https://claude.ai/code)