### PR TITLE
🐛 Fix missing 'count' field in issues list command output (Fixes #404)

### DIFF
--- a/youtrack_cli/managers/issues.py
+++ b/youtrack_cli/managers/issues.py
@@ -173,6 +173,12 @@ class IssueManager:
             skip=skip,
         )
 
+        # Add count field for backward compatibility with command layer
+        if result["status"] == "success" and "data" in result:
+            issues = result["data"]
+            if isinstance(issues, list):
+                result["count"] = len(issues)
+
         # Add presentation logic for different output formats
         if result["status"] == "success" and format_output != "json":
             issues = result["data"]


### PR DESCRIPTION
## Summary

Fixes the `KeyError: 'count'` error in `yt issues list --top 10` command that was introduced by the service layer refactoring.

## Problem
The `yt issues list --top 10` command was failing with:
```
❌ Error listing issues: 'count'
Error: Failed to list issues
```

This occurred because the service layer refactoring changed the response format from the manager methods, but the command layer still expected a 'count' field.

## Solution
- Added count field to the `search_issues` response in `IssueManager` for backward compatibility  
- The count is calculated as `len(result['data'])` after the service layer call
- This maintains backward compatibility with the command layer expectations

## Testing
- [x] Installed CLI in development mode
- [x] Authenticated with YouTrack
- [x] Tested `yt issues list --top 10` command successfully
- [x] Verified count is displayed correctly: "Total: 10 issues"
- [x] All core pre-commit checks passed (linting, type checking, tests)

## Files Changed
- `youtrack_cli/managers/issues.py` - Added count field calculation

Fixes #404

🤖 Generated with [Claude Code](https://claude.ai/code)