### PR TITLE
🔧 Fix state field handling across projects (Fixes #425)

### DIFF
--- a/tests/services/test_issues.py
+++ b/tests/services/test_issues.py
@@ -77,9 +77,19 @@ class TestIssueServiceCreation:
                 "project": {"id": "project-1"},
                 "summary": "Test Summary",
                 "description": "Test Description",
-                "type": {"name": "Bug"},
-                "priority": {"name": "High"},
                 "assignee": {"login": "user123"},
+                "customFields": [
+                    {
+                        "$type": "SingleEnumIssueCustomField",
+                        "name": "Priority",
+                        "value": {"$type": "EnumBundleElement", "name": "High"},
+                    },
+                    {
+                        "$type": "SingleEnumIssueCustomField",
+                        "name": "Type",
+                        "value": {"$type": "EnumBundleElement", "name": "Bug"},
+                    },
+                ],
             }
 
             mock_request.assert_called_once_with("POST", "issues", json_data=expected_data)
@@ -222,9 +232,13 @@ class TestIssueServiceUpdate:
         with (
             patch.object(issue_service, "_make_request", new_callable=AsyncMock) as mock_request,
             patch.object(issue_service, "_handle_response", new_callable=AsyncMock) as mock_handle,
+            patch.object(issue_service, "_get_project_id_from_issue", new_callable=AsyncMock) as mock_get_project,
+            patch.object(issue_service, "_discover_state_field_for_project", new_callable=AsyncMock) as mock_discover,
         ):
             mock_request.return_value = mock_response
             mock_handle.return_value = {"status": "success"}
+            mock_get_project.return_value = "TEST"
+            mock_discover.return_value = {"field_name": "State", "bundle_type": "EnumBundleElement"}
 
             await issue_service.update_issue("TEST-1", summary="Updated Summary", state="In Progress", priority="High")
 

--- a/youtrack_cli/services/field_cache.py
+++ b/youtrack_cli/services/field_cache.py
@@ -1,0 +1,99 @@
+"""Simple caching mechanism for project field metadata."""
+
+import time
+from typing import Any, Dict, Optional
+
+
+class FieldCache:
+    """Simple in-memory cache for project field metadata.
+
+    Caches field discovery results to avoid repeated API calls.
+    Cache entries expire after a configurable TTL (time-to-live).
+    """
+
+    def __init__(self, ttl_seconds: int = 300):  # 5 minutes default
+        """Initialize the cache.
+
+        Args:
+            ttl_seconds: Time-to-live for cache entries in seconds
+        """
+        self._cache: Dict[str, Dict[str, Any]] = {}
+        self._ttl = ttl_seconds
+
+    def _get_cache_key(self, project_id: str, field_type: str = "state") -> str:
+        """Generate cache key for project field metadata."""
+        return f"{project_id}:{field_type}"
+
+    def _is_expired(self, entry: Dict[str, Any]) -> bool:
+        """Check if cache entry has expired."""
+        if "timestamp" not in entry:
+            return True
+        return time.time() - entry["timestamp"] > self._ttl
+
+    def get(self, project_id: str, field_type: str = "state") -> Optional[Dict[str, Any]]:
+        """Get cached field metadata for a project.
+
+        Args:
+            project_id: Project ID
+            field_type: Type of field to get (default: "state")
+
+        Returns:
+            Cached field metadata or None if not found/expired
+        """
+        cache_key = self._get_cache_key(project_id, field_type)
+
+        if cache_key not in self._cache:
+            return None
+
+        entry = self._cache[cache_key]
+        if self._is_expired(entry):
+            del self._cache[cache_key]
+            return None
+
+        return entry.get("data")
+
+    def set(self, project_id: str, field_data: Dict[str, Any], field_type: str = "state") -> None:
+        """Cache field metadata for a project.
+
+        Args:
+            project_id: Project ID
+            field_data: Field metadata to cache
+            field_type: Type of field being cached (default: "state")
+        """
+        cache_key = self._get_cache_key(project_id, field_type)
+        self._cache[cache_key] = {"data": field_data, "timestamp": time.time()}
+
+    def clear(self, project_id: Optional[str] = None) -> None:
+        """Clear cache entries.
+
+        Args:
+            project_id: If provided, clear only entries for this project.
+                       If None, clear all entries.
+        """
+        if project_id is None:
+            self._cache.clear()
+        else:
+            # Clear all entries for the specified project
+            keys_to_remove = [key for key in self._cache.keys() if key.startswith(f"{project_id}:")]
+            for key in keys_to_remove:
+                del self._cache[key]
+
+    def get_cache_stats(self) -> Dict[str, int]:
+        """Get cache statistics for debugging."""
+        total_entries = len(self._cache)
+        expired_entries = sum(1 for entry in self._cache.values() if self._is_expired(entry))
+
+        return {
+            "total_entries": total_entries,
+            "active_entries": total_entries - expired_entries,
+            "expired_entries": expired_entries,
+        }
+
+
+# Global cache instance to be shared across services
+_field_cache = FieldCache()
+
+
+def get_field_cache() -> FieldCache:
+    """Get the global field cache instance."""
+    return _field_cache


### PR DESCRIPTION
## Summary

Fixes #425: `yt issues update --state` command now works correctly across different YouTrack projects with varying field configurations.

### Key Changes

- **Dynamic State Field Discovery**: Automatically detects the correct state field name for each project (e.g., "State", "Kanban State", "Status", "Stage")
- **Field Metadata Caching**: Implements TTL-based caching (5 minutes) to avoid repeated API calls for field discovery
- **Bundle Type Detection**: Correctly identifies whether to use `EnumBundleElement` or `StateBundleElement` based on field configuration
- **Enhanced Error Messages**: Provides clear, actionable error messages showing available fields when operations fail

### Files Modified

- `youtrack_cli/services/projects.py`: Added `discover_state_field()` and `get_custom_field_details()` methods
- `youtrack_cli/services/field_cache.py` (NEW): Simple in-memory caching system for field metadata
- `youtrack_cli/services/issues.py`: Updated `update_issue()` to use dynamic field discovery with fallback error handling
- `tests/services/test_issues.py`: Updated tests to mock new field discovery methods

### Testing

✅ Successfully tested with:
- **FPU Project**: Updates "Kanban State" field (uses `StateBundleElement`)
- **DEMO Project**: Updates "State" field (uses `EnumBundleElement`)

Both projects now work correctly with the same `yt issues update --state` command.

### Error Handling Improvements

- Shows available custom fields when field discovery fails
- Detects field type mismatches and provides specific guidance
- Falls back gracefully when API limitations prevent full validation

🤖 Generated with [Claude Code](https://claude.ai/code)