### PR TITLE
🐛 Fix issue fields showing N/A instead of actual values in show command (Fixes #323)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Fix `yt issues show` command displaying "N/A" for State, Priority, and Type fields (#323)
+  - Added fallback logic to check custom fields when built-in fields are not available
+  - Implemented `_get_field_with_fallback` method to handle both built-in and custom field structures
+  - Ensures consistent field resolution between table and detail views
 - Fix `yt articles tree` command missing child articles in tree display (#320)
   - Resolved ID mismatch between parent grouping (internal IDs) and child matching (readable IDs)
   - Tree now correctly displays hierarchical article structure with all child articles

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -1748,3 +1748,45 @@ class TestIssueTablePagination:
 
             # Should format ID as PROJ-42
             mock_console.print.assert_called_once()
+
+    def test_get_field_with_fallback_built_in_dict(self, issue_manager):
+        """Test _get_field_with_fallback with built-in field as dict."""
+        issue = {"state": {"name": "Open"}, "customFields": [{"name": "State", "value": {"name": "Custom Open"}}]}
+
+        result = issue_manager._get_field_with_fallback(issue, "state", ["State"])
+        assert result == "Open"
+
+    def test_get_field_with_fallback_built_in_string(self, issue_manager):
+        """Test _get_field_with_fallback with built-in field as string."""
+        issue = {"state": "Open", "customFields": [{"name": "State", "value": {"name": "Custom Open"}}]}
+
+        result = issue_manager._get_field_with_fallback(issue, "state", ["State"])
+        assert result == "Open"
+
+    def test_get_field_with_fallback_custom_field(self, issue_manager):
+        """Test _get_field_with_fallback falls back to custom field."""
+        issue = {"customFields": [{"name": "State", "value": {"name": "Custom Open"}}]}
+
+        result = issue_manager._get_field_with_fallback(issue, "state", ["State"])
+        assert result == "Custom Open"
+
+    def test_get_field_with_fallback_multiple_custom_names(self, issue_manager):
+        """Test _get_field_with_fallback tries multiple custom field names."""
+        issue = {"customFields": [{"name": "Stage", "value": {"name": "In Progress"}}]}
+
+        result = issue_manager._get_field_with_fallback(issue, "state", ["State", "Stage"])
+        assert result == "In Progress"
+
+    def test_get_field_with_fallback_no_match(self, issue_manager):
+        """Test _get_field_with_fallback returns N/A when no field found."""
+        issue = {"customFields": []}
+
+        result = issue_manager._get_field_with_fallback(issue, "state", ["State"])
+        assert result == "N/A"
+
+    def test_get_field_with_fallback_empty_built_in(self, issue_manager):
+        """Test _get_field_with_fallback with empty built-in field."""
+        issue = {"state": {}, "customFields": [{"name": "State", "value": {"name": "Custom Open"}}]}
+
+        result = issue_manager._get_field_with_fallback(issue, "state", ["State"])
+        assert result == "Custom Open"


### PR DESCRIPTION
## Summary

Fixed the `yt issues show` command displaying "N/A" for State, Priority, and Type fields instead of their actual YouTrack values. The issue was caused by the detail view only checking built-in fields without falling back to custom fields like the table view does.

## Changes Made

- **Added `_get_field_with_fallback` method**: Handles field resolution with fallback to custom fields
- **Updated `_display_issue_details_traditional`**: Now uses the new method for State, Priority, and Type fields
- **Ensured consistency**: Both table and detail views now use the same field resolution logic
- **Added comprehensive tests**: 6 new test cases covering various scenarios
- **Updated CHANGELOG.md**: Documented the fix

## Testing

- [x] Functional testing with `yt issues show DEMO-18` - now shows actual values instead of "N/A"
- [x] Tested with multiple issues from different projects (DEMO, FPU)
- [x] Unit tests added for the new `_get_field_with_fallback` method
- [x] All tests pass for the new functionality
- [x] Type checking and linting pass

## Testing Evidence

**Before (showing "N/A"):**
```
│ State       │ N/A                                                                                                     │
│ Priority    │ N/A                                                                                                     │
│ Type        │ N/A                                                                                                     │
```

**After (showing actual values):**
```
│ State       │ Open                                                           │
│ Priority    │ Major                                                          │
│ Type        │ Task                                                           │
```

## Edge Cases Handled

- Built-in fields as objects with `name` property
- Built-in fields as strings
- Empty or missing built-in fields falling back to custom fields
- Multiple custom field name variants (e.g., "State" or "Stage")
- No matching fields returning "N/A"

Fixes #323

🤖 Generated with [Claude Code](https://claude.ai/code)