### PR TITLE
🐛 Fix issue type update parameter not working in issues update command (Fixes #515)

### DIFF
--- a/youtrack_cli/services/issues.py
+++ b/youtrack_cli/services/issues.py
@@ -140,8 +140,6 @@ class IssueService(BaseService):
                 update_data["summary"] = summary
             if description is not None:
                 update_data["description"] = description
-            if issue_type is not None:
-                update_data["type"] = {"name": issue_type}
 
             # Handle state field with dynamic discovery
             if state is not None:
@@ -215,6 +213,16 @@ class IssueService(BaseService):
                         "$type": "SingleEnumIssueCustomField",
                         "name": "Priority",
                         "value": {"$type": "EnumBundleElement", "name": priority},
+                    }
+                )
+
+            # Handle issue type field (as custom field, consistent with create_issue)
+            if issue_type is not None:
+                custom_fields.append(
+                    {
+                        "$type": "SingleEnumIssueCustomField",
+                        "name": "Type",
+                        "value": {"$type": "EnumBundleElement", "name": issue_type},
                     }
                 )
 


### PR DESCRIPTION
## Summary

Fixed the `--type` parameter in the `yt i u` (issues update) command that was not working correctly. The issue type parameter now properly updates issue types in YouTrack.

## Root Cause

The issue was in the `IssueService.update_issue` method where issue type was being handled as a regular field (`update_data["type"] = {"name": issue_type}`) instead of as a custom field. This was inconsistent with:

1. How `create_issue` handles issue type (as a custom field)
2. How other update parameters like priority and assignee are handled (as custom fields)

## Changes Made

- **Fixed issue type handling in `youtrack_cli/services/issues.py`**:
  - Removed incorrect regular field handling for issue type (lines 143-144)
  - Added proper custom field handling using `SingleEnumIssueCustomField` with `EnumBundleElement`
  - Made it consistent with create_issue implementation and other custom field updates

## Testing

### Manual Testing Results
✅ **Issue Type Updates Work**: Successfully tested updating issue types:
- `yt i u DEMO-14 --type "Epic"` ✅ (Task → Epic)
- `yt i u DEMO-14 --type "Bug"` ✅ (Epic → Bug)  
- `yt i u DEMO-14 --type "Feature"` ✅ (Bug → Feature)

✅ **Combined Updates Work**: Successfully tested updating type with other fields:
- `yt i u DEMO-14 --type "Feature" --summary "Updated summary and type together"` ✅

✅ **Error Handling**: Properly handles projects without Type fields:
- Returns appropriate error message when Type field doesn't exist in project

### Automated Testing
- ✅ All 1340 tests pass
- ✅ Pre-commit hooks pass (linting, type checking, security checks)
- ✅ Test coverage maintained at 62.74%

## Compatibility

- **No Breaking Changes**: Existing functionality remains unchanged
- **Consistent API**: Issue type handling now matches create operations
- **Error Messages**: Clear error messages when Type field not available in project

## Impact

Users can now successfully change issue types through the CLI, eliminating the need to use the web interface for this common operation.

**Before**: `yt i u DEMO-14 --type "Epic"` → Failed silently or with API error
**After**: `yt i u DEMO-14 --type "Epic"` → ✅ Issue updated successfully

Fixes #515

🤖 Generated with [Claude Code](https://claude.ai/code)