### PR TITLE
🐛 Fix issues update command state field type mismatch (Fixes #442)

### DIFF
--- a/youtrack_cli/services/issues.py
+++ b/youtrack_cli/services/issues.py
@@ -191,11 +191,12 @@ class IssueService(BaseService):
 
                 # Use fallback only if field discovery didn't work
                 if not state_field_added:
+                    # Use StateBundleElement for state-type fields (consistent with move_issue logic)
                     custom_fields.append(
                         {
                             "$type": "SingleEnumIssueCustomField",
                             "name": "State",
-                            "value": {"$type": "EnumBundleElement", "name": state},
+                            "value": {"$type": "StateBundleElement", "name": state},
                         }
                     )
 


### PR DESCRIPTION
## Summary

Fixes a type mismatch error when updating issue state fields via the `yt issues update` command. The API was expecting `StateBundleElement` type but receiving `EnumBundleElement` type instead.

## Changes Made

- Fixed fallback logic in `youtrack_cli/services/issues.py` line 199 to use `StateBundleElement` instead of `EnumBundleElement` for state field updates
- This change aligns the `update_issue` method with the working `move_issue` method which already uses the correct type
- Added clarifying comment about the fix and consistency with `move_issue` logic

## Root Cause

The error occurred in the fallback logic when dynamic state field discovery failed. The code was using `EnumBundleElement` as the field type, but YouTrack's API expects `StateBundleElement` for state-type fields.

## Testing

- **Manual Testing**: ✅ Verified fix works with DEMO project issues
- **CLI Testing Agent**: ✅ Comprehensive testing completed - all modified CLI commands work correctly
- **State Updates**: ✅ Successfully tested state changes: "Open" ↔ "In Progress" ↔ "Submitted"
- **Combined Updates**: ✅ Tested simultaneous state + summary + priority updates
- **Error Handling**: ✅ Invalid state values return appropriate error messages
- **Cross-Project**: ✅ Verified works with different projects (DEMO, FPU) and their respective state fields

## Pre-commit Validation

- [x] All pre-commit checks passed
- [x] Test coverage: 63.44% (above required 50%)
- [x] Linting and formatting passed
- [x] Type checking passed
- [x] Security checks passed
- [x] Documentation builds successfully

## Related Issues

This fix resolves the core issue described in #442 where users encountered:
```
The API expects StateBundleElement-type values but encountered EnumBundleElementMegaProxy-type instead
```

## Breaking Changes

None - this is a bug fix that maintains backward compatibility.

Fixes #442

🤖 Generated with [Claude Code](https://claude.ai/code)