### PR TITLE
🐛 Fix false success in issues move command between projects (Fixes #518)

### DIFF
--- a/youtrack_cli/services/issues.py
+++ b/youtrack_cli/services/issues.py
@@ -2,7 +2,10 @@
 
 from typing import Any, Dict, Optional
 
+from ..logging import get_logger
 from .base import BaseService
+
+logger = get_logger(__name__)
 
 
 class IssueService(BaseService):
@@ -389,16 +392,26 @@ class IssueService(BaseService):
 
             # Make the API call to move the issue
             response = await self._make_request("POST", f"issues/{issue_id}/project", json_data={"id": target_db_id})
-
             result = await self._handle_response(response, success_codes=[200, 204])
 
-            # Enhance success message
-            if result["status"] == "success":
-                issue_readable_id = current_issue.get("idReadable", issue_id)
-                result["message"] = (
-                    f"Issue '{issue_readable_id}' successfully moved from '{current_project_name}' "
-                    f"to '{target_project_id}'"
-                )
+            # Verify the move was actually successful by checking if returned project ID matches target
+            if result["status"] == "success" and result["data"]:
+                returned_project_id = result["data"].get("id")
+
+                if returned_project_id == target_db_id:
+                    # Move was successful
+                    issue_readable_id = current_issue.get("idReadable", issue_id)
+                    result["message"] = (
+                        f"Issue '{issue_readable_id}' successfully moved from '{current_project_name}' "
+                        f"to '{target_project_id}'"
+                    )
+                else:
+                    # Move failed - YouTrack returned current project instead of target project
+                    return self._create_error_response(
+                        f"Failed to move issue '{issue_id}' to project '{target_project_id}'. "
+                        f"This may be due to insufficient permissions or project constraints. "
+                        f"Verify you have 'Update Issue' permission in both projects."
+                    )
 
             return result
 


### PR DESCRIPTION
## Summary

Fixes the critical bug where `yt issues move ISSUE-ID -p PROJECT` shows success but doesn't actually move issues between projects.

## Problem

The YouTrack API returns HTTP 200 with the **current project info** instead of confirming successful moves, causing the CLI to show misleading success messages while issues remain in their original projects.

## Root Cause

The move operation was only checking HTTP status codes (200 = success) without validating that the returned project ID matches the target project ID.

## Solution

- Add project ID validation after move API calls
- Compare returned project ID with target project ID  
- Show proper error message when IDs don't match
- Provide helpful guidance about permissions/constraints

## Changes Made

- Enhanced `_move_issue_to_project()` in `youtrack_cli/services/issues.py`
- Added project ID verification logic
- Improved error messaging with actionable guidance

## Testing

- ✅ Manually reproduced the original bug
- ✅ Verified fix correctly detects failed moves
- ✅ Shows helpful error instead of false success
- ✅ All unit and integration tests pass (1340 passed)
- ✅ Pre-commit validation successful

## Before Fix
```
yt issues move DEMO-26 -p FPU
🚚 Moving issue 'DEMO-26'...
✅ Issue 'DEMO-26' successfully moved from 'Demo project' to 'FPU'
# But issue actually remained in DEMO project\!
```

## After Fix  
```
yt issues move DEMO-26 -p FPU
🚚 Moving issue 'DEMO-26'...
❌ Failed to move issue 'DEMO-26' to project 'FPU'. This may be due to 
insufficient permissions or project constraints. Verify you have 'Update Issue' 
permission in both projects.
```

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>