### PR TITLE
🐛 Fix time log WorkItemType entity error with work type resolution (Fixes #524)

### DIFF
--- a/docs/commands/time.rst
+++ b/docs/commands/time.rst
@@ -15,10 +15,11 @@ YouTrack time tracking helps teams monitor effort, generate reports, and underst
 * Log work time on issues with flexible duration formats
 * List time entries with filtering options
 * Track different types of work (Development, Testing, etc.)
-* List time entries with filtering
+* List available work types for your organization
 * View time summaries grouped by various criteria
 * Export time data for analysis and billing
 * Support for historical time entries and date flexibility
+* Automatic work type name resolution to IDs
 
 Base Command
 ------------
@@ -192,6 +193,47 @@ View time summaries with aggregation and grouping options.
    # User-specific summary for performance review
    yt time summary --user-id USER-123 --start-date "2024-01-01" --end-date "2024-03-31"
 
+work-types
+~~~~~~~~~~
+
+List available work types for time tracking.
+
+.. code-block:: bash
+
+   yt time work-types [OPTIONS]
+
+**Options:**
+
+.. list-table::
+   :widths: 20 20 60
+   :header-rows: 1
+
+   * - Option
+     - Type
+     - Description
+   * - ``--issue, -i``
+     - string
+     - Issue ID to get project-specific work types
+   * - ``--format, -f``
+     - choice
+     - Output format: table, json (default: table)
+
+**Examples:**
+
+.. code-block:: bash
+
+   # List all available work types
+   yt time work-types
+
+   # List work types in JSON format
+   yt time work-types --format json
+
+   # List project-specific work types for an issue
+   yt time work-types --issue ISSUE-123
+
+   # Export work types for documentation
+   yt time work-types --format json > work_types.json
+
 Duration Formats
 ----------------
 
@@ -280,7 +322,24 @@ Relative Dates
 Work Types
 ----------
 
-Common work type classifications for better time categorization:
+YouTrack supports configurable work types for time categorization. The CLI automatically resolves work type names to their IDs when logging time.
+
+.. note::
+   Work types are case-insensitive when logging time. The CLI will match "development", "Development", or "DEVELOPMENT" to the same work type.
+
+Listing Available Work Types
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   # List all available work types
+   yt time work-types
+
+   # List project-specific work types
+   yt time work-types --issue ISSUE-123
+
+   # Export work types for reference
+   yt time work-types --format json > available_work_types.json
 
 Development Work
 ~~~~~~~~~~~~~~~
@@ -540,7 +599,7 @@ Common error scenarios and solutions:
   Be careful not to log duplicate time entries for the same work.
 
 **Invalid Work Type**
-  Verify work type names match your organization's standards.
+  The CLI will show available work types when an invalid type is provided. Use ``yt time work-types`` to list all available work types beforehand.
 
 Performance Optimization
 -----------------------


### PR DESCRIPTION
## Summary

This PR fixes the critical issue where `yt time log` command fails with "WorkItemType entity error" when using the `--work-type` parameter. The root cause was that YouTrack API requires WorkItemType entities to be specified by ID, not name.

## Changes Made

### Core Functionality
- **Work Type Resolution**: Automatically fetch available work types and resolve names to IDs before API calls
- **New Command**: Added `yt time work-types` to list available work types (global and project-specific)
- **Case-Insensitive Matching**: Allow flexible input - "development", "Development", or "DEVELOPMENT" all work
- **Enhanced Error Handling**: Show available work types when invalid ones are provided

### API Integration
- Fetch project-specific work types when possible, fall back to global work types
- Fixed API request format from `{"type": {"name": "Development"}}` to `{"type": {"id": "168-0"}}`
- Added proper error handling for permission issues and invalid work types

### User Experience Improvements
- **Discovery**: Users can now run `yt time work-types` to see available options
- **Helpful Errors**: Invalid work types show all available types in error message
- **Flexible Input**: Case-insensitive work type matching for better UX
- **Backward Compatibility**: Existing commands without work-type continue to work

## Testing
- [x] Unit tests added for work type resolution functionality
- [x] Integration tests for new work-types command
- [x] Case-insensitive matching tests
- [x] Error handling validation tests
- [x] CLI command validation with test environment
- [x] All existing tests continue to pass

## Documentation
- [x] Updated time command documentation with new work-types command
- [x] Added work type resolution information and examples
- [x] Enhanced error handling documentation
- [x] Updated overview section with new capabilities

## Examples

### Before (failed):
```bash
yt time log DEMO-4 "30 mins" --work-type Development
# ERROR: YouTrack is unable to locate an WorkItemType-type entity unless its ID is also provided
```

### After (works):
```bash
# Discover available work types
yt time work-types
# ✅ Shows: Development, Testing, Documentation, Investigation, Implementation

# Log time with work type (case-insensitive)
yt time log DEMO-4 "30 mins" --work-type Development  # ✅ Works
yt time log DEMO-4 "30 mins" --work-type development  # ✅ Also works
yt time log DEMO-4 "30 mins" --work-type DEVELOPMENT  # ✅ Also works

# Invalid work type shows helpful error
yt time log DEMO-4 "30 mins" --work-type InvalidType
# ❌ Invalid work type 'InvalidType'. Available types: Development, Testing, Documentation, Investigation, Implementation
```

## Validation

✅ **CLI Testing Results**: All modified commands tested successfully with comprehensive validation
- Work type resolution working correctly
- New work-types command functioning properly  
- Error handling providing helpful messages
- Case-insensitive matching working as expected
- Backward compatibility maintained

Fixes #524

🤖 Generated with [Claude Code](https://claude.ai/code)