### PR TITLE
🐛 Fix move command ' is required' error (Fixes #416)

### DIFF
--- a/youtrack_cli/managers/issues.py
+++ b/youtrack_cli/managers/issues.py
@@ -581,18 +581,7 @@ class IssueManager:
         self, issue_id: str, state: Optional[str] = None, project_id: Optional[str] = None
     ) -> Dict[str, Any]:
         """Move an issue to a different state or project."""
-        if not state and not project_id:
-            return {"status": "error", "message": "Either state or project_id must be provided"}
-
-        if state:
-            # Move to different state
-            return await self.update_issue(issue_id, state=state)
-        elif project_id:
-            # Move to different project - would need project service integration
-            return {"status": "error", "message": "Moving issues between projects not yet implemented"}
-
-        # This should never be reached, but adding for type safety
-        return {"status": "error", "message": "Invalid parameters"}
+        return await self.issue_service.move_issue(issue_id, state=state, project_id=project_id)
 
     def display_comments_table(self, comments: List[Dict[str, Any]]) -> None:
         """Display comments in a table format."""


### PR DESCRIPTION
## Summary

Resolved issue where the `yt issues move` command failed with "$type is required" error by implementing proper YouTrack API type annotations and intelligent state field detection.

## Changes Made

### Enhanced move_issue method in services layer
- ✅ **Automatic state field detection** - Works across different projects (State, Stage, Status, Kanban State)
- ✅ **Proper API structure** - Added required $type fields for YouTrack compliance
- ✅ **Intelligent state mapping** - Maps state names to IDs with correct entity types
- ✅ **Enhanced error handling** - Better field prioritization and validation

### Key Technical Fixes
- **Root payload**: Added `"$type": "Issue"` to main request
- **Custom fields**: Added `"$type": "SingleEnumIssueCustomField"` for field definitions  
- **State values**: Added `"$type": "StateBundleElement"` for state enum values (vs EnumBundleElement)
- **Field detection**: Auto-detects correct state field name per project configuration
- **Value mapping**: Properly maps state names to IDs to avoid YouTrack lookup errors

### API Compliance Improvements
- ✅ Follows YouTrack's entity type system requirements
- ✅ Uses StateBundleElement for stage fields vs EnumBundleElement for other fields
- ✅ Includes both name and ID for state values to prevent "{1}" placeholder errors
- ✅ Prioritizes common state field names (State > Stage > Status > Kanban State)

## Testing Results

✅ **Successfully tested state transitions** with FPU project  
✅ **Move command now works**: `yt issues move ISSUE-ID --state STATE_NAME`  
✅ **Proper error handling** for YouTrack workflow validation rules  
✅ **Auto-detection works** across different project configurations  
✅ **No more "$type is required" errors** - the original issue is resolved  

### Test Commands Used
```bash
# Example usage that now works:
yt issues move FPU-26 --state "Test"     # ✅ Successfully moved from Backlog to Test
yt issues move FPU-26 --state "Staging"  # ❌ Correctly blocked by workflow rules (expected)
```

## Impact

- **Users can now successfully move issues between states** using the CLI
- **API requests include proper $type fields** as required by YouTrack
- **Enhanced error messages** for workflow validation
- **Better project compatibility** with automatic field detection

## Files Modified

- `youtrack_cli/services/issues.py` - Enhanced move_issue method with proper API structure
- `youtrack_cli/managers/issues.py` - Updated to use service layer directly  
- `scratch/issue-416.md` - Added comprehensive implementation documentation

## Related Issues

Fixes #416

🤖 Generated with [Claude Code](https://claude.ai/code)