### PR TITLE
🐛 Fix articles sort command not finding child articles that exist in tree view (Fixes #324)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Fix `yt articles sort` command not finding child articles that exist in tree view (#324)
+  - Added logic to resolve parent article readable IDs to internal IDs for proper filtering
+  - Child articles are now correctly identified when using readable parent IDs (e.g., "FPU-A-1")
+  - Ensures consistent behavior between `yt articles tree` and `yt articles sort` commands
 - Fix `yt issues show` command displaying "N/A" for State, Priority, and Type fields (#323)
   - Added fallback logic to check custom fields when built-in fields are not available
   - Implemented `_get_field_with_fallback` method to handle both built-in and custom field structures


### PR DESCRIPTION
## Summary

Fixed the issue where `yt articles sort FPU-A-1` reported "No child articles found" even though child articles existed and were visible in `yt articles tree`.

## Root Cause

The problem was a mismatch between how parent-child relationships were identified:

1. The `sort` command was filtering child articles by comparing the parent article's internal ID (e.g., "167-6") with the provided readable ID (e.g., "FPU-A-1")
2. The YouTrack API returns parent article information with only internal IDs in the `parentArticle` field
3. When users provide readable IDs like "FPU-A-1", the filtering logic failed to match them with internal IDs

## Changes Made

### Core Fix
- **Enhanced parent ID resolution**: Added logic to resolve readable parent IDs to their corresponding internal IDs before filtering
- **Dual matching**: The filtering now matches against both the provided parent_id and the resolved internal ID
- **Fallback handling**: If the parent article can't be found in the current data, attempts to fetch it directly; falls back to using the provided ID as-is

### Testing
- **Added comprehensive test cases**: 
  - `test_list_articles_with_parent_id_filtering`: Tests filtering with readable parent ID
  - `test_list_articles_with_parent_id_no_children`: Tests edge case with no child articles
- **All existing tests pass**: Verified no regression in existing functionality

### Documentation
- **Updated CHANGELOG.md**: Added entry documenting the fix and its impact

## Testing

### Manual Testing
✅ **Before Fix:**
```bash
$ yt articles sort FPU-A-1
📋 Fetching child articles for 'FPU-A-1'...
No child articles found.
```

✅ **After Fix:**
```bash
$ yt articles sort FPU-A-1
📋 Fetching child articles for 'FPU-A-1'...
Found 3 child articles:
┏━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ ID      ┃ Title         ┃ Summary      ┃ Author ┃ Created       ┃ Visibility ┃
┡━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
│ FPU-A-3 │ Draft Article │ This is a... │ admin  │ 2025-07-13    │ Visible    │
│ FPU-A-4 │ Updated Test  │ This is...   │ admin  │ 2025-07-13    │ Visible    │
│ FPU-A-2 │ Test Child    │ This is a... │ admin  │ 2025-07-16    │ Visible    │
└─────────┴───────────────┴──────────────┴────────┴───────────────┴────────────┘
```

### Edge Cases Tested
✅ Articles with no children return empty results correctly  
✅ Tree command continues to work as expected  
✅ Both readable IDs and internal IDs work as parent_id input  
✅ Non-existent parent IDs handled gracefully  

### Automated Testing
✅ All existing tests continue to pass  
✅ New tests added for parent_id filtering functionality  
✅ Code coverage maintained  

## Consistency Achieved

This fix ensures that both `yt articles tree` and `yt articles sort` commands now behave consistently when working with parent-child article relationships, resolving the user-reported discrepancy.

🤖 Generated with [Claude Code](https://claude.ai/code)