### PR TITLE
🐛 Fix KeyError in update command error handling (Fixes #417)

### DIFF
--- a/youtrack_cli/commands/issues.py
+++ b/youtrack_cli/commands/issues.py
@@ -654,9 +654,11 @@ def update(
             )
 
             if result["status"] == "success":
-                console.print(f"✅ {result['message']}", style="green")
+                message = result.get("message", "Issue updated successfully")
+                console.print(f"✅ {message}", style="green")
             else:
-                console.print(f"❌ {result['message']}", style="red")
+                message = result.get("message", "Failed to update issue")
+                console.print(f"❌ {message}", style="red")
                 raise click.ClickException("Failed to update issue")
 
         except Exception as e:


### PR DESCRIPTION
## Summary

Fixes a KeyError that occurs when the `yt issues update` command fails with an API error that doesn't include a 'message' key in the response dictionary.

## Changes Made

- Updated error handling in the `update` command to use safe dictionary access with `.get()` method
- Added fallback messages for both success and error cases:
  - Success: "Issue updated successfully" (when no message provided)
  - Error: "Failed to update issue" (when no message provided)
- Prevents KeyError exceptions that were masking the actual API errors

## Root Cause

The issue occurred when the YouTrack API returned error responses with different structures than expected. The command was trying to access `result['message']` directly, which caused a KeyError when the 'message' key didn't exist in the response dictionary.

## Testing

- ✅ Tested successful update operations - still work correctly
- ✅ Tested failed update operations - now show proper error handling without KeyError
- ✅ All pre-commit checks pass
- ✅ All tests pass with 57.39% coverage

## Impact

- Users will no longer see confusing KeyError messages when update commands fail
- Actual API error messages are now properly displayed when available
- Improved error handling robustness across the update workflow

Fixes #417

🤖 Generated with [Claude Code](https://claude.ai/code)