### PR TITLE
🐛 Fix JSON output pollution in yt issues attach list command (Fixes #500)

### DIFF
--- a/youtrack_cli/commands/issues.py
+++ b/youtrack_cli/commands/issues.py
@@ -1412,7 +1412,16 @@ def list_attachments(
     auth_manager = AuthManager(ctx.obj.get("config"))
     issue_manager = IssueManager(auth_manager)
 
-    console.print(f"📎 Fetching attachments for issue '{issue_id}'...", style="blue")
+    # Print progress message to stderr when JSON format is used to avoid polluting JSON output
+    if format == "json":
+        import sys
+
+        from rich.console import Console
+
+        stderr_console = Console(file=sys.stderr)
+        stderr_console.print(f"📎 Fetching attachments for issue '{issue_id}'...", style="blue")
+    else:
+        console.print(f"📎 Fetching attachments for issue '{issue_id}'...", style="blue")
 
     try:
         result = asyncio.run(issue_manager.list_attachments(issue_id))


### PR DESCRIPTION
## Summary

Fixed progress message pollution in JSON output for the `yt issues attach list --format json` command. Progress messages now go to stderr when JSON format is requested, ensuring clean JSON output on stdout for automation scripts.

## Changes Made
- Modified `list_attachments` function in `youtrack_cli/commands/issues.py`
- Added conditional logic to direct progress messages to stderr when `--format json` is used
- Maintained existing behavior for table format (progress messages to stdout)
- Clean JSON output now available for automation and scripting

## Testing
- ✅ Verified JSON output is clean and parseable
- ✅ Confirmed progress messages appear on stderr for JSON format
- ✅ Maintained existing behavior for table format
- ✅ All pre-commit hooks pass
- ✅ Type checking with ty passes
- ✅ Unit and integration tests pass

## Impact
This fix resolves the CLI test failure where JSON parsing was broken due to progress messages being mixed with JSON output. Automation scripts can now reliably parse the JSON output without encountering invalid JSON.

## Before/After

**Before:**
```
📎 Fetching attachments for issue 'FPU-1'...
[
  {
    "name": "test-attachment.txt",
    ...
  }
]
```

**After:**
```
[
  {
    "name": "test-attachment.txt", 
    ...
  }
]
```
*(Progress message appears on stderr, not mixed with JSON)*

Fixes #500

🤖 Generated with [Claude Code](https://claude.ai/code)