### PR TITLE
🐛 Fix users create command Hub API endpoint (Fixes #435)

### DIFF
--- a/tests/services/test_users.py
+++ b/tests/services/test_users.py
@@ -184,7 +184,7 @@ class TestUserServiceCreateUser:
                 "email": "test@example.com",
                 "forceChangePassword": False,
             }
-            mock_request.assert_called_once_with("POST", "users", json_data=expected_data)
+            mock_request.assert_called_once_with("POST", "../hub/api/rest/users", json_data=expected_data)
             mock_handle.assert_called_once_with(mock_response, success_codes=[200, 201])
             assert result["status"] == "success"
 
@@ -213,7 +213,7 @@ class TestUserServiceCreateUser:
                 "password": "secret123",
                 "forceChangePassword": True,
             }
-            mock_request.assert_called_once_with("POST", "users", json_data=expected_data)
+            mock_request.assert_called_once_with("POST", "../hub/api/rest/users", json_data=expected_data)
             assert result["status"] == "success"
 
     @pytest.mark.asyncio

--- a/youtrack_cli/services/users.py
+++ b/youtrack_cli/services/users.py
@@ -115,7 +115,7 @@ class UserService(BaseService):
             if password:
                 user_data["password"] = password
 
-            response = await self._make_request("POST", "users", json_data=user_data)
+            response = await self._make_request("POST", "../hub/api/rest/users", json_data=user_data)
             return await self._handle_response(response, success_codes=[200, 201])
 
         except ValueError as e:


### PR DESCRIPTION
## Summary

Fixed the `yt users create` command which was failing with the error "<no user> is not a valid user login". The issue was that the command was using the YouTrack REST API endpoint instead of the required Hub REST API endpoint for user creation.

## Root Cause

According to YouTrack documentation, user creation operations must use the Hub REST API since YouTrack uses Hub as its authentication service. The command was incorrectly posting to `/api/users` instead of `/hub/api/rest/users`.

## Changes Made

- **UserService.create_user()**: Changed endpoint from `"users"` to `"../hub/api/rest/users"`
- **Tests**: Updated corresponding unit tests to expect the new endpoint
- **Documentation**: Added implementation plan with detailed analysis

## Testing

- ✅ Manual testing confirms user creation now works successfully
- ✅ Both CLI password (`--password`) and interactive password prompts work
- ✅ All existing tests pass (1327/1327)
- ✅ Pre-commit validation passes
- ✅ Created multiple test users successfully:
  - `testuser435` (User ID: fa493cde-22d6-4ff3-9033-13ed3555c1de)
  - `testuser436` (User ID: 7e3e6c7d-24a7-441e-a56f-e50bfb2fee93)
  - `testuser437` (User ID: 7b9fdf94-0ba9-494d-9664-d76f25225528)

## Validation Commands

```bash
# Test with password via CLI
yt users create testuser "Test User" "test@example.com" --password mypassword

# Test with interactive password prompt  
yt users create testuser "Test User" "test@example.com"
```

Fixes #435

🤖 Generated with [Claude Code](https://claude.ai/code)