### PR TITLE
Fix integer timestamp rendering error in 'yt issues show' command (Fixes #319)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `yt issues links list` now shows user-friendly issue IDs (e.g., "FPU-5" instead of "3-2")
   - `yt time list` and `yt time report` now show user-friendly issue IDs in Issue column
   - Time entry IDs moved to last column as "Entry ID" for reference
+- Fix integer timestamp rendering error in `yt issues show` command (#319)
+  - Timestamps are now properly formatted as human-readable strings instead of raw integers
+  - Added `format_timestamp` utility function to handle Unix timestamp conversion
 
 ## [0.10.0] - 2025-07-20
 

--- a/youtrack_cli/issues.py
+++ b/youtrack_cli/issues.py
@@ -19,6 +19,7 @@ from .panels import (
     create_issue_overview_panel,
 )
 from .progress import get_progress_manager
+from .utils import format_timestamp
 
 __all__ = ["IssueManager"]
 
@@ -1704,8 +1705,8 @@ class IssueManager:
         table.add_row("Project", project_name)
 
         # Timestamps
-        table.add_row("Created", issue.get("created", "N/A"))
-        table.add_row("Updated", issue.get("updated", "N/A"))
+        table.add_row("Created", format_timestamp(issue.get("created")))
+        table.add_row("Updated", format_timestamp(issue.get("updated")))
 
         # Tags if any
         tags = issue.get("tags", [])

--- a/youtrack_cli/panels.py
+++ b/youtrack_cli/panels.py
@@ -8,6 +8,7 @@ from rich.table import Table
 from rich.text import Text
 
 from .console import get_console
+from .utils import format_timestamp
 
 
 def _get_assignee_from_issue_data(issue_data: Dict[str, Any]) -> str:
@@ -295,7 +296,7 @@ def create_issue_overview_panel(issue_data: Dict[str, Any]) -> Panel:
     return PanelFactory.create_details_panel(
         title="Issue Overview",
         data=overview_data,
-        subtitle=f"Created: {issue_data.get('created', 'Unknown')}",
+        subtitle=f"Created: {format_timestamp(issue_data.get('created'))}",
     )
 
 
@@ -312,9 +313,9 @@ def create_issue_details_panel(issue_data: Dict[str, Any]) -> Panel:
         "Description": issue_data.get("description", "No description"),
         "Reporter": issue_data.get("reporter", {}).get("name"),
         "Assignee": _get_assignee_from_issue_data(issue_data),
-        "Created": issue_data.get("created"),
-        "Updated": issue_data.get("updated"),
-        "Resolved": issue_data.get("resolved"),
+        "Created": format_timestamp(issue_data.get("created")),
+        "Updated": format_timestamp(issue_data.get("updated")),
+        "Resolved": format_timestamp(issue_data.get("resolved")),
     }
 
     return PanelFactory.create_details_panel(


### PR DESCRIPTION
## Summary

Fixes the integer timestamp rendering error that was causing the `yt issues show` command to fail with the error "unable to render int; a string or other renderable object is required". This issue occurred when the YouTrack API returned timestamp fields as integers (Unix timestamps) but the Rich library's `table.add_row()` method expected string values.

## Changes Made

- **Added `format_timestamp` utility function** in `utils.py` to handle Unix timestamp conversion
  - Supports Unix timestamps in milliseconds (YouTrack format)
  - Handles ISO format strings and other timestamp formats
  - Provides fallback handling for invalid or null timestamps
  - Returns human-readable format: "YYYY-MM-DD HH:MM:SS"

- **Updated `_display_issue_details_traditional()` method** in `issues.py:1707-1708`
  - Now uses `format_timestamp()` for Created and Updated fields
  - Ensures proper string formatting before passing to Rich table

- **Updated panel functions** in `panels.py`
  - `create_issue_overview_panel()` subtitle now formats the created timestamp
  - `create_issue_details_panel()` now formats Created, Updated, and Resolved timestamps

## Testing

- [x] Tested with `yt issues show DEMO-18` (the original failing case)
- [x] Tested with `yt issues show FPU-1` to verify consistency
- [x] All tests pass (except one unrelated auth test that was already failing)
- [x] Code passes linting (ruff) and type checking (ty)
- [x] Timestamps now display correctly as human-readable strings

## Before/After

**Before**: Error message
```
❌ Error getting issue details: unable to render int; a string or other renderable object is required
```

**After**: Properly formatted timestamps
```
│ Created     │ 2025-07-16 19:44:11             │
│ Updated     │ 2025-07-20 14:51:25             │
```

## Documentation

- [x] Updated CHANGELOG.md with fix details
- [x] Added comprehensive docstring for `format_timestamp` utility function

Fixes #319

🤖 Generated with [Claude Code](https://claude.ai/code)