### PR TITLE
📄 Implement pagination for handling large result sets efficiently (Fixes #388)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Implement pagination for handling large result sets efficiently (#388)
+  - Enhanced API client with unified pagination support for cursor-based and offset-based APIs
+  - Automatic pagination type detection based on endpoint patterns
+  - New CLI options for all list commands: `--page-size`, `--after-cursor`, `--before-cursor`, `--all`, `--max-results`
+  - Updated `yt issues list`, `yt projects list`, `yt users list`, and `yt articles list` commands with pagination support
+  - Backward compatibility maintained with existing `--top` parameter (now legacy)
+  - Comprehensive pagination configuration with per-entity limits and performance optimization
+  - Enhanced user experience with pagination navigation hints in CLI output
+  - Full test coverage for pagination functionality including edge cases and error handling
 - Add comprehensive request timeout configuration (#387)
   - Configure timeouts for all API calls to prevent hanging requests and improve reliability
   - Support for environment variables: YOUTRACK_DEFAULT_TIMEOUT, YOUTRACK_CONNECT_TIMEOUT, YOUTRACK_READ_TIMEOUT, YOUTRACK_WRITE_TIMEOUT, YOUTRACK_POOL_TIMEOUT


### PR DESCRIPTION
## Summary

This PR implements comprehensive pagination functionality to handle large result sets efficiently across all list commands in the YouTrack CLI, addressing issue #388.

## Changes Made

### Core Implementation
- **Enhanced API client** with unified pagination support for both cursor-based and offset-based APIs
- **Automatic pagination type detection** based on endpoint patterns (issues use cursor, others use offset)
- **Updated backend methods** in `projects.py`, `users.py`, and `articles.py` with full pagination support
- **Comprehensive pagination configuration** with per-entity limits and performance optimization

### CLI Command Updates
Added new pagination options to all list commands:
- `--page-size`: Number of items per page (default: 100)
- `--after-cursor`: Start pagination after this cursor
- `--before-cursor`: Start pagination before this cursor  
- `--all`: Fetch all results using pagination
- `--max-results`: Maximum total number of results to fetch

Updated commands:
- `yt issues list` (already had pagination, now enhanced)
- `yt projects list` 
- `yt users list`
- `yt articles list`

### User Experience Enhancements
- **Pagination navigation hints** in CLI output when more results are available
- **Backward compatibility** maintained with existing `--top` parameter (now marked as legacy)
- **Enhanced error handling** and validation for pagination parameters

### Testing & Documentation
- **Extended test coverage** in `tests/test_pagination.py` with comprehensive edge cases
- **Updated CHANGELOG.md** with detailed feature description
- **Maintained existing help documentation** patterns with clear parameter descriptions

## Testing

### Unit Tests
- [x] Extended pagination tests with both cursor and offset scenarios
- [x] Edge case handling (empty results, single page, error conditions)
- [x] Parameter validation and error handling
- [x] Backward compatibility with legacy `--top` parameter

### Manual Testing
- [x] All list commands work with new pagination options
- [x] Cursor navigation functions correctly
- [x] Legacy `--top` parameter maintains compatibility
- [x] Pagination hints display properly in terminal output

### Integration Testing
- [x] Commands integrate properly with existing authentication and configuration
- [x] Output formatting works with both table and JSON modes
- [x] No breaking changes to existing CLI workflows

## Usage Examples

```bash
# Fetch all projects with automatic pagination
yt projects list --all

# Get first 50 users with custom page size  
yt users list --page-size 50

# Continue from a specific cursor position
yt issues list --after-cursor "cursor123"

# Limit total results across all pages
yt articles list --max-results 200

# Legacy support still works
yt projects list --top 25
```

## Performance Impact

- **Reduced memory usage** for large datasets through controlled page sizes
- **Configurable limits** prevent overwhelming API calls
- **Efficient cursor-based pagination** for issues API
- **Smart batching** with automatic pagination type detection

## Migration Notes

- **No breaking changes** - all existing commands continue to work
- **`--top` parameter** is now legacy but fully supported
- **New pagination options** are opt-in and don't affect existing workflows
- **Default behavior unchanged** unless new pagination flags are used

Fixes #388

🤖 Generated with [Claude Code](https://claude.ai/code)