### PR TITLE
🐛 Fix assignee parameter not working in issues create command (Fixes #516)

### DIFF
--- a/tests/services/test_issues.py
+++ b/tests/services/test_issues.py
@@ -77,7 +77,6 @@ class TestIssueServiceCreation:
                 "project": {"id": "project-1"},
                 "summary": "Test Summary",
                 "description": "Test Description",
-                "assignee": {"login": "user123"},
                 "customFields": [
                     {
                         "$type": "SingleEnumIssueCustomField",
@@ -88,6 +87,11 @@ class TestIssueServiceCreation:
                         "$type": "SingleEnumIssueCustomField",
                         "name": "Type",
                         "value": {"$type": "EnumBundleElement", "name": "Bug"},
+                    },
+                    {
+                        "$type": "SingleUserIssueCustomField",
+                        "name": "Assignee",
+                        "value": {"login": "user123"},
                     },
                 ],
             }

--- a/youtrack_cli/services/issues.py
+++ b/youtrack_cli/services/issues.py
@@ -43,10 +43,8 @@ class IssueService(BaseService):
 
             if description:
                 issue_data["description"] = description
-            if assignee:
-                issue_data["assignee"] = {"login": assignee}
 
-            # Handle custom fields - Priority and Type are typically custom fields in YouTrack
+            # Handle custom fields - Priority, Type, and Assignee are typically custom fields in YouTrack
             if priority:
                 custom_fields.append(
                     {
@@ -62,6 +60,15 @@ class IssueService(BaseService):
                         "$type": "SingleEnumIssueCustomField",
                         "name": "Type",
                         "value": {"$type": "EnumBundleElement", "name": issue_type},
+                    }
+                )
+
+            if assignee:
+                custom_fields.append(
+                    {
+                        "$type": "SingleUserIssueCustomField",
+                        "name": "Assignee",
+                        "value": {"login": assignee},
                     }
                 )
 


### PR DESCRIPTION
## Summary

Fixes the assignee parameter not working in the `yt i c` (issues create) command by correcting the API field format used when creating issues.

## Root Cause

The issue was caused by the assignee being set as a direct field in the API request:
```json
{
  "assignee": {"login": "username"}
}
```

According to the YouTrack API documentation, the assignee should be set as a custom field:
```json
{
  "customFields": [
    {
      "$type": "SingleUserIssueCustomField",
      "name": "Assignee",
      "value": {"login": "username"}
    }
  ]
}
```

## Changes Made

- **Fixed assignee implementation**: Updated `IssueService.create_issue()` to set assignee as a custom field instead of a direct field
- **Updated test expectations**: Modified the corresponding test to match the new API structure
- **Maintained backward compatibility**: No changes to the CLI interface - users continue to use `--assignee` parameter as before

## Testing

- ✅ Created test issues with assignee parameter in local YouTrack instance
- ✅ Verified assignee is correctly set and displayed in issue details
- ✅ All existing tests pass
- ✅ Updated failing test to match new expected API structure
- ✅ Pre-commit hooks pass

### Test Commands
```bash
# These commands now work correctly:
yt issues create FPU "Test issue" --assignee admin
yt issues create DEMO "Bug report" --description "Description" --type "Bug" --priority "High" --assignee admin
```

## Impact

- **User Experience**: Users can now successfully assign issues during creation via CLI
- **API Compatibility**: Follows YouTrack REST API specification for custom fields
- **No Breaking Changes**: CLI interface remains unchanged

## Related Issues

Fixes #516 - Assignee parameter not working in issues create command