### PR TITLE
📚 Fix README placeholder URLs (Fixes #340)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Features comprehensive error handling and validation
 
 ### Fixed
+- Fix README and CONTRIBUTING placeholder URLs to use correct repository URL (#340)
+  - Replaced `YOUR_USERNAME` placeholders with `ryancheley` in README.md and CONTRIBUTING.md
+  - Updated GitHub links for issues, discussions, and repository cloning
+  - Ensures professional documentation appearance and working links
 - Fix `yt articles sort` command to properly display child articles and remove misleading functionality (#327)
   - Fixed child article filtering bug that prevented proper parent-child relationship matching
   - Replaced misleading `--update` flag with `--sort-by` and `--reverse` options for display sorting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Thank you for your interest in contributing to YouTrack CLI! This document provi
 
 1. **Fork and Clone the Repository**
    ```bash
-   git clone https://github.com/YOUR_USERNAME/yt-cli.git
+   git clone https://github.com/ryancheley/yt-cli.git
    cd yt-cli
    ```
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ pip install yt-cli
 
 ```bash
 # Clone and set up for development
-git clone https://github.com/ryancheley/yt-cli.git
+git clone https://github.com/YOUR_USERNAME/yt-cli.git
 cd yt-cli
 
 # Using uv (recommended)
@@ -216,7 +216,7 @@ This project uses `uv` for dependency management.
 
 ```bash
 # Clone the repository
-git clone https://github.com/ryancheley/yt-cli.git
+git clone https://github.com/YOUR_USERNAME/yt-cli.git
 cd yt-cli
 
 # Install dependencies

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ pip install yt-cli
 
 ```bash
 # Clone and set up for development
-git clone https://github.com/YOUR_USERNAME/yt-cli.git
+git clone https://github.com/ryancheley/yt-cli.git
 cd yt-cli
 
 # Using uv (recommended)
@@ -205,8 +205,8 @@ yt reports velocity PROJECT-123 --sprints 10
 ## Help and Support
 
 - 📖 **[Documentation](https://yt-cli.readthedocs.io/en/latest/)** - Comprehensive guides and examples
-- 🐛 **[Issue Tracker](https://github.com/YOUR_USERNAME/yt-cli/issues)** - Report bugs and request features
-- 💬 **[Discussions](https://github.com/YOUR_USERNAME/yt-cli/discussions)** - Ask questions and share ideas
+- 🐛 **[Issue Tracker](https://github.com/ryancheley/yt-cli/issues)** - Report bugs and request features
+- 💬 **[Discussions](https://github.com/ryancheley/yt-cli/discussions)** - Ask questions and share ideas
 
 ## Development
 
@@ -216,7 +216,7 @@ This project uses `uv` for dependency management.
 
 ```bash
 # Clone the repository
-git clone https://github.com/YOUR_USERNAME/yt-cli.git
+git clone https://github.com/ryancheley/yt-cli.git
 cd yt-cli
 
 # Install dependencies


### PR DESCRIPTION
## Summary

Replaced placeholder URLs containing `YOUR_USERNAME` with the correct username `ryancheley` in documentation files to ensure professional appearance and working GitHub links.

## Changes Made
- Updated 4 placeholder URLs in README.md (lines 59, 208, 209, 219)  
- Fixed 1 placeholder URL in CONTRIBUTING.md (line 30)
- Updated CHANGELOG.md with documentation fix entry

## Testing
- [x] All placeholder text verified as replaced
- [x] GitHub URLs confirmed to point to correct repository
- [x] Pre-commit hooks passed successfully
- [x] No code changes - documentation only

## Documentation  
- [x] CHANGELOG.md updated with changes
- [x] No other documentation updates required (docs/ already correct)

Fixes #340