### PR TITLE
🐛 Fix projects create command response handling bug (Fixes #441)

### DIFF
--- a/youtrack_cli/commands/projects.py
+++ b/youtrack_cli/commands/projects.py
@@ -355,12 +355,14 @@ def projects_create(
         )
 
         if result["status"] == "success":
-            console.print(f"✅ {result['message']}", style="green")
             project = result["data"]
+            project_name = project.get("name", name)
+            console.print(f"✅ Project '{project_name}' created successfully", style="green")
             console.print(f"Project ID: {project.get('id', 'N/A')}", style="blue")
             console.print(f"Short Name: {project.get('shortName', 'N/A')}", style="blue")
         else:
-            console.print(f"❌ {result['message']}", style="red")
+            error_message = result.get("message", "Unknown error occurred")
+            console.print(f"❌ {error_message}", style="red")
             raise click.ClickException("Failed to create project")
 
     except Exception as e:


### PR DESCRIPTION
## Summary

Fixed a bug in the `yt projects create` command where successful project creation responses were causing a KeyError when trying to access the 'message' field.

## Root Cause Analysis

The issue described in #441 was not actually with user lookup logic (which was working correctly), but with response handling after successful project creation. The service layer returns `{status: "success", data: ...}` without a message field, but the command was trying to access `result['message']` for successful responses.

## Changes Made

- **Fixed response handling**: Updated the project creation success case to generate an appropriate success message instead of trying to access a non-existent 'message' field
- **Improved error handling**: Made error message access safe using `.get()` method
- **Preserved existing functionality**: User lookup and validation continues to work correctly for both usernames and user IDs

## Testing

- [x] Manual testing with valid usernames (e.g., 'admin')
- [x] Manual testing with invalid usernames (proper error handling)
- [x] Unit and integration tests passing
- [x] Pre-commit checks passed
- [x] Project creation now works correctly without errors

## User Impact

Users can now successfully create projects using the CLI without encountering the "'message'" KeyError. The command works with both usernames and user IDs as expected.

## Example Usage

```bash
# Works correctly now
yt projects create "My Project" MP --leader admin --description "Project description"
```

Fixes #441

🤖 Generated with [Claude Code](https://claude.ai/code)