### PR TITLE
🐛 Fix issues update command to allow empty assignee for unassignment (Fixes #470)

### DIFF
--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -1589,6 +1589,75 @@ class TestIssuesCLI:
             assert result.exit_code == 1
             assert "api request failed" in result.output.lower()
 
+    def test_issues_update_command_empty_assignee_valid(self):
+        """Test that empty assignee string is treated as valid update."""
+        from youtrack_cli.main import main
+
+        runner = CliRunner()
+
+        with patch("youtrack_cli.main.asyncio.run") as mock_run:
+            mock_run.return_value = {
+                "status": "success",
+                "message": "Issue updated successfully",
+            }
+
+            result = runner.invoke(main, ["issues", "update", "PROJ-123", "--assignee", ""])
+
+            assert result.exit_code == 0
+            assert "updating issue" in result.output.lower()
+            assert "no updates specified" not in result.output.lower()
+
+    def test_issues_update_command_empty_summary_valid(self):
+        """Test that empty summary string is treated as valid update."""
+        from youtrack_cli.main import main
+
+        runner = CliRunner()
+
+        with patch("youtrack_cli.main.asyncio.run") as mock_run:
+            mock_run.return_value = {
+                "status": "success",
+                "message": "Issue updated successfully",
+            }
+
+            result = runner.invoke(main, ["issues", "update", "PROJ-123", "--summary", ""])
+
+            assert result.exit_code == 0
+            assert "updating issue" in result.output.lower()
+            assert "no updates specified" not in result.output.lower()
+
+    def test_issues_update_command_no_options_invalid(self):
+        """Test that no update options still shows 'no updates specified'."""
+        from youtrack_cli.main import main
+
+        runner = CliRunner()
+
+        result = runner.invoke(main, ["issues", "update", "PROJ-123"])
+
+        # Should exit with 0 but show the validation message and return early
+        assert result.exit_code == 0
+        assert "no updates specified" in result.output.lower()
+
+    def test_issues_update_command_empty_fields_combination(self):
+        """Test that combination of empty fields is treated as valid update."""
+        from youtrack_cli.main import main
+
+        runner = CliRunner()
+
+        with patch("youtrack_cli.main.asyncio.run") as mock_run:
+            mock_run.return_value = {
+                "status": "success",
+                "message": "Issue updated successfully",
+            }
+
+            result = runner.invoke(
+                main,
+                ["issues", "update", "PROJ-123", "--assignee", "", "--description", "", "--summary", "New summary"],
+            )
+
+            assert result.exit_code == 0
+            assert "updating issue" in result.output.lower()
+            assert "no updates specified" not in result.output.lower()
+
 
 @pytest.mark.unit
 class TestIssueTablePagination:

--- a/youtrack_cli/commands/issues.py
+++ b/youtrack_cli/commands/issues.py
@@ -629,7 +629,16 @@ def update(
             console.print(f"❌ Error getting issue details: {e}", style="red")
             raise click.ClickException("Failed to get issue details") from e
     else:
-        if not any([summary, description, state, priority, assignee, type]):
+        if not any(
+            [
+                summary is not None,
+                description is not None,
+                state is not None,
+                priority is not None,
+                assignee is not None,
+                type is not None,
+            ]
+        ):
             console.print("❌ No updates specified.", style="red")
             console.print(
                 "Use --summary, --description, --state, --priority, --assignee, "


### PR DESCRIPTION
## Summary
- Fix validation logic in issues update command to allow empty assignee strings for unassignment
- Change validation check from truthiness to explicit `is not None` checks  
- Add comprehensive tests for the fix

## Problem
The 'yt issues update' command cannot be used to unassign issues (set assignee to null/empty) because the CLI validation rejects empty strings as 'no updates specified'.

## Root Cause
In `youtrack_cli/commands/issues.py`, the validation check:
```python
if not any([summary, description, state, priority, assignee, type]):
```
treats empty strings as falsy values, preventing unassignment operations.

## Solution
Changed the validation to distinguish between `None` (not provided) and empty string (intentional unassignment):
```python
if not any([summary is not None, description is not None, state is not None, priority is not None, assignee is not None, type is not None]):
```

## Testing
- ✅ Added 4 comprehensive test cases covering all scenarios
- ✅ Manual CLI testing confirms fix works as expected
- ✅ All existing tests continue to pass
- ✅ Pre-commit validation passes

## Test plan
- [x] Unit tests added for all validation scenarios
- [x] Manual testing with local YouTrack instance
- [x] Verified empty assignee string now works: `yt issues update ISSUE-ID --assignee ""`
- [x] Verified "no updates specified" still appears when no options provided
- [x] Verified other empty string fields also work correctly
- [x] All linting and type checking passes

🤖 Generated with [Claude Code](https://claude.ai/code)