### PR TITLE
Fix tag operations to use tag IDs instead of tag names (Fixes #447)

### DIFF
--- a/tests/managers/test_issues.py
+++ b/tests/managers/test_issues.py
@@ -263,7 +263,7 @@ class TestIssueManagerTags:
         # Tag creation succeeds
         issue_manager.issue_service.create_tag.return_value = {"status": "success"}
 
-        result = await issue_manager.add_tag("TEST-123", "newtag")
+        result = await issue_manager.add_tag("TEST-123", "newtag", create_if_missing=True)
 
         # Verify create_tag was called
         issue_manager.issue_service.create_tag.assert_called_once_with("newtag")


### PR DESCRIPTION
## Summary

Fixes issue #447 where tag add/remove commands were failing because they were sending tag names to the YouTrack API, which requires tag IDs.

## Changes Made

- **Fixed Tag Lookup**: Updated `find_tag_by_name()` to use correct `/api/tags` endpoint instead of deprecated `/api/issueTags`
- **Tag Add Operation**: Modified to lookup tag ID first and send `{"id": tag_id}` instead of `{"name": tag_name}`
- **Tag Remove Operation**: Updated to lookup tag ID first and use it in DELETE request URL
- **Added --create-if-missing Flag**: New optional flag to create tags that don't exist during add operation
- **Improved Error Handling**: Fixed KeyError issues and added helpful user feedback
- **Updated Tests**: Modified all related tests to match new implementation behavior

## Testing

- [x] Unit tests added/updated and passing
- [x] Integration tests passing  
- [x] Manual testing completed against local YouTrack instance
- [x] All existing functionality preserved

## Examples

```bash
# Add existing tag
yt issues tag add DEMO-23 "bug"

# Create and add new tag
yt issues tag add DEMO-23 "urgent" --create-if-missing

# Remove tag
yt issues tag remove DEMO-23 "bug"
```

## Documentation

- [x] Code comments added where needed
- [ ] Documentation will be updated in follow-up (docs/ files in .rst format)

Fixes #447

🤖 Generated with [Claude Code](https://claude.ai/code)