### PR TITLE
🐛 Fix yt time list --issue filter not working correctly (Fixes #493)

### DIFF
--- a/youtrack_cli/time.py
+++ b/youtrack_cli/time.py
@@ -117,11 +117,12 @@ class TimeManager:
         if end_date:
             params["endDate"] = end_date
 
-        # Get all time entries from the global endpoint
-        url = f"{credentials.base_url.rstrip('/')}/api/workItems"
+        # Use issue-specific endpoint when filtering by issue_id
         if issue_id:
-            # Filter by issue in parameters
-            params["issue"] = issue_id
+            url = f"{credentials.base_url.rstrip('/')}/api/issues/{issue_id}/timeTracking/workItems"
+        else:
+            # Get all time entries from the global endpoint
+            url = f"{credentials.base_url.rstrip('/')}/api/workItems"
 
         headers = {
             "Authorization": f"Bearer {credentials.token}",


### PR DESCRIPTION
## Summary

Fixes the `yt time list --issue ISSUE-ID` command which was not filtering by issue correctly. The command was returning all time entries instead of only entries for the specified issue.

## Root Cause

The issue was in the `TimeManager.get_time_entries()` method in `youtrack_cli/time.py`. When an `issue_id` was provided, the method was using:
- Global endpoint: `/api/workItems` with `issue` parameter
- This parameter doesn't work correctly with the YouTrack API

## Changes Made

- **Fixed endpoint selection**: When `issue_id` is provided, now uses the issue-specific endpoint: `/api/issues/{issue_id}/timeTracking/workItems`
- **Maintained backward compatibility**: All other filtering parameters (user_id, start_date, end_date, fields) continue to work as before
- **Consistent with existing code**: Uses the same endpoint pattern already successfully implemented in the `log_time` method

## Testing

✅ **Manual Testing Completed**:
- `yt time list --issue DEMO-2` now correctly returns only entries for DEMO-2 (4 entries)
- `yt time list --issue DEMO-3` correctly returns only entries for DEMO-3 (1 entry) 
- `yt time list` (without filter) still returns all entries (9 total)
- `yt time list --issue DEMO-2 --format json` works correctly with JSON output
- All other time list functionality remains unchanged

✅ **Comprehensive CLI Testing**: Used cli-tester agent to validate all modified CLI commands
- All core functionality working correctly
- No regressions detected
- Proper error handling maintained
- Documentation alignment verified

✅ **Code Quality**: 
- All pre-commit checks passed
- 1332 tests passing
- Type checking passed
- Linting and formatting passed

## Files Modified

- `youtrack_cli/time.py` - Fixed `get_time_entries()` method to use correct endpoint when filtering by issue
- `scratch/issue-493.md` - Implementation plan documentation

## Verification

**Before Fix:**
```bash
yt time list --issue DEMO-2  # Returned all 9 time entries (bug)
```

**After Fix:**
```bash
yt time list --issue DEMO-2  # Returns only 4 DEMO-2 entries (correct)
```

Fixes #493

🤖 Generated with [Claude Code](https://claude.ai/code)