### PR TITLE
♻️ Rename 'issues dependencies' to 'issues related' and show all relationship types dynamically (Fixes #519)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- ♻️ Rename 'issues dependencies' to 'issues related' and show all relationship types dynamically (#519)
+  - Rename command from `yt issues dependencies` to `yt issues related` for better clarity
+  - Dynamically fetch and display all relationship types from YouTrack instance
+  - Support custom relationship types specific to different YouTrack configurations
+  - Enhanced tree and table formats showing relationship directions (inward/outward)
+  - Maintain backward compatibility with `dependencies` as an alias
+  - Improved display with proper relationship type names (sourceToTarget/targetToSource)
 - ✨ Add CSV format support to yt issues attach list command (#505)
   - Implement CSV output formatting for attachment listings
   - Support for all three formats: table, json, and csv


### PR DESCRIPTION
## Summary

Rename the `yt issues dependencies` command to `yt issues related` to better reflect its purpose of showing all issue relationships, not just dependencies. The command now dynamically fetches and displays all relationship types from the YouTrack instance.

## Changes Made

- **Command Renamed**: `yt issues dependencies` → `yt issues related` for better clarity
- **Dynamic Relationship Types**: Fetches all available relationship types from YouTrack instance via `/api/issueLinkTypes` endpoint
- **Enhanced Display**: Shows all relationship types (not just dependencies) with proper directional names (sourceToTarget/targetToSource)
- **Improved Tree Format**: New `create_issue_relationships_tree()` function with relationship type grouping and direction indicators (← →)
- **Enhanced Table Format**: New `display_relationships_table()` method with relationship type grouping and direction symbols
- **Backward Compatibility**: Maintains `dependencies` as an alias so existing scripts continue to work
- **Custom Relationship Support**: Adapts to custom relationship types specific to different YouTrack configurations

## Test Plan

- [x] Unit tests passing (1349 passed, 77 skipped)
- [x] All linting, formatting, and type checking passed
- [x] Manual testing with `yt issues related FPU-1` 
- [x] Backward compatibility verified with `yt issues dependencies FPU-1`
- [x] Both tree and table formats tested
- [x] Command help text updated and verified
- [x] CHANGELOG.md updated with changes

## API Integration

The implementation leverages the existing YouTrack API integration:
- Uses `/api/issueLinkTypes` endpoint to fetch available relationship types
- Maps relationship type IDs to display appropriate names based on direction
- Handles both inward and outward relationships correctly
- Supports custom relationship types from different YouTrack instances

## Migration Notes

- **No Breaking Changes**: The `dependencies` command continues to work as an alias
- **Enhanced Functionality**: Users get more comprehensive relationship information
- **Dynamic Adaptation**: Works with any YouTrack instance configuration
- **Updated Documentation**: Help text reflects new dynamic capabilities

## Examples

```bash
# New command - shows all relationship types dynamically
yt issues related DEMO-123

# Backward compatibility - still works identically  
yt issues dependencies DEMO-123

# Enhanced table format with relationship grouping
yt issues related DEMO-123 --format table
```

This implementation provides a much more comprehensive view of issue relationships while maintaining full backward compatibility and adapting to different YouTrack instance configurations.

🤖 Generated with [Claude Code](https://claude.ai/code)