### PR TITLE
🐛 Fix admin maintenance clear-cache command returning 404 error (Fixes #431)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🐛 Fix issue create command project ID structure error (#419)
 - 🐛 Fix move command "$type is required" error (#416, #420)
 - 🐛 Fix KeyError in update command error handling (#421)
+- 🐛 Fix admin maintenance clear-cache command returning 404 error (#431)
+  - Updated clear_caches method to return informative error message explaining cache clearing is not available through YouTrack REST API
+  - Updated documentation to clarify cache management must be done through YouTrack UI or server-side tools
+  - Fixed tests to expect the correct error response
 
 ### Improved
 - 🧪 Reduce excessive test coverage and eliminate redundant tests (#423)

--- a/docs/commands/admin.rst
+++ b/docs/commands/admin.rst
@@ -138,7 +138,15 @@ System Maintenance
 maintenance clear-cache
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Clear system caches to improve performance or resolve issues.
+.. note::
+   This command is not functional as cache clearing is not available through the YouTrack REST API.
+   Cache management must be performed through:
+
+   * The YouTrack administrative UI
+   * Server restart procedures
+   * Direct server access
+
+   Please consult your YouTrack administrator or the JetBrains support team for alternative methods.
 
 .. code-block:: bash
 
@@ -153,7 +161,7 @@ Clear system caches to improve performance or resolve issues.
    * - Option
      - Type
      - Description
-   * - ``--confirm``
+   * - ``--force``
      - flag
      - Skip confirmation prompt
 
@@ -161,14 +169,11 @@ Clear system caches to improve performance or resolve issues.
 
 .. code-block:: bash
 
-   # Clear caches with confirmation prompt
+   # Attempting to clear caches will show an informative error message
    yt admin maintenance clear-cache
 
-   # Clear caches without confirmation
-   yt admin maintenance clear-cache --confirm
-
-   # Use in automated maintenance scripts
-   yt admin maintenance clear-cache --confirm
+   # The command will explain that this functionality is not available
+   yt admin maintenance clear-cache --force
 
 System Health Monitoring
 ------------------------
@@ -344,7 +349,7 @@ System Maintenance
 ~~~~~~~~~~~~~~~~~
 
 **Cache Management**
-  Clear system caches to resolve performance issues and ensure data consistency.
+  Note: Cache clearing is not available through the REST API. Use the YouTrack administrative UI or server-side tools for cache management.
 
 **Health Monitoring**
   Comprehensive system health checks and diagnostics.
@@ -410,9 +415,9 @@ Regular Maintenance
    # Weekly maintenance routine
    echo "=== Weekly YouTrack Maintenance ==="
 
-   # Clear caches for performance
-   echo "Clearing system caches..."
-   yt admin maintenance clear-cache --confirm
+   # Note: Cache clearing is not available through the REST API
+   echo "Cache clearing must be done through the YouTrack UI or server tools"
+   # yt admin maintenance clear-cache --force  # This will show an informative error
 
    # Health check after maintenance
    echo "Post-maintenance health check..."
@@ -543,8 +548,8 @@ Common Issues and Solutions
 **Setting Not Found**
   Check setting key spelling and availability in your YouTrack version.
 
-**Cache Clear Failures**
-  Ensure system has sufficient resources and no active maintenance operations.
+**Cache Clear Not Available**
+  The clear-cache command returns an error explaining that cache clearing is not available through the YouTrack REST API. Use the administrative UI or server-side tools instead.
 
 **Group Creation Failures**
   Check for naming conflicts and permission requirements.
@@ -596,9 +601,9 @@ Error Recovery
    # Error recovery procedures
    echo "=== Administrative Error Recovery ==="
 
-   # Clear caches if system is unresponsive
-   echo "Clearing system caches..."
-   yt admin maintenance clear-cache --confirm
+   # Note: Cache clearing is not available through the REST API
+   echo "Cache management must be done through YouTrack UI or server tools"
+   # Manual intervention required for cache clearing
 
    # Verify system health after recovery
    echo "Verifying system health..."
@@ -669,9 +674,9 @@ Automation Scripts
 
    log "Starting automated maintenance"
 
-   # Clear caches
-   log "Clearing system caches"
-   yt admin maintenance clear-cache --confirm
+   # Note: Cache clearing is not available through the REST API
+   log "Cache clearing must be done through YouTrack UI or server tools"
+   # Manual cache management required
 
    # Health check
    log "Running health check"

--- a/youtrack_cli/admin.py
+++ b/youtrack_cli/admin.py
@@ -473,42 +473,17 @@ class AdminManager:
         Returns:
             Dictionary with operation result
         """
-        credentials = self.auth_manager.load_credentials()
-        if not credentials:
-            return {
-                "status": "error",
-                "message": "Not authenticated. Run 'yt auth login' first.",
-            }
-
-        headers = {
-            "Authorization": f"Bearer {credentials.token}",
-            "Accept": "application/json",
+        return {
+            "status": "error",
+            "message": (
+                "Cache clearing is not available through the YouTrack REST API.\n"
+                "This functionality may be available through:\n"
+                "- The YouTrack administrative UI\n"
+                "- Server restart procedures\n"
+                "- Direct server access\n\n"
+                "Please consult your YouTrack administrator or the JetBrains support team for alternative methods."
+            ),
         }
-
-        client_manager = get_client_manager()
-        try:
-            await client_manager.make_request(
-                "POST",
-                f"{credentials.base_url.rstrip('/')}/api/admin/maintenance/clearCache",
-                headers=headers,
-                timeout=30.0,
-            )
-
-            return {
-                "status": "success",
-                "message": "System caches cleared successfully",
-            }
-
-        except httpx.HTTPError as e:
-            if hasattr(e, "response") and e.response is not None:
-                if e.response.status_code == 403:
-                    return {
-                        "status": "error",
-                        "message": "Insufficient permissions for maintenance.",
-                    }
-            return {"status": "error", "message": f"HTTP error: {e}"}
-        except Exception as e:
-            return {"status": "error", "message": f"Unexpected error: {e}"}
 
     # User Groups Management
     async def list_user_groups(self, fields: Optional[str] = None) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

This PR fixes the `yt admin maintenance clear-cache` command which was returning a 404 error because the YouTrack REST API does not provide an endpoint for clearing system caches.

## Changes Made

- Updated the `clear_caches()` method in `admin.py` to return an informative error message explaining that cache clearing is not available through the YouTrack REST API
- Updated tests to expect the correct error response
- Updated documentation to clarify that cache management must be done through alternative methods
- Added CHANGELOG entry documenting the fix

## Testing

- [x] Unit tests updated and passing
- [x] Integration tests passing
- [x] Manual testing shows informative error message
- [x] Pre-commit hooks passing
- [x] Documentation updated

## Documentation

Updated the admin command documentation to explain that cache clearing functionality is not available through the REST API and must be performed through:
- The YouTrack administrative UI
- Server restart procedures
- Direct server access

Fixes #431