### PR TITLE
🐛 Fix issues links subcommand group completely broken (Fixes #453)

### DIFF
--- a/tests/managers/test_issues.py
+++ b/tests/managers/test_issues.py
@@ -450,28 +450,37 @@ class TestIssueManagerLinks:
         assert result == expected_result
 
     @pytest.mark.asyncio
-    async def test_create_link_not_implemented(self, issue_manager):
-        """Test create link (not implemented)."""
+    async def test_create_link(self, issue_manager):
+        """Test create link calls service layer."""
+        expected_result = {"status": "success", "message": "Link created"}
+        issue_manager.issue_service.create_link = AsyncMock(return_value=expected_result)
+
         result = await issue_manager.create_link("TEST-123", "TEST-456", "relates to")
 
-        assert result["status"] == "error"
-        assert "not yet implemented" in result["message"]
+        assert result == expected_result
+        issue_manager.issue_service.create_link.assert_called_once_with("TEST-123", "TEST-456", "relates to")
 
     @pytest.mark.asyncio
-    async def test_delete_link_not_implemented(self, issue_manager):
-        """Test delete link (not implemented)."""
-        result = await issue_manager.delete_link("TEST-123", "link-1")
+    async def test_delete_link(self, issue_manager):
+        """Test delete link calls service layer."""
+        expected_result = {"status": "success", "message": "Link deleted"}
+        issue_manager.issue_service.delete_link = AsyncMock(return_value=expected_result)
 
-        assert result["status"] == "error"
-        assert "not yet implemented" in result["message"]
+        result = await issue_manager.delete_link("TEST-123", "TEST-456", "relates to")
+
+        assert result == expected_result
+        issue_manager.issue_service.delete_link.assert_called_once_with("TEST-123", "TEST-456", "relates to")
 
     @pytest.mark.asyncio
-    async def test_list_link_types_not_implemented(self, issue_manager):
-        """Test list link types (not implemented)."""
+    async def test_list_link_types(self, issue_manager):
+        """Test list link types calls service layer."""
+        expected_result = {"status": "success", "data": []}
+        issue_manager.issue_service.list_link_types = AsyncMock(return_value=expected_result)
+
         result = await issue_manager.list_link_types()
 
-        assert result["status"] == "error"
-        assert "not yet implemented" in result["message"]
+        assert result == expected_result
+        issue_manager.issue_service.list_link_types.assert_called_once()
 
 
 class TestIssueManagerUtilities:

--- a/youtrack_cli/commands/issues.py
+++ b/youtrack_cli/commands/issues.py
@@ -1503,14 +1503,15 @@ def list_links(
 
 @links.command(name="delete")
 @click.argument("source_issue_id")
-@click.argument("link_id")
+@click.argument("target_issue_id")
+@click.argument("link_type")
 @click.option(
     "--force",
     is_flag=True,
     help="Skip confirmation prompt",
 )
 @click.pass_context
-def delete_link(ctx: click.Context, source_issue_id: str, link_id: str, force: bool) -> None:
+def delete_link(ctx: click.Context, source_issue_id: str, target_issue_id: str, link_type: str, force: bool) -> None:
     """Remove a link between issues."""
     from ..managers.issues import IssueManager
 
@@ -1519,14 +1520,18 @@ def delete_link(ctx: click.Context, source_issue_id: str, link_id: str, force: b
     issue_manager = IssueManager(auth_manager)
 
     if not force:
-        if not click.confirm(f"Are you sure you want to delete link '{link_id}'?"):
+        if not click.confirm(
+            f"Are you sure you want to delete '{link_type}' link between '{source_issue_id}' and '{target_issue_id}'?"
+        ):
             console.print("Delete cancelled.", style="yellow")
             return
 
-    console.print(f"🔗 Deleting link '{link_id}'...", style="blue")
+    console.print(
+        f"🔗 Deleting '{link_type}' link between '{source_issue_id}' and '{target_issue_id}'...", style="blue"
+    )
 
     try:
-        result = asyncio.run(issue_manager.delete_link(source_issue_id, link_id))
+        result = asyncio.run(issue_manager.delete_link(source_issue_id, target_issue_id, link_type))
 
         if result["status"] == "success":
             console.print(f"✅ {result['message']}", style="green")

--- a/youtrack_cli/managers/issues.py
+++ b/youtrack_cli/managers/issues.py
@@ -805,18 +805,15 @@ class IssueManager:
 
     async def create_link(self, source_issue_id: str, target_issue_id: str, link_type: str) -> Dict[str, Any]:
         """Create a link between two issues."""
-        # This would need to be implemented in the service layer
-        return {"status": "error", "message": "Issue linking not yet implemented in service layer"}
+        return await self.issue_service.create_link(source_issue_id, target_issue_id, link_type)
 
-    async def delete_link(self, source_issue_id: str, link_id: str) -> Dict[str, Any]:
+    async def delete_link(self, source_issue_id: str, target_issue_id: str, link_type: str) -> Dict[str, Any]:
         """Delete a link between issues."""
-        # This would need to be implemented in the service layer
-        return {"status": "error", "message": "Issue link deletion not yet implemented in service layer"}
+        return await self.issue_service.delete_link(source_issue_id, target_issue_id, link_type)
 
     async def list_link_types(self) -> Dict[str, Any]:
         """List available link types."""
-        # This would need to be implemented in the service layer
-        return {"status": "error", "message": "Link types listing not yet implemented in service layer"}
+        return await self.issue_service.list_link_types()
 
     def display_link_types_table(self, link_types: List[Dict[str, Any]]) -> None:
         """Display link types in a table format."""


### PR DESCRIPTION
## Summary

Fixed the completely broken `yt issues links` subcommand group by implementing all missing functionality in the service layer and connecting it properly to the CLI commands.

## Changes Made

### 🔧 Service Layer Implementation (`youtrack_cli/services/issues.py`)
- Implemented `create_link()`, `delete_link()`, and `list_link_types()` methods
- Added YouTrack REST API integration for all link operations
- Created `_resolve_issue_id()` helper for readable→internal ID conversion (FPU-1 → 3-21)
- Added link type name→ID resolution with direction handling for directed links

### 🔧 Manager Layer Updates (`youtrack_cli/managers/issues.py`)
- Updated all methods to call service layer instead of returning "not implemented" errors
- Maintained existing interfaces while adding real functionality

### 🔧 CLI Command Improvements (`youtrack_cli/commands/issues.py`)
- Updated delete command signature for better usability:
  - **Before:** `yt issues links delete SOURCE_ISSUE_ID LINK_ID`
  - **After:** `yt issues links delete SOURCE_ISSUE_ID TARGET_ISSUE_ID LINK_TYPE`
- Improved confirmation messages and user feedback

### 🧪 Test Updates (`tests/managers/test_issues.py`)
- Fixed tests to verify actual functionality instead of "not implemented" errors
- Added proper mocking to test service layer integration

## API Integration

Implemented proper YouTrack REST API endpoints:
- **List Link Types:** `GET /api/issueLinkTypes`
- **Create Links:** `POST /api/issues/{issueID}/links/{linkID}/issues`
- **Delete Links:** `DELETE /api/issues/{issueID}/links/{linkID}/issues/{targetIssueID}`

## Commands Now Available

All commands are fully functional:

```bash
# List available link types
yt issues links types

# List all links for an issue
yt issues links list FPU-1

# Create links between issues
yt issues links create FPU-1 FPU-2 "Relates"
yt issues links create FPU-1 FPU-3 "Depends"

# Delete specific links
yt issues links delete FPU-1 FPU-2 "Relates"
```

## Key Features

- ✅ Supports both readable IDs (FPU-1) and internal IDs (3-21)
- ✅ Smart link type resolution (names ↔ API IDs)
- ✅ Handles directed/undirected link types correctly
- ✅ User-friendly error messages and confirmations
- ✅ Full YouTrack API integration

## Test plan

- [x] Unit tests pass with proper mocking
- [x] Real API integration tested successfully
- [x] ID conversion works correctly (FPU-1 ↔ 3-21)
- [x] Link type resolution works (name ↔ ID)
- [x] Create, list, and delete operations verified
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)