### PR TITLE
🐛 Fix issue and attachment deletion commands showing 'message' error despite successful execution (Fixes #477)

### DIFF
--- a/youtrack_cli/commands/issues.py
+++ b/youtrack_cli/commands/issues.py
@@ -702,7 +702,7 @@ def delete(ctx: click.Context, issue_id: str, force: bool) -> None:
         result = asyncio.run(issue_manager.delete_issue(issue_id))
 
         if result["status"] == "success":
-            console.print(f"✅ {result['message']}", style="green")
+            console.print(f"✅ Issue '{issue_id}' deleted successfully", style="green")
         else:
             console.print(f"❌ {result['message']}", style="red")
             raise click.ClickException("Failed to delete issue")
@@ -1443,7 +1443,7 @@ def delete_attachment(ctx: click.Context, issue_id: str, attachment_id: str, for
         result = asyncio.run(issue_manager.delete_attachment(issue_id, attachment_id))
 
         if result["status"] == "success":
-            console.print(f"✅ {result['message']}", style="green")
+            console.print(f"✅ Attachment '{attachment_id}' deleted successfully", style="green")
         else:
             console.print(f"❌ {result['message']}", style="red")
             raise click.ClickException("Failed to delete attachment")


### PR DESCRIPTION
## Summary

Fixed issue and attachment deletion commands that were showing "'message'" error despite successfully executing the operations.

## Root Cause

Both `yt issues delete` and `yt issues attach delete` commands were attempting to access a `message` field from the service response, but DELETE operations return 204 status codes with empty response bodies. The service layer correctly handles this by returning `{"status": "success", "data": None}`, but the command layer was still trying to access `result['message']` which doesn't exist.

## Changes Made

- **Issue deletion**: Updated success message from `result['message']` to hardcoded `"Issue '{issue_id}' deleted successfully"`
- **Attachment deletion**: Updated success message from `result['message']` to hardcoded `"Attachment '{attachment_id}' deleted successfully"`
- Applied same pattern used for comment deletion fix in #451

## Testing

- ✅ Created test issue and successfully deleted it - shows proper success message
- ✅ No more "'message'" error displayed
- ✅ Operations still work correctly (issues are actually deleted)
- ✅ Pre-commit hooks pass
- ✅ All tests pass

## Before Fix
```
🗑️  Deleting issue 'ISSUE-ID'...
❌ Error deleting issue: 'message'
```

## After Fix
```
🗑️  Deleting issue 'ISSUE-ID'...
✅ Issue 'ISSUE-ID' deleted successfully
```

## Related Issues

This follows the same pattern as the comment deletion fix implemented in #451. The service layer was already properly handling 204 status codes, but the command layer needed to be updated to provide hardcoded success messages instead of relying on response messages.

Fixes #477

🤖 Generated with [Claude Code](https://claude.ai/code)