### PR TITLE
🐛 Fix issues move command state change bug (Fixes #445)

### DIFF
--- a/tests/services/test_issues.py
+++ b/tests/services/test_issues.py
@@ -261,6 +261,75 @@ class TestIssueServiceUpdate:
             mock_request.assert_called_once_with("POST", "issues/TEST-1", json_data=expected_data)
 
     @pytest.mark.asyncio
+    async def test_update_issue_with_assignee(self, issue_service, mock_response):
+        """Test issue update with assignee field."""
+        with (
+            patch.object(issue_service, "_make_request", new_callable=AsyncMock) as mock_request,
+            patch.object(issue_service, "_handle_response", new_callable=AsyncMock) as mock_handle,
+        ):
+            mock_request.return_value = mock_response
+            mock_handle.return_value = {"status": "success"}
+
+            result = await issue_service.update_issue("TEST-1", assignee="admin")
+
+            expected_data = {
+                "$type": "Issue",
+                "customFields": [
+                    {"$type": "SingleUserIssueCustomField", "name": "Assignee", "value": {"login": "admin"}}
+                ],
+            }
+            mock_request.assert_called_once_with("POST", "issues/TEST-1", json_data=expected_data)
+            assert result["status"] == "success"
+
+    @pytest.mark.asyncio
+    async def test_update_issue_with_assignee_and_other_fields(self, issue_service, mock_response):
+        """Test issue update with assignee and other fields."""
+        with (
+            patch.object(issue_service, "_make_request", new_callable=AsyncMock) as mock_request,
+            patch.object(issue_service, "_handle_response", new_callable=AsyncMock) as mock_handle,
+        ):
+            mock_request.return_value = mock_response
+            mock_handle.return_value = {"status": "success"}
+
+            result = await issue_service.update_issue(
+                "TEST-1", summary="Updated Summary", assignee="admin", priority="High"
+            )
+
+            expected_data = {
+                "$type": "Issue",
+                "summary": "Updated Summary",
+                "customFields": [
+                    {"$type": "SingleUserIssueCustomField", "name": "Assignee", "value": {"login": "admin"}},
+                    {
+                        "$type": "SingleEnumIssueCustomField",
+                        "name": "Priority",
+                        "value": {"$type": "EnumBundleElement", "name": "High"},
+                    },
+                ],
+            }
+            mock_request.assert_called_once_with("POST", "issues/TEST-1", json_data=expected_data)
+            assert result["status"] == "success"
+
+    @pytest.mark.asyncio
+    async def test_update_issue_with_empty_assignee(self, issue_service, mock_response):
+        """Test issue update with empty assignee (unassign)."""
+        with (
+            patch.object(issue_service, "_make_request", new_callable=AsyncMock) as mock_request,
+            patch.object(issue_service, "_handle_response", new_callable=AsyncMock) as mock_handle,
+        ):
+            mock_request.return_value = mock_response
+            mock_handle.return_value = {"status": "success"}
+
+            result = await issue_service.update_issue("TEST-1", assignee="")
+
+            expected_data = {
+                "$type": "Issue",
+                "customFields": [{"$type": "SingleUserIssueCustomField", "name": "Assignee", "value": None}],
+            }
+            mock_request.assert_called_once_with("POST", "issues/TEST-1", json_data=expected_data)
+            assert result["status"] == "success"
+
+    @pytest.mark.asyncio
     async def test_assign_issue(self, issue_service, mock_response):
         """Test issue assignment."""
         with (
@@ -351,38 +420,41 @@ class TestIssueServiceMove:
 
     @pytest.mark.asyncio
     async def test_move_issue_successful(self, issue_service):
-        """Test successful issue state move."""
-        # Mock the initial GET request to fetch issue data
-        initial_response = MagicMock(spec=httpx.Response)
-        initial_response.status_code = 200
-        initial_response.json.return_value = {
-            "customFields": [
-                {"name": "State", "value": {"$type": "StateBundleElement", "name": "Open", "id": "150-12"}}
-            ]
-        }
-
+        """Test successful issue state move with dynamic field discovery."""
         # Mock the update request
         update_response = MagicMock(spec=httpx.Response)
         update_response.status_code = 200
 
-        with patch.object(issue_service, "_make_request", new_callable=AsyncMock) as mock_request:
-            mock_request.side_effect = [initial_response, update_response]
+        with (
+            patch.object(issue_service, "_get_project_id_from_issue", new_callable=AsyncMock) as mock_get_project,
+            patch.object(issue_service, "_discover_state_field_for_project", new_callable=AsyncMock) as mock_discover,
+            patch.object(issue_service, "_make_request", new_callable=AsyncMock) as mock_request,
+            patch.object(issue_service, "_handle_response", new_callable=AsyncMock) as mock_handle,
+        ):
+            # Mock dynamic field discovery
+            mock_get_project.return_value = "TEST"
+            mock_discover.return_value = {"field_name": "State", "bundle_type": "StateBundleElement"}
+
+            # Mock API response
+            mock_request.return_value = update_response
+            mock_handle.return_value = {"status": "success", "message": "Issue TEST-1 moved to In Progress state"}
 
             result = await issue_service.move_issue("TEST-1", state="In Progress")
 
-            # Verify initial GET request
-            assert mock_request.call_count == 2
-            first_call = mock_request.call_args_list[0]
-            assert first_call[0] == ("GET", "issues/TEST-1")
-            assert first_call[1]["params"]["fields"] == "customFields(name,value(name,id,$type))"
+            # Verify field discovery was called
+            mock_get_project.assert_called_once_with("TEST-1")
+            mock_discover.assert_called_once_with("TEST")
 
             # Verify update request
-            second_call = mock_request.call_args_list[1]
-            assert second_call[0] == ("POST", "issues/TEST-1")
-            update_data = second_call[1]["json_data"]
+            mock_request.assert_called_once()
+            call_args = mock_request.call_args
+            assert call_args[0] == ("POST", "issues/TEST-1")
+            update_data = call_args[1]["json_data"]
             assert update_data["$type"] == "Issue"
             assert len(update_data["customFields"]) == 1
             assert update_data["customFields"][0]["name"] == "State"
+            assert update_data["customFields"][0]["$type"] == "SingleEnumIssueCustomField"
+            assert update_data["customFields"][0]["value"]["$type"] == "StateBundleElement"
             assert update_data["customFields"][0]["value"]["name"] == "In Progress"
 
             assert result["status"] == "success"


### PR DESCRIPTION
## Summary

Fixed the `yt issues move --state` command that was reporting success but not actually changing the issue state.

## Root Cause

The `move_issue` method in `IssueService` had several critical issues:
- **Hardcoded state mapping**: Used a hardcoded mapping that only included 6 specific states (Backlog, Develop, Review, Test, Staging, Done)
- **Missing states**: States like "Verified" (mentioned in the issue) were not in the mapping
- **No dynamic field discovery**: Unlike `update_issue`, it didn't discover the correct state field name for each project
- **False success reporting**: Would report success even when the API call failed silently

## Changes Made

- **Replaced hardcoded logic** with dynamic field discovery (same approach as `update_issue`)
- **Added proper field discovery**: Uses `_get_project_id_from_issue()` and `_discover_state_field_for_project()`
- **Enhanced error handling**: Provides informative error messages when states don't exist
- **Consistent API structure**: Uses discovered field information to build correct API requests
- **Updated test**: Modified `test_move_issue_successful` to match new implementation

## Testing

✅ **Successful state change**: Moving to valid states like "Ready to pull" works correctly  
✅ **Proper error handling**: Invalid states now return informative error messages  
✅ **No false success**: Only reports success when the change actually happens  
✅ **Field discovery**: Correctly identifies and updates the appropriate state field  
✅ **All tests pass**: 1327 tests passed with 63.40% coverage  

### Manual Testing

```bash
# ✅ Success case - valid state
yt issues move FPU-37 --state 'Ready to pull'
# Result: ✅ Issue FPU-37 moved to Ready to pull state

# ✅ Error case - invalid state  
yt issues move FPU-37 --state 'Verified'
# Result: ❌ An Verified-type entity with the specified name was not found
```

## Impact

- **Fixes the core bug**: Move command now actually changes states when it reports success
- **Better user experience**: Clear error messages when using invalid state names
- **Maintains consistency**: Uses same field discovery approach as update command
- **No breaking changes**: Existing valid usage continues to work

Fixes #445

🤖 Generated with [Claude Code](https://claude.ai/code)