### PR TITLE
🐛 Fix comment deletion and other DELETE operations showing 'message' error (Fixes #451)

### DIFF
--- a/youtrack_cli/commands/issues.py
+++ b/youtrack_cli/commands/issues.py
@@ -1243,7 +1243,7 @@ def delete_comment(ctx: click.Context, issue_id: str, comment_id: str, force: bo
         result = asyncio.run(issue_manager.delete_comment(issue_id, comment_id))
 
         if result["status"] == "success":
-            console.print(f"✅ {result['message']}", style="green")
+            console.print(f"✅ Comment '{comment_id}' deleted successfully", style="green")
         else:
             console.print(f"❌ {result['message']}", style="red")
             raise click.ClickException("Failed to delete comment")

--- a/youtrack_cli/services/issues.py
+++ b/youtrack_cli/services/issues.py
@@ -325,7 +325,7 @@ class IssueService(BaseService):
         """
         try:
             response = await self._make_request("DELETE", f"issues/{issue_id}")
-            return await self._handle_response(response)
+            return await self._handle_response(response, success_codes=[200, 204])
 
         except ValueError as e:
             return self._create_error_response(str(e))
@@ -575,7 +575,7 @@ class IssueService(BaseService):
         """
         try:
             response = await self._make_request("DELETE", f"issues/{issue_id}/tags/{tag_name}")
-            return await self._handle_response(response)
+            return await self._handle_response(response, success_codes=[200, 204])
 
         except ValueError as e:
             return self._create_error_response(str(e))
@@ -680,7 +680,7 @@ class IssueService(BaseService):
         """
         try:
             response = await self._make_request("DELETE", f"issues/{issue_id}/comments/{comment_id}")
-            return await self._handle_response(response)
+            return await self._handle_response(response, success_codes=[200, 204])
 
         except ValueError as e:
             return self._create_error_response(str(e))
@@ -747,7 +747,7 @@ class IssueService(BaseService):
         """
         try:
             response = await self._make_request("DELETE", f"issues/{issue_id}/attachments/{attachment_id}")
-            return await self._handle_response(response)
+            return await self._handle_response(response, success_codes=[200, 204])
 
         except ValueError as e:
             return self._create_error_response(str(e))


### PR DESCRIPTION
## Summary

Fixes the issue where comment deletion and other DELETE operations showed cryptic `'message'` errors despite successful execution. This issue was causing high user confusion as operations appeared to fail when they actually succeeded.

## Changes Made

### Service Layer Fixes (`youtrack_cli/services/issues.py`)
- **Fixed DELETE operations to handle 204 No Content status codes properly**
  - Updated `delete_comment()` to accept `[200, 204]` success codes
  - Updated `delete_issue()` to accept `[200, 204]` success codes  
  - Updated `remove_tag()` to accept `[200, 204]` success codes
  - Updated `delete_attachment()` to accept `[200, 204]` success codes

### Command Layer Fixes (`youtrack_cli/commands/issues.py`)
- **Improved comment deletion success message display**
  - Changed from displaying `result['message']` (which could be None for 204 responses)
  - Now shows clear success message: `✅ Comment 'COMMENT-ID' deleted successfully`

## Root Cause Analysis

The issue occurred because:
1. YouTrack API DELETE operations return 204 No Content on success
2. The `_handle_response()` method only considered 200 as successful by default
3. 204 responses were treated as errors, triggering error handling code
4. Error handling tried to access a 'message' field that didn't exist in the response
5. This resulted in the cryptic `'message'` error being displayed

## Testing

- **Manual Testing**: ✅ Verified comment deletion now shows proper success messages
- **CLI Testing**: ✅ Comprehensive testing performed with cli-tester agent  
- **Pre-commit Checks**: ✅ All linting, formatting, and type checking passed
- **Unit Tests**: ✅ All existing tests continue to pass

## Test Evidence

### Before Fix:
```
🗑️  Deleting comment '7-14'...
❌ Error deleting comment: 'message'
Error: Failed to delete comment
```

### After Fix:
```
🗑️  Deleting comment '7-14'...
✅ Comment '7-14' deleted successfully
```

## Impact

- **✅ Eliminates user confusion** - No more false error messages for successful operations
- **✅ Builds user confidence** - Clear success feedback for delete operations  
- **✅ Consistent behavior** - All DELETE operations now handle 204 responses properly
- **✅ No breaking changes** - Maintains backward compatibility

## Related Issues

This fix addresses the pattern mentioned in issue #451. Similar issues exist for comment add/update operations but are tracked separately in issues #476 and #477 created during testing.

## Documentation

No documentation changes required - this is a bug fix that restores expected behavior.

Fixes #451

🤖 Generated with [Claude Code](https://claude.ai/code)