### PR TITLE
✨ Add comment IDs to issues comments list command (Fixes #450)

### DIFF
--- a/youtrack_cli/managers/issues.py
+++ b/youtrack_cli/managers/issues.py
@@ -745,19 +745,21 @@ class IssueManager:
         return await self.issue_service.move_issue(issue_id, state=state, project_id=project_id)
 
     def display_comments_table(self, comments: List[Dict[str, Any]]) -> None:
-        """Display comments in a table format."""
+        """Display comments in a table format with comment IDs for delete/update operations."""
         if not comments:
             self.console.print("[yellow]No comments found.[/yellow]")
             return
 
         from rich.table import Table
 
-        table = Table(title="Issue Comments")
+        table = Table(title="📋 Issue Comments")
+        table.add_column("ID", style="bright_black", no_wrap=True, width=10)
         table.add_column("Author", style="cyan", no_wrap=True)
         table.add_column("Date", style="blue")
         table.add_column("Comment", style="white")
 
         for comment in comments:
+            comment_id = comment.get("id", "N/A")
             author = comment.get("author", {}).get("fullName", "Unknown")
             created = comment.get("created", "")
             text = comment.get("text", "")
@@ -766,7 +768,7 @@ class IssueManager:
             if len(text) > 100:
                 text = text[:97] + "..."
 
-            table.add_row(author, str(created), text)
+            table.add_row(str(comment_id), author, str(created), text)
 
         self.console.print(table)
 


### PR DESCRIPTION
## Summary

This PR adds comment IDs to the `yt issues comments list` command output, addressing the issue where users couldn't discover comment IDs needed for delete/update operations.

## Changes Made

- Added ID column to the comments table display in `display_comments_table()` method
- Enhanced table title with emoji for better UX
- Extracts comment ID from API response and displays it in the first column
- Maintains backward compatibility with existing command behavior
- Updated method docstring to reflect the new purpose

## Before & After

**Before:**
```
Issue Comments
┏━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Author ┃ Date          ┃ Comment                     ┃
┡━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ admin  │ 1754171771333 │ Test comment for ID display │
└────────┴───────────────┴─────────────────────────────┘
```

**After:**
```
📋 Issue Comments
┏━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ ID         ┃ Author ┃ Date          ┃ Comment                     ┃
┡━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ 7-11       │ admin  │ 1754171771333 │ Test comment for ID display │
└────────────┴────────┴───────────────┴─────────────────────────────┘
```

## Testing

- ✅ All pre-commit hooks pass
- ✅ All tests pass (1327 passed, 74 skipped)
- ✅ CLI tested with real YouTrack instance 
- ✅ Verified comment IDs work with update/delete operations
- ✅ Tested with both empty and populated comment lists
- ✅ Confirmed JSON output includes comment IDs
- ✅ CLI tester agent validation passed all checks

## Example Workflow

Now users can effectively manage comments:

```bash
# List comments to see IDs
$ yt issues comments list FPU-1
📋 Issue Comments
┏━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ ID         ┃ Author ┃ Date          ┃ Comment                     ┃
┡━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ 7-11       │ admin  │ 1754171771333 │ Test comment for ID display │
└────────────┴────────┴───────────────┴─────────────────────────────┘

# Update comment using the visible ID
$ yt issues comments update FPU-1 7-11 "Updated comment text"
✅ Comment updated successfully

# Delete comment using the visible ID  
$ yt issues comments delete FPU-1 7-11
✅ Comment deleted successfully
```

## Related Issues

Fixes #450

## Documentation

- [x] Method docstring updated to reflect new functionality
- [x] No breaking changes to existing API
- [x] Maintains full backward compatibility

Fixes #450