### PR TITLE
🐛 Fix 'Type unknown' in yt projects fields list command (Fixes #292)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Support for both table and JSON output formats
 
 ### Fixed
+- Fix 'Type unknown' in `yt projects fields list` command (#292)
+  - Updated API request to include fieldType presentation for proper field type display
+  - Field types now show correctly as enum[1], user[1], state[1], etc. instead of 'Unknown'
 - Fix 'None' permissions column in `yt users groups` and `yt users roles` commands (#291)
   - Enhanced API field configurations to properly retrieve group and role permissions
   - Improved fallback methods to include permissions data when primary API calls fail

--- a/tests/integration/test_projects_integration.py
+++ b/tests/integration/test_projects_integration.py
@@ -406,7 +406,7 @@ class TestProjectCustomFieldsIntegration:
                 "field": {
                     "id": "field-1",
                     "name": "Priority",
-                    "fieldType": {"name": "EnumIssueCustomField"},
+                    "fieldType": {"id": "enum[1]", "presentation": "enum[1]"},
                 },
             },
             {
@@ -417,7 +417,7 @@ class TestProjectCustomFieldsIntegration:
                 "field": {
                     "id": "field-2",
                     "name": "Assignee",
-                    "fieldType": {"name": "SingleUserIssueCustomField"},
+                    "fieldType": {"id": "user[1]", "presentation": "user[1]"},
                 },
             },
         ]
@@ -438,7 +438,7 @@ class TestProjectCustomFieldsIntegration:
                 "field": {
                     "id": "field-1",
                     "name": "Field Without Empty Text",
-                    "fieldType": {"name": "SimpleIssueCustomField"},
+                    "fieldType": {"id": "text[1]", "presentation": "text[1]"},
                 },
             },
             {
@@ -449,7 +449,7 @@ class TestProjectCustomFieldsIntegration:
                 "field": {
                     "id": "field-2",
                     "name": "Field With Very Long Name That Might Cause Display Issues",
-                    "fieldType": {"name": "TextIssueCustomField"},
+                    "fieldType": {"id": "text[*]", "presentation": "text[*]"},
                 },
             },
             {

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -775,7 +775,7 @@ class TestProjectCustomFields:
                 "field": {
                     "id": "global-field-1",
                     "name": "Priority",
-                    "fieldType": {"name": "EnumIssueCustomField"},
+                    "fieldType": {"id": "enum[1]", "presentation": "enum[1]"},
                 },
                 "bundle": {
                     "id": "bundle-1",
@@ -793,7 +793,7 @@ class TestProjectCustomFields:
                 "field": {
                     "id": "global-field-2",
                     "name": "Assignee",
-                    "fieldType": {"name": "SingleUserIssueCustomField"},
+                    "fieldType": {"id": "user[1]", "presentation": "user[1]"},
                 },
             },
         ]
@@ -996,7 +996,7 @@ class TestProjectCustomFields:
                 "field": {
                     "id": "global-field-1",
                     "name": "Priority",
-                    "fieldType": {"name": "EnumIssueCustomField"},
+                    "fieldType": {"id": "enum[1]", "presentation": "enum[1]"},
                 },
             },
             {
@@ -1007,13 +1007,69 @@ class TestProjectCustomFields:
                 "field": {
                     "id": "global-field-2",
                     "name": "Assignee",
-                    "fieldType": {"name": "SingleUserIssueCustomField"},
+                    "fieldType": {"id": "user[1]", "presentation": "user[1]"},
                 },
             },
         ]
 
-        # This should not raise an exception
+        # This should not raise an exception and should display field types correctly
         project_manager.display_custom_fields_table(custom_fields)
+
+    def test_display_custom_fields_table_shows_correct_field_types(self, capsys):
+        """Test that field types are displayed correctly instead of 'Unknown'."""
+        auth_manager = Mock()
+        project_manager = ProjectManager(auth_manager)
+
+        custom_fields = [
+            {
+                "id": "field-1",
+                "canBeEmpty": True,
+                "emptyFieldText": "No Priority",
+                "isPublic": True,
+                "field": {
+                    "id": "global-field-1",
+                    "name": "Priority",
+                    "fieldType": {"id": "enum[1]", "presentation": "enum[1]"},
+                },
+            },
+            {
+                "id": "field-2",
+                "canBeEmpty": False,
+                "emptyFieldText": "Unassigned",
+                "isPublic": True,
+                "field": {
+                    "id": "global-field-2",
+                    "name": "Assignee",
+                    "fieldType": {"id": "user[1]", "presentation": "user[1]"},
+                },
+            },
+            {
+                "id": "field-3",
+                "canBeEmpty": True,
+                "emptyFieldText": "No stage",
+                "isPublic": True,
+                "field": {
+                    "id": "global-field-3",
+                    "name": "Stage",
+                    "fieldType": {"id": "state[1]", "presentation": "state[1]"},
+                },
+            },
+        ]
+
+        project_manager.display_custom_fields_table(custom_fields)
+
+        captured = capsys.readouterr()
+
+        # Verify that field types are shown correctly, not as 'Unknown'
+        assert "enum[1]" in captured.out
+        assert "user[1]" in captured.out
+        assert "state[1]" in captured.out
+        assert "Unknown" not in captured.out
+
+        # Verify field names are displayed
+        assert "Priority" in captured.out
+        assert "Assignee" in captured.out
+        assert "Stage" in captured.out
 
 
 class TestProjectCustomFieldsCLI:
@@ -1065,7 +1121,7 @@ class TestProjectCustomFieldsCLI:
             "data": [
                 {
                     "id": "field-1",
-                    "field": {"name": "Priority", "fieldType": {"name": "EnumIssueCustomField"}},
+                    "field": {"name": "Priority", "fieldType": {"id": "enum[1]", "presentation": "enum[1]"}},
                     "canBeEmpty": True,
                     "isPublic": True,
                 }

--- a/youtrack_cli/projects.py
+++ b/youtrack_cli/projects.py
@@ -550,7 +550,11 @@ class ProjectManager:
 
         # Default fields to return
         if not fields:
-            fields = "id,canBeEmpty,emptyFieldText,isPublic,field(id,name,fieldType),bundle(id,values(id,name))"
+            fields = (
+                "id,canBeEmpty,emptyFieldText,isPublic,"
+                "field(id,name,fieldType(id,presentation)),"
+                "bundle(id,values(id,name))"
+            )
 
         # Build query parameters
         params = {"fields": fields}
@@ -859,7 +863,7 @@ class ProjectManager:
             # Get field name and type
             field_info = field.get("field", {})
             field_name = field_info.get("name", "N/A") if field_info else "N/A"
-            field_type = field_info.get("fieldType", {}).get("name", "Unknown") if field_info else "Unknown"
+            field_type = field_info.get("fieldType", {}).get("presentation", "Unknown") if field_info else "Unknown"
 
             # Format required status
             can_be_empty = field.get("canBeEmpty", True)

--- a/youtrack_cli/users.py
+++ b/youtrack_cli/users.py
@@ -829,14 +829,16 @@ class UserManager:
         for group in groups:
             name = group.get("name", "N/A")
             description = group.get("description", "")
-            
+
             # Groups are organizational units in YouTrack, not permission holders
             group_type = "Organizational"
 
             table.add_row(name, description or "No description", group_type)
 
         self.console.print(table)
-        self.console.print("\n[dim]Note: Groups are organizational units. User permissions are managed through roles.[/dim]")
+        self.console.print(
+            "\n[dim]Note: Groups are organizational units. User permissions are managed through roles.[/dim]"
+        )
 
     def display_user_roles(self, roles: list[dict[str, Any]], user_id: str) -> None:
         """Display user roles in a formatted table.


### PR DESCRIPTION
## Summary

Fixed the issue where the `yt projects fields list` command was displaying 'Type unknown' for all custom field types instead of the actual field type names.

## Changes Made
- Updated API request to include `fieldType(id,presentation)` instead of just `fieldType`
- Changed display logic to use `fieldType.presentation` instead of `fieldType.name`
- Updated all test mock data to reflect the new fieldType structure with presentation property
- Added comprehensive test to verify field types display correctly
- Updated CHANGELOG.md with fix details

## Testing
- [x] Unit tests added/updated and passing
- [x] Manual testing completed with real YouTrack instance
- [x] Field types now display correctly (enum[1], user[1], state[1], etc.)
- [x] Pre-commit hooks passing

## Before/After

**Before:** All field types showed as "Unknown"
```
┃ Name         ┃ Type    ┃ Required ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━┩
│ Priority     │ Unknown │ Yes      │
│ Assignee     │ Unknown │ No       │
```

**After:** Field types display correctly
```
┃ Name         ┃ Type     ┃ Required ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━┩
│ Priority     │ enum[1]  │ Yes      │
│ Assignee     │ user[1]  │ No       │
```

Fixes #292

🤖 Generated with [Claude Code](https://claude.ai/code)