### PR TITLE
📝 Fix documentation inconsistency: Update --confirm to --force in delete commands (Fixes #504)

### DIFF
--- a/docs/commands/issues.rst
+++ b/docs/commands/issues.rst
@@ -358,7 +358,7 @@ Delete Comments
    yt issues comments delete ISSUE_ID COMMENT_ID [OPTIONS]
 
 **Options:**
-  * ``--confirm`` - Skip confirmation prompt
+  * ``--force`` - Skip confirmation prompt
 
 Attachment Management
 ---------------------
@@ -406,7 +406,7 @@ Delete Attachments
    yt issues attach delete ISSUE_ID ATTACHMENT_ID [OPTIONS]
 
 **Options:**
-  * ``--confirm`` - Skip confirmation prompt
+  * ``--force`` - Skip confirmation prompt
 
 Issue Relationships
 -------------------
@@ -461,7 +461,7 @@ Delete Links
    yt issues links delete SOURCE_ISSUE_ID LINK_ID [OPTIONS]
 
 **Options:**
-  * ``--confirm`` - Skip confirmation prompt
+  * ``--force`` - Skip confirmation prompt
 
 List Link Types
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary

Fixes documentation inconsistency where three delete commands showed `--confirm` flag in docs but actually implemented `--force` flag.

## Changes Made
- Updated `docs/commands/issues.rst` to use `--force` instead of `--confirm` for:
  - `yt issues attach delete` command 
  - `yt issues comments delete` command
  - `yt issues links delete` command
- Documentation now accurately reflects the actual CLI implementation

## Root Cause Analysis
The CLI implementation correctly used `--force` flag (which is the standard CLI convention for "skip confirmation prompt"), but the documentation incorrectly showed `--confirm`. Since `--force` is more conventional and all implementations were consistent, the fix was to update documentation rather than change code.

## Testing
- [x] Verified all three commands show `--force` in help output
- [x] Confirmed `--confirm` flag fails with "No such option" error  
- [x] All pre-commit checks pass (linting, type checking, tests)
- [x] Documentation builds successfully
- [x] Manual CLI testing completed

## Documentation
- [x] Documentation updated (docs/commands/issues.rst)
- [x] Documentation build validated
- [x] Changes follow project RST format conventions

## Validation Commands Used
```bash
# Verified correct flag in help output
yt issues attach delete --help    # Shows --force
yt issues comments delete --help  # Shows --force  
yt issues links delete --help     # Shows --force

# Confirmed --confirm fails as expected
yt issues attach delete FAKE-1 FAKE-1 --confirm  # Error: No such option: --confirm
```

Fixes #504

🤖 Generated with [Claude Code](https://claude.ai/code)