### PR TITLE
🐛 Fix attachment list rendering error (Fixes #413)

### DIFF
--- a/youtrack_cli/managers/issues.py
+++ b/youtrack_cli/managers/issues.py
@@ -623,7 +623,7 @@ class IssueManager:
             author = attachment.get("author", {}).get("fullName", "Unknown")
             created = attachment.get("created", "")
 
-            table.add_row(name, str(size), author, created)
+            table.add_row(name, str(size), author, str(created))
 
         self.console.print(table)
 


### PR DESCRIPTION
## Summary

Fixed the attachment list rendering error by converting the `created` field to a string before adding it to the Rich table. This resolves the error that occurred when trying to display attachment lists in the CLI.

## Changes Made
- Modified `youtrack_cli/managers/issues.py:626` to convert the `created` timestamp to string
- Ensures all table cell values are strings for proper Rich table rendering

## Testing
- [x] Tested the fix with `yt issues attach list FPU-1` command
- [x] Verified attachment list displays correctly without errors
- [x] All type checks and linting passed

## Root Cause
The `created` field was an integer timestamp that couldn't be rendered directly by Rich tables. Converting it to string resolves the rendering issue while maintaining the information display.

Fixes #413