### PR TITLE
🐛 Fix articles tree command NoneType error (Fixes #299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix `yt articles tree` command throwing NoneType error when parentArticle field is null (#299)
+
 ## [0.10.0] - 2025-07-20
 
 ### Added

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -460,6 +460,33 @@ class TestArticleManager:
             mock_tree.assert_called_once()
             mock_console.return_value.print.assert_called()
 
+    def test_display_articles_tree_with_null_parent_article(self, article_manager):
+        """Test displaying articles tree with null parentArticle field (fixes #299)."""
+        articles = [
+            {
+                "id": "123",
+                "summary": "Root Article",
+                "parentArticle": None,  # This would cause NoneType error before fix
+                "visibility": {"type": "public"},
+            },
+            {
+                "id": "124",
+                "summary": "Another Root Article",
+                "visibility": {"type": "public"},
+            },
+        ]
+
+        with (
+            patch("youtrack_cli.articles.get_console") as mock_console,
+            patch("youtrack_cli.articles.Tree") as mock_tree,
+        ):
+            article_manager.console = mock_console.return_value
+            # This should not raise AttributeError: 'NoneType' object has no attribute 'get'
+            article_manager.display_articles_tree(articles)
+
+            mock_tree.assert_called_once()
+            mock_console.return_value.print.assert_called()
+
     def test_display_article_details(self, article_manager):
         """Test displaying article details."""
         article = {

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -357,6 +357,33 @@ class TestEnhancedArticlesTree:
 
         assert isinstance(tree, Tree)
 
+    def test_create_enhanced_articles_tree_with_null_parent_article(self):
+        """Test creating enhanced articles tree with null parentArticle field (fixes #299)."""
+        articles = [
+            {
+                "id": "ART-1",
+                "idReadable": "ART-1",
+                "summary": "Root Article",
+                "parentArticle": None,  # This would cause NoneType error before fix
+                "reporter": {"fullName": "Author One"},
+                "created": "2024-01-01T00:00:00Z",
+                "visibility": {"$type": "UnlimitedVisibility"},
+            },
+            {
+                "id": "ART-2",
+                "idReadable": "ART-2",
+                "summary": "Another Root Article",
+                "reporter": {"fullName": "Author Two"},
+                "created": "2024-01-02T00:00:00Z",
+                "visibility": {"$type": "LimitedVisibility"},
+            },
+        ]
+
+        # This should not raise AttributeError: 'NoneType' object has no attribute 'get'
+        tree = create_enhanced_articles_tree(articles, show_metadata=True)
+
+        assert isinstance(tree, Tree)
+
 
 @pytest.mark.unit
 class TestStatusColorFunction:

--- a/youtrack_cli/articles.py
+++ b/youtrack_cli/articles.py
@@ -659,7 +659,8 @@ class ArticleManager:
         child_articles: dict[str, list[dict[str, Any]]] = {}
 
         for article in articles:
-            parent_id = article.get("parentArticle", {}).get("id")
+            parent_article = article.get("parentArticle")
+            parent_id = parent_article.get("id") if parent_article else None
             if parent_id:
                 if parent_id not in child_articles:
                     child_articles[parent_id] = []

--- a/youtrack_cli/trees.py
+++ b/youtrack_cli/trees.py
@@ -302,7 +302,8 @@ def create_enhanced_articles_tree(
     child_articles: Dict[str, List[Dict[str, Any]]] = {}
 
     for article in articles:
-        parent_id = article.get("parentArticle", {}).get("id")
+        parent_article = article.get("parentArticle")
+        parent_id = parent_article.get("id") if parent_article else None
         if parent_id:
             if parent_id not in child_articles:
                 child_articles[parent_id] = []


### PR DESCRIPTION
## Summary

Fixes the `yt articles tree` command that was failing with `AttributeError: 'NoneType' object has no attribute 'get'` when the YouTrack API returns `null` for the `parentArticle` field.

## Problem

The issue occurred in two locations where the code assumed `parentArticle` field would either be missing or contain a dictionary, but the YouTrack API can return `null/None` for this field:

- `youtrack_cli/trees.py:305` - Enhanced tree display
- `youtrack_cli/articles.py:662` - Standard tree display

## Solution

Replaced the problematic pattern:
```python
parent_id = article.get("parentArticle", {}).get("id")
```

With proper null checking:
```python
parent_article = article.get("parentArticle")
parent_id = parent_article.get("id") if parent_article else None
```

## Changes Made

- ✅ Fixed NoneType error in `youtrack_cli/trees.py:305`
- ✅ Fixed NoneType error in `youtrack_cli/articles.py:662`
- ✅ Added comprehensive test coverage for null parentArticle scenarios
- ✅ Updated CHANGELOG.md with bug fix entry
- ✅ Verified fix works with real CLI commands

## Testing

- [x] Added unit tests for null parentArticle scenarios in both files
- [x] Verified enhanced and standard tree display work correctly
- [x] Manual testing with `yt articles tree --project-id FPU`
- [x] Manual testing with `yt articles tree --project-id FPU --enhanced`
- [x] All pre-commit checks pass
- [x] All tests pass

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

Fixes #299

🤖 Generated with [Claude Code](https://claude.ai/code)