### PR TITLE
🐛 Fix NoneType error in time summary group-by type (Fixes #377)

### DIFF
--- a/youtrack_cli/time.py
+++ b/youtrack_cli/time.py
@@ -277,7 +277,11 @@ class TimeManager:
                 issue = entry.get("issue", {})
                 key = f"{issue.get('id', 'Unknown')} - {issue.get('summary', 'No summary')}"
             elif group_by == "type":
-                key = entry.get("type", {}).get("name", "No type")
+                work_type = entry.get("type")
+                if isinstance(work_type, dict) and work_type.get("name"):
+                    key = work_type.get("name")
+                else:
+                    key = "No type"
             else:
                 key = "All"
 


### PR DESCRIPTION
## Summary

This PR fixes the NoneType error that occurs when running `yt time summary --group-by type` when some time entries have null/None work item types.

## Related Issues
Fixes #377

## Problem Description
The `yt time summary --group-by type` command was failing with a NoneType error when trying to group time entries by work item type. The error occurred because some time entries have null/None type values, and the code was trying to call `.get("name", "No type")` on None values.

**Error message:**
```
❌ Error: 'NoneType' object has no attribute 'get'
```

## Solution
- Modified the `_aggregate_time_data` method in `youtrack_cli/time.py` to properly handle None values for work item types
- Applied the same defensive null-checking logic that was already used in the `display_time_entries` method
- Entries with None/null type are now grouped under "No type" instead of causing a runtime error

## Changes Made
- Updated `youtrack_cli/time.py:279-284` to use proper None-checking for work item types
- Changed from: `key = entry.get("type", {}).get("name", "No type")`
- Changed to: Proper isinstance check and null handling

## Testing
- ✅ Manually tested with local YouTrack instance using `FPU` project
- ✅ Confirmed `yt time summary --group-by type` now works correctly  
- ✅ Verified entries with no type are grouped under "No type"
- ✅ Confirmed other group-by options still work (`--group-by user`, `--group-by issue`)
- ✅ All time-related unit tests pass (22/22 tests)
- ✅ No regression in existing functionality

## Test Results
```bash
$ yt time summary --group-by type
📋 Generating time summary...

Time Summary
Total Time: 0.0h (0 minutes)
                Time by Group                 
┏━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┓
┃ Group          ┃ Hours ┃ Minutes ┃ Entries ┃
┡━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━╇━━━━━━━━━┩
│ Implementation │ 0.0   │ 0       │ 2       │
│ Investigation  │ 0.0   │ 0       │ 1       │
│ No type        │ 0.0   │ 0       │ 3       │
└────────────────┴───────┴─────────┴─────────┘

📊 Based on 6 entries
```

## Documentation
- ✅ No documentation changes needed (bug fix maintains existing API)
- ✅ Error handling is now more robust and user-friendly

🤖 Generated with [Claude Code](https://claude.ai/code)