### PR TITLE
🐛 Fix issues tag list command returning empty results (Fixes #520)

### DIFF
--- a/tests/services/test_issues.py
+++ b/tests/services/test_issues.py
@@ -541,7 +541,7 @@ class TestIssueServiceTags:
 
             await issue_service.list_tags("TEST-1")
 
-            mock_request.assert_called_once_with("GET", "issues/TEST-1/tags")
+            mock_request.assert_called_once_with("GET", "issues/TEST-1/tags", params={"fields": "id,name"})
 
     @pytest.mark.asyncio
     async def test_find_tag_by_name(self, issue_service, mock_response):

--- a/youtrack_cli/services/issues.py
+++ b/youtrack_cli/services/issues.py
@@ -714,7 +714,8 @@ class IssueService(BaseService):
             API response with tag list
         """
         try:
-            response = await self._make_request("GET", f"issues/{issue_id}/tags")
+            params = {"fields": "id,name"}
+            response = await self._make_request("GET", f"issues/{issue_id}/tags", params=params)
             return await self._handle_response(response)
 
         except ValueError as e:


### PR DESCRIPTION
## Summary

Fixed the `yt issues tag list` command which was returning empty results even when tags existed on issues. The issue was that the API request wasn't specifying which fields to return, resulting in empty tag data.

## Changes Made
- Added `fields` parameter to `list_tags` method in `IssueService` to request 'id,name' fields
- Updated corresponding test to expect the fields parameter

## Testing
- [x] Unit tests added/updated
- [x] Integration tests passing  
- [x] Manual testing completed
- [x] Security review completed (N/A - read-only operation)

## Documentation
- [x] Code comments added where needed (N/A - simple parameter addition)
- [x] Documentation updated (not needed - behavior unchanged)
- [x] CHANGELOG.md updated with changes (N/A - bug fix)

## Manual Testing Results
```bash
# Before fix - tags not shown
$ yt issues tag list FPU-50
🏷️  Fetching tags for issue 'FPU-50'...
Tags:

# After fix - tags properly displayed
$ yt issues tag list FPU-50
🏷️  Fetching tags for issue 'FPU-50'...
Tags: test-tag, another-tag
```

Fixes #520

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>