### PR TITLE
🐛 Fix admin i18n get command showing N/A values and add rich table formatting (Fixes #432)

### DIFF
--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -461,7 +461,18 @@ class TestAdminLocaleManager:
     async def test_locale_operations(self, admin_manager, auth_manager):
         """Test locale settings operations."""
         # Test successful locale settings retrieval
-        mock_locale_settings = {"locale": {"name": "English", "id": "en_US"}, "isRTL": False}
+        mock_locale_settings = {
+            "locale": {
+                "name": "English",
+                "id": "en_US",
+                "language": "en",
+                "locale": "en_US",
+                "community": False,
+                "$type": "LocaleDescriptor",
+            },
+            "isRTL": False,
+            "$type": "LocaleSettings",
+        }
 
         with patch("youtrack_cli.admin.get_client_manager") as mock_get_client:
             mock_client_manager = Mock()
@@ -473,6 +484,11 @@ class TestAdminLocaleManager:
             result = await admin_manager.get_locale_settings()
             assert result["status"] == "success"
             assert result["data"] == mock_locale_settings
+
+            # Verify the API call was made with the correct fields parameter
+            mock_client_manager.make_request.assert_called_once()
+            call_args = mock_client_manager.make_request.call_args
+            assert call_args[1]["params"]["fields"] == "locale(id,name,language,locale,community),isRTL"
 
         # Test locale settings update
         with patch("youtrack_cli.admin.get_client_manager") as mock_get_client:

--- a/youtrack_cli/admin.py
+++ b/youtrack_cli/admin.py
@@ -674,6 +674,7 @@ class AdminManager:
                 "GET",
                 f"{credentials.base_url.rstrip('/')}/api/admin/globalSettings/localeSettings",
                 headers=headers,
+                params={"fields": "locale(id,name,language,locale,community),isRTL"},
                 timeout=10.0,
             )
 
@@ -1069,26 +1070,33 @@ class AdminManager:
         Args:
             locale_settings: Locale settings dictionary
         """
-        self.console.print("\n[bold blue]Locale Settings[/bold blue]")
+        table = Table(title="Locale Settings")
+        table.add_column("Setting", style="cyan", no_wrap=True)
+        table.add_column("Value", style="green")
 
         locale = locale_settings.get("locale", {})
         is_rtl = locale_settings.get("isRTL", False)
 
-        self.console.print(f"[cyan]Language:[/cyan] {locale.get('name', 'N/A')}")
-        self.console.print(f"[cyan]Locale ID:[/cyan] {locale.get('id', 'N/A')}")
-        self.console.print(f"[cyan]Language Code:[/cyan] {locale.get('language', 'N/A')}")
-        self.console.print(f"[cyan]Full Locale:[/cyan] {locale.get('locale', 'N/A')}")
+        # Add locale information rows
+        table.add_row("Language", locale.get("name", "N/A"))
+        table.add_row("Locale ID", locale.get("id", "N/A"))
+        table.add_row("Language Code", locale.get("language", "N/A"))
+        table.add_row("Full Locale", locale.get("locale", "N/A"))
 
-        # Display community status
+        # Display community status with color
         is_community = locale.get("community", False)
         community_text = "Yes" if is_community else "No"
         community_color = "yellow" if is_community else "green"
-        self.console.print(f"[cyan]Community Language:[/cyan] [{community_color}]{community_text}[/{community_color}]")
+        community_styled = Text(community_text, style=community_color)
+        table.add_row("Community Language", community_styled)
 
-        # Display RTL status
+        # Display RTL status with color
         rtl_text = "Yes" if is_rtl else "No"
         rtl_color = "blue" if is_rtl else "green"
-        self.console.print(f"[cyan]Right-to-Left:[/cyan] [{rtl_color}]{rtl_text}[/{rtl_color}]")
+        rtl_styled = Text(rtl_text, style=rtl_color)
+        table.add_row("Right-to-Left", rtl_styled)
+
+        self.console.print(table)
 
     def display_available_locales(self, locales: list[dict[str, Any]], message: Optional[str] = None) -> None:
         """Display available locales in a formatted table.


### PR DESCRIPTION
## Summary

Fixed the `yt admin i18n get` command to display actual locale values instead of "N/A" and converted the output to use rich table formatting for better readability and consistency with other CLI commands.

## Changes Made

- **API Fix**: Added `fields` parameter to `get_locale_settings()` API call: `locale(id,name,language,locale,community),isRTL`
- **Display Enhancement**: Replaced `display_locale_settings()` console prints with Rich Table implementation
- **Test Updates**: Enhanced test with proper mock data structure and API call verification
- Both `yt admin i18n get` and `yt admin locale get` commands now work correctly

## Before
```
Locale Settings
Language: N/A
Locale ID: N/A
Language Code: N/A
Full Locale: N/A
Community Language: No
Right-to-Left: No
```

## After
```
        Locale Settings         
┏━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
┃ Setting            ┃ Value   ┃
┡━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
│ Language           │ English │
│ Locale ID          │ en_US   │
│ Language Code      │ en      │
│ Full Locale        │ en_US   │
│ Community Language │ No      │
│ Right-to-Left      │ No      │
└────────────────────┴─────────┘
```

## Testing

- [x] Unit tests updated and passing
- [x] Integration tests verified with local YouTrack instance
- [x] Both `yt admin i18n get` and `yt admin locale get` tested
- [x] Pre-commit hooks passing
- [x] Manual testing completed

## Root Cause

The original API call to `/api/admin/globalSettings/localeSettings` was missing the `fields` parameter, resulting in a minimal response that only contained metadata (`{'id': '121-0', '$type': 'LocaleSettings'}`). By adding the proper fields parameter, the API now returns the complete locale data structure.

Fixes #432

🤖 Generated with [Claude Code](https://claude.ai/code)