### PR TITLE
🐛 Fix inconsistent parent ID validation in articles create command (Fixes #527)

### DIFF
--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -204,6 +204,24 @@ class TestArticleManager:
             assert internal_id == "167-6"
 
     @pytest.mark.asyncio
+    async def test_resolve_article_id_nonexistent_internal(self, article_manager):
+        """Test that _resolve_article_id fails for non-existent internal IDs."""
+
+        with patch("youtrack_cli.articles.get_client_manager") as mock_get_client:
+            mock_client_manager = Mock()
+            # Mock response for non-existent article (404 or error)
+            mock_resp = Mock()
+            mock_resp.status_code = 404
+            mock_resp.text = "Article not found"
+            mock_resp.headers = {"content-type": "text/plain"}
+            mock_client_manager.make_request = AsyncMock(side_effect=Exception("Article not found"))
+            mock_get_client.return_value = mock_client_manager
+
+            # Test with non-existent internal ID
+            with pytest.raises(ValueError, match="Article '999-999' not found"):
+                await article_manager._resolve_article_id("999-999")
+
+    @pytest.mark.asyncio
     async def test_list_articles_success(self, article_manager):
         """Test successful article listing."""
         mock_response = [


### PR DESCRIPTION
## Summary

This PR fixes inconsistent parent ID validation behavior in the `yt articles create` command where non-existent internal IDs would silently succeed and create root articles instead of failing with clear error messages.

## Changes Made
- Modified `_resolve_article_id` method in `youtrack_cli/articles.py` to validate both readable and internal IDs
- Removed early return logic that skipped validation for assumed internal IDs
- Added comprehensive validation by attempting to fetch all article IDs from the API
- Added test case `test_resolve_article_id_nonexistent_internal` to ensure non-existent internal IDs fail properly
- Ensured consistent error messages for both readable and internal ID failures

## Issue Resolution
- **Before**: Non-existent readable ID (e.g., 'FPU-A-999') correctly failed, but non-existent internal ID (e.g., '999-999') silently succeeded and created root article
- **After**: Both scenarios now fail consistently with clear error messages

## Testing
- [x] Unit tests added for non-existent internal ID validation
- [x] Integration tests passing for all scenarios:
  - ✅ Valid readable ID: Works correctly  
  - ✅ Valid internal ID: Works correctly
  - ❌ Non-existent readable ID: Fails with clear error message
  - ❌ Non-existent internal ID: Fails with clear error message (fixed\!)
- [x] All existing tests continue to pass
- [x] Pre-commit checks passing
- [x] Manual testing with local YouTrack instance successful

## Documentation
- [x] Code comments updated to reflect new validation behavior
- [x] Implementation plan documented in `scratch/issue-527.md`

Fixes #527

🤖 Generated with [Claude Code](https://claude.ai/code)