### PR TITLE
Fix TypeError in 'yt new' command - incorrect parameter name

### DIFF
--- a/youtrack_cli/main.py
+++ b/youtrack_cli/main.py
@@ -1100,13 +1100,12 @@ def new(
     # Call the underlying issues create command
     ctx.invoke(
         create,
-        project=project,
-        title=title,
+        project_id=project,
+        summary=title,
         description=description,
         type=type,
         priority=priority,
         assignee=assignee,
-        tag=tag,
     )
 
 


### PR DESCRIPTION
## Summary

This PR fixes a TypeError that occurs when using the `yt new` command due to incorrect parameter names being passed to the underlying `create` function.

## Changes Made

- Changed parameter name from `project` to `project_id` when invoking the create function
- Changed parameter name from `title` to `summary` to match the create function signature
- Removed unsupported `tag` parameter from the invoke call (tag functionality needs separate implementation)

## Testing

- [x] Tested `yt new` command locally with the fix
- [x] Command now creates issues successfully without TypeError
- [x] Pre-commit checks passed (except for unrelated logout hook issue)

## Test Example

```bash
uv run python -m youtrack_cli.main new FPU 'This is a yt new test'
```

Output:
```
🐛 Creating issue 'This is a yt new test' in project 'FPU'...
Success: Issue 'This is a yt new test' created successfully
Issue ID: FPU-13
```

## Note

The `--tag` option in the `yt new` command is not currently functional as the underlying `create` function doesn't support tags. This would need to be implemented as a separate feature (possibly by adding tags after issue creation).

Fixes #368

🤖 Generated with [Claude Code](https://claude.ai/code)