### PR TITLE
✨ Add attachment IDs to issues attach list command output (Fixes #521)

### DIFF
--- a/docs/commands/issues.rst
+++ b/docs/commands/issues.rst
@@ -391,12 +391,16 @@ Download Attachments
 List Attachments
 ~~~~~~~~~~~~~~~~
 
+List all attachments for an issue, displaying attachment IDs needed for download and delete operations.
+
 .. code-block:: bash
 
    yt issues attach list ISSUE_ID [OPTIONS]
 
 **Options:**
   * ``--format [table|json|csv]`` - Output format
+
+**Output:** Displays attachment ID, name, size, author, and creation date. The attachment ID can be used with the ``download`` and ``delete`` commands.
 
 Delete Attachments
 ~~~~~~~~~~~~~~~~~~

--- a/tests/managers/test_issues.py
+++ b/tests/managers/test_issues.py
@@ -669,7 +669,15 @@ class TestIssueManagerFormatting:
 
     def test_display_attachments_table(self, issue_manager):
         """Test displaying attachments table."""
-        attachments = [{"name": "test.txt", "size": 1234, "author": {"fullName": "Test User"}, "created": "2023-01-01"}]
+        attachments = [
+            {
+                "id": "attach-1",
+                "name": "test.txt",
+                "size": 1234,
+                "author": {"fullName": "Test User"},
+                "created": "2023-01-01",
+            }
+        ]
 
         issue_manager.display_attachments_table(attachments)
         issue_manager.console.print.assert_called_once()

--- a/youtrack_cli/commands/issues.py
+++ b/youtrack_cli/commands/issues.py
@@ -94,18 +94,19 @@ def _format_attachments_as_csv(attachments):
     import io
 
     if not attachments:
-        return "Name,Size,Author,Created\n"
+        return "ID,Name,Size,Author,Created\n"
 
     # Create CSV in memory
     output = io.StringIO()
     writer = csv.writer(output)
 
     # Write header
-    headers = ["Name", "Size", "Author", "Created"]
+    headers = ["ID", "Name", "Size", "Author", "Created"]
     writer.writerow(headers)
 
     # Write data rows
     for attachment in attachments:
+        attachment_id = attachment.get("id", "N/A")
         name = attachment.get("name", "N/A")
         size = attachment.get("size", "N/A")
 
@@ -116,7 +117,7 @@ def _format_attachments_as_csv(attachments):
 
         created = attachment.get("created", "")
 
-        row = [name, str(size), author_name, str(created)]
+        row = [str(attachment_id), name, str(size), author_name, str(created)]
         writer.writerow(row)
 
     return output.getvalue()

--- a/youtrack_cli/managers/issues.py
+++ b/youtrack_cli/managers/issues.py
@@ -841,19 +841,21 @@ class IssueManager:
 
         from rich.table import Table
 
-        table = Table(title="Issue Attachments")
+        table = Table(title="📎 Attachments")
+        table.add_column("ID", style="bright_black", no_wrap=True, width=10)
         table.add_column("Name", style="cyan", no_wrap=True)
         table.add_column("Size", style="blue")
         table.add_column("Author", style="green")
         table.add_column("Created", style="yellow")
 
         for attachment in attachments:
+            attachment_id = attachment.get("id", "N/A")
             name = attachment.get("name", "N/A")
             size = attachment.get("size", "N/A")
             author = attachment.get("author", {}).get("fullName", "Unknown")
             created = attachment.get("created", "")
 
-            table.add_row(name, str(size), author, str(created))
+            table.add_row(str(attachment_id), name, str(size), author, str(created))
 
         self.console.print(table)
 


### PR DESCRIPTION
## Summary

Adds attachment IDs to the `yt issues attach list` command output, enabling users to use the download and delete commands which require attachment IDs as parameters.

## Changes Made

- **Enhanced Table Display**: Added ID column as the first column with proper styling and fixed width
- **Updated CSV Format**: Added ID as the first column: `ID,Name,Size,Author,Created`
- **Improved UX**: Changed table title to "📎 Attachments" for better visual appeal
- **Updated Tests**: Modified test data to include ID field in attachment tests
- **Enhanced Documentation**: Updated docs to explain ID display functionality and usage

## Impact

Before this change, users could not use the download or delete commands because attachment IDs were not displayed:
- `yt issues attach download ISSUE-ID <attachment-id>` - unusable
- `yt issues attach delete ISSUE-ID <attachment-id>` - unusable

After this change, users can see attachment IDs and use them with these commands.

## Example Output

### Before:
```
Issue Attachments
┃ Name                ┃ Size ┃ Author ┃ Created       ┃
```

### After:
```
📎 Attachments
┃ ID         ┃ Name                ┃ Size ┃ Author ┃ Created       ┃
│ 12-15      │ test-attachment.txt │ 43   │ admin  │ 1754258351626 │
```

## Testing

- [x] Created test attachment and verified ID is displayed
- [x] Verified attachment ID can be used with download command
- [x] Tested all output formats (table, CSV, JSON)
- [x] All existing tests pass (1349 passed, 77 skipped)
- [x] Pre-commit hooks pass (linting, type checking, tests, docs)
- [x] 62.30% test coverage maintained

## Backward Compatibility

- ✅ JSON format already included IDs - no breaking changes
- ✅ CSV format enhanced with ID column as first field
- ✅ Table format enhanced with ID column as first field
- ✅ All existing functionality preserved

Fixes #521

🤖 Generated with [Claude Code](https://claude.ai/code)