### PR TITLE
🐛 Fix projects list command 'count' error (Fixes #426)

### DIFF
--- a/youtrack_cli/managers/projects.py
+++ b/youtrack_cli/managers/projects.py
@@ -116,12 +116,18 @@ class ProjectManager:
             return result
         else:
             # Legacy single request approach
-            return await self.project_service.list_projects(
+            result = await self.project_service.list_projects(
                 fields=fields,
                 top=top,
                 skip=0,
                 show_archived=show_archived,
             )
+
+            # Ensure count field is always present
+            if result["status"] == "success" and isinstance(result["data"], list):
+                result["count"] = len(result["data"])
+
+            return result
 
     async def get_project(self, project_id: str, fields: Optional[str] = None) -> Dict[str, Any]:
         """Get a specific project with enhanced error handling.


### PR DESCRIPTION
## Summary

This PR fixes a bug where the `yt projects list` command successfully displays project data but then fails with a 'count' error, preventing successful completion of the command.

## Problem

The issue occurred in the `ProjectManager.list_projects()` method:
- When pagination is enabled, the method returns a result that includes a `count` field
- When pagination is disabled (default case), it returns the raw service result without a `count` field
- The command always tries to access `result['count']` causing a KeyError

## Solution

Modified the `list_projects` method in `ProjectManager` to ensure the `count` field is always present:
- Added count calculation logic for non-paginated results
- Maintains backward compatibility with existing pagination logic
- Ensures consistent result structure regardless of pagination mode

## Changes Made

- **File:** `youtrack_cli/managers/projects.py`
- **Lines:** 119-130
- Added count field calculation when pagination is not used
- Result now consistently includes `count` field for successful operations

## Testing

- ✅ Manual testing: `yt projects list` runs successfully without errors
- ✅ Projects table displays correctly with total count shown
- ✅ All pre-commit hooks pass (linting, formatting, type checking)
- ✅ All unit and integration tests pass
- ✅ Package builds successfully
- ✅ Documentation builds without errors

## Before/After

**Before:** Command displayed projects but crashed with `'count'` KeyError  
**After:** Command displays projects and total count successfully

## Impact

- **Risk:** Low - minimal change that only adds missing field
- **Scope:** Single method modification
- **Compatibility:** Fully backward compatible

Fixes #426