### PR TITLE
🐛 Fix articles reorder --live flag not working

### DIFF
--- a/youtrack_cli/commands/articles.py
+++ b/youtrack_cli/commands/articles.py
@@ -1152,7 +1152,7 @@ def reorder(
     article_manager = ArticleManager(auth_manager)
 
     # Determine if we're doing live reordering
-    is_live = live and not dry_run
+    is_live = live
 
     if is_live:
         console.print("🚀 [bold green]LIVE REORDERING MODE[/bold green]", style="bold green")


### PR DESCRIPTION
## Summary
Fixes a critical bug where the `--live` flag in `yt articles reorder` command was not working, preventing users from actually performing article reordering.

## Problem
- The `--live` flag was being negated by the default `--dry-run=True` setting
- Logic `is_live = live and not dry_run` always evaluated to `False`
- Users were stuck in preview mode even when explicitly requesting live execution
- No way to actually reorder articles despite having the functionality implemented

## Solution
- Simplified the logic from `is_live = live and not dry_run` to `is_live = live`
- The `--live` flag now properly overrides the `--dry-run` default behavior
- Live reordering mode activates correctly with proper confirmation prompts

## Test Plan
- [x] Verified `--live` flag now activates live mode (shows "🚀 LIVE REORDERING MODE")
- [x] Confirmed sorting functionality works correctly for all sort criteria
- [x] All 21 reorder-related tests pass
- [x] Linting and type checking pass
- [x] Manual testing shows confirmation prompt appears in live mode

## Before
```bash
yt articles reorder --project-id FPU --sort-by title --live --method custom-field
# Always showed "📋 PREVIEW MODE" despite --live flag
```

## After
```bash
yt articles reorder --project-id FPU --sort-by title --live --method custom-field
# Now shows "🚀 LIVE REORDERING MODE" and asks for confirmation
```

🤖 Generated with [Claude Code](https://claude.ai/code)