### PR TITLE
🔧 Simplify 'yt projects fields' command to only provide list functionality (Fixes #523)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Comprehensive validation and error handling
   - Enhanced command help with examples
 
+### Changed
+- 🔧 Simplify 'yt projects fields' command to only provide list functionality (#523)
+  - **BREAKING CHANGE**: Removed attach, update, and detach subcommands from `yt projects fields`
+  - Command now directly lists project fields: `yt projects fields PROJECT-ID`
+  - Field management operations should be performed through YouTrack web interface
+  - Simplified CLI interface reduces maintenance burden and prevents accidental field modifications
+  - Updated documentation to reflect read-only nature of field operations
+
 ### Fixed
 - 🐛 Fix documentation inconsistency: Update --confirm to --force in delete commands (#506)
 - 🐛 Fix JSON output pollution in issues attach list command (#502)

--- a/docs/commands/projects.rst
+++ b/docs/commands/projects.rst
@@ -251,16 +251,19 @@ Project Features
 Custom Fields Management
 ------------------------
 
-The ``yt projects fields`` command group provides comprehensive management of custom fields within projects. Custom fields extend the default issue properties and allow you to track additional information specific to your project needs.
+The ``yt projects fields`` command provides read-only access to view custom fields within projects. Custom fields extend the default issue properties and allow you to track additional information specific to your project needs.
 
-fields list
-~~~~~~~~~~~
+.. note::
+   Custom field management operations (attach, update, detach) should be performed through the YouTrack web interface. This command provides only listing functionality for viewing project field configurations.
+
+fields
+~~~~~~
 
 List all custom fields configured for a specific project.
 
 .. code-block:: bash
 
-   yt projects fields list PROJECT_ID [OPTIONS]
+   yt projects fields PROJECT_ID [OPTIONS]
 
 **Arguments:**
 
@@ -290,212 +293,31 @@ List all custom fields configured for a specific project.
 .. code-block:: bash
 
    # List all custom fields for a project
-   yt projects fields list FPU
-
+   yt projects fields FPU
 
    # List with specific fields and JSON format
-   yt projects fields list FPU --fields "id,field(name,fieldType),canBeEmpty" --format json
+   yt projects fields FPU --fields "id,field(name,fieldType),canBeEmpty" --format json
 
    # Limit results
-   yt projects fields list FPU --top 5
+   yt projects fields FPU --top 5
 
-fields attach
-~~~~~~~~~~~~~
+   # Output as JSON for automation
+   yt projects fields FPU --format json
 
-Attach an existing global custom field to a project.
-
-.. code-block:: bash
-
-   yt projects fields attach PROJECT_ID FIELD_ID [OPTIONS]
-
-**Arguments:**
-
-* ``PROJECT_ID`` - The project ID or short name (required)
-* ``FIELD_ID`` - The global custom field ID to attach (required)
-
-**Options:**
-
-.. list-table::
-   :widths: 20 20 60
-   :header-rows: 1
-
-   * - Option
-     - Type
-     - Description
-   * - ``--type``
-     - choice
-     - Type of project custom field (required)
-   * - ``--required``
-     - flag
-     - Make the field required (cannot be empty)
-   * - ``--empty-text``
-     - text
-     - Text to display when field is empty
-   * - ``--private``
-     - flag
-     - Make the field private (not visible to all users)
-
-**Field Types:**
-
-* ``EnumProjectCustomField`` - Single-select dropdown
-* ``MultiEnumProjectCustomField`` - Multi-select dropdown
-* ``SingleUserProjectCustomField`` - Single user selection
-* ``MultiUserProjectCustomField`` - Multiple user selection
-* ``SimpleProjectCustomField`` - Text/numeric fields
-* ``VersionProjectCustomField`` - Version fields
-* ``MultiVersionProjectCustomField`` - Multiple version fields
-* ``DateProjectCustomField`` - Date fields
-* ``IntegerProjectCustomField`` - Integer fields
-* ``FloatProjectCustomField`` - Float fields
-* ``BooleanProjectCustomField`` - Boolean fields
-
-**Examples:**
-
-.. code-block:: bash
-
-   # Attach a priority field as required
-   yt projects fields attach FPU field-priority-123 \
-     --type EnumProjectCustomField \
-     --required \
-     --empty-text "No priority set"
-
-   # Attach a private assignee field
-   yt projects fields attach FPU field-assignee-456 \
-     --type SingleUserProjectCustomField \
-     --private
-
-fields update
-~~~~~~~~~~~~~
-
-Update settings of a custom field already attached to a project.
-
-.. code-block:: bash
-
-   yt projects fields update PROJECT_ID FIELD_ID [OPTIONS]
-
-**Arguments:**
-
-* ``PROJECT_ID`` - The project ID or short name (required)
-* ``FIELD_ID`` - The project custom field ID to update (required)
-
-**Options:**
-
-.. list-table::
-   :widths: 20 20 60
-   :header-rows: 1
-
-   * - Option
-     - Type
-     - Description
-   * - ``--required/--optional``
-     - boolean
-     - Make the field required or optional
-   * - ``--empty-text``
-     - text
-     - Text to display when field is empty
-   * - ``--public/--private``
-     - boolean
-     - Make the field public or private
-
-**Examples:**
-
-.. code-block:: bash
-
-   # Make a field required
-   yt projects fields update FPU project-field-123 --required
-
-   # Update empty text and make private
-   yt projects fields update FPU project-field-123 \
-     --empty-text "Please specify" \
-     --private
-
-   # Make field optional
-   yt projects fields update FPU project-field-123 --optional
-
-fields detach
-~~~~~~~~~~~~~
-
-Remove a custom field from a project.
-
-.. code-block:: bash
-
-   yt projects fields detach PROJECT_ID FIELD_ID [OPTIONS]
-
-**Arguments:**
-
-* ``PROJECT_ID`` - The project ID or short name (required)
-* ``FIELD_ID`` - The project custom field ID to remove (required)
-
-**Options:**
-
-.. list-table::
-   :widths: 20 20 60
-   :header-rows: 1
-
-   * - Option
-     - Type
-     - Description
-   * - ``--force``
-     - flag
-     - Skip confirmation prompt
-
-**Examples:**
-
-.. code-block:: bash
-
-   # Remove a custom field (with confirmation)
-   yt projects fields detach FPU project-field-123
-
-   # Remove without confirmation
-   yt projects fields detach FPU project-field-123 --force
-
-Custom Fields Workflows
+Custom Fields Discovery
 ~~~~~~~~~~~~~~~~~~~~~~~
-
-**Project Setup with Custom Fields:**
-
-.. code-block:: bash
-
-   # 1. List current custom fields
-   yt projects fields list FPU
-
-   # 2. Attach required fields for project workflow
-   yt projects fields attach FPU priority-field-id \
-     --type EnumProjectCustomField \
-     --required \
-     --empty-text "Priority not set"
-
-   yt projects fields attach FPU assignee-field-id \
-     --type SingleUserProjectCustomField \
-     --empty-text "Unassigned"
-
-   # 3. Verify configuration
-   yt projects fields list FPU
-
-**Custom Fields Maintenance:**
-
-.. code-block:: bash
-
-   # Update field visibility
-   yt projects fields update FPU project-field-123 --private
-
-   # Change requirement status
-   yt projects fields update FPU project-field-456 --optional
-
-   # Update empty text for better UX
-   yt projects fields update FPU project-field-789 \
-     --empty-text "Please select a priority level"
-
-**Custom Fields Discovery:**
 
 .. code-block:: bash
 
    # Export custom fields configuration
-   yt projects fields list FPU --format json > project_fields.json
+   yt projects fields FPU --format json > project_fields.json
 
    # List only specific field attributes
-   yt projects fields list FPU \
+   yt projects fields FPU \
      --fields "field(name,fieldType),canBeEmpty,isPublic"
+
+   # View field types and requirements
+   yt projects fields FPU --fields "field(name),canBeEmpty,$type"
 
 Common Workflows
 ----------------

--- a/docs/custom-fields.rst
+++ b/docs/custom-fields.rst
@@ -136,18 +136,20 @@ The issues commands automatically handle custom fields for common use cases:
 Projects Commands
 -----------------
 
-Manage custom fields at the project level:
+View custom fields at the project level:
 
 .. code-block:: bash
 
     # List project custom fields
-    yt projects fields list PROJECT-ID
+    yt projects fields PROJECT-ID
 
-    # Attach a custom field to a project
-    yt projects fields attach PROJECT-ID FIELD-ID EnumProjectCustomField
+    # List with specific attributes in JSON format
+    yt projects fields PROJECT-ID --fields "field(name),canBeEmpty" --format json
 
-    # Update custom field settings
-    yt projects fields update PROJECT-ID FIELD-ID --can-be-empty false
+.. note::
+    Custom field management operations (attach, update, detach) should be performed
+    through the YouTrack web interface. The CLI provides read-only access for
+    viewing field configurations.
 
 Admin Commands
 --------------

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -830,152 +830,6 @@ class TestProjectCustomFields:
         assert result["status"] == "error"
         assert "Not authenticated" in result["message"]
 
-    @pytest.mark.asyncio
-    async def test_attach_custom_field_success(self, project_manager, auth_manager):
-        """Test successful custom field attachment."""
-        mock_attached_field = {
-            "id": "project-field-1",
-            "canBeEmpty": False,
-            "emptyFieldText": "Required field",
-            "isPublic": True,
-            "field": {
-                "id": "global-field-1",
-                "name": "Priority",
-            },
-        }
-
-        with patch("youtrack_cli.projects.get_client_manager") as mock_get_client_manager:
-            mock_response = Mock()
-            mock_response.json.return_value = mock_attached_field
-            mock_response.raise_for_status.return_value = None
-            mock_response.headers = {"content-type": "application/json"}
-            mock_response.text = '{"id": "project-field-1"}'
-            mock_response.status_code = 200
-
-            mock_client_manager = Mock()
-            mock_client_manager.make_request = AsyncMock(return_value=mock_response)
-            mock_get_client_manager.return_value = mock_client_manager
-
-            result = await project_manager.attach_custom_field(
-                project_id="TEST-PROJECT",
-                field_id="global-field-1",
-                field_type="EnumProjectCustomField",
-                can_be_empty=False,
-                empty_field_text="Required field",
-                is_public=True,
-            )
-
-            assert result["status"] == "success"
-            assert "attached" in result["message"]
-            assert result["data"]["field"]["name"] == "Priority"
-
-    @pytest.mark.asyncio
-    async def test_attach_custom_field_already_exists(self, project_manager, auth_manager):
-        """Test attaching a custom field that already exists."""
-        with patch("youtrack_cli.projects.get_client_manager") as mock_get_client_manager:
-            mock_response = Mock()
-            mock_response.status_code = 400
-
-            mock_client_manager = Mock()
-            mock_client_manager.make_request = AsyncMock(side_effect=httpx.HTTPError("Bad request"))
-            mock_get_client_manager.return_value = mock_client_manager
-
-            result = await project_manager.attach_custom_field(
-                project_id="TEST-PROJECT",
-                field_id="global-field-1",
-                field_type="EnumProjectCustomField",
-            )
-
-            assert result["status"] == "error"
-            assert "Invalid custom field data" in result["message"] or "HTTP error" in result["message"]
-
-    @pytest.mark.asyncio
-    async def test_update_custom_field_success(self, project_manager, auth_manager):
-        """Test successful custom field update."""
-        mock_updated_field = {
-            "id": "project-field-1",
-            "canBeEmpty": True,
-            "emptyFieldText": "Updated text",
-            "isPublic": False,
-            "field": {
-                "id": "global-field-1",
-                "name": "Priority",
-            },
-        }
-
-        with patch("youtrack_cli.projects.get_client_manager") as mock_get_client_manager:
-            mock_response = Mock()
-            mock_response.json.return_value = mock_updated_field
-            mock_response.raise_for_status.return_value = None
-            mock_response.headers = {"content-type": "application/json"}
-            mock_response.text = '{"id": "project-field-1"}'
-            mock_response.status_code = 200
-
-            mock_client_manager = Mock()
-            mock_client_manager.make_request = AsyncMock(return_value=mock_response)
-            mock_get_client_manager.return_value = mock_client_manager
-
-            result = await project_manager.update_custom_field(
-                project_id="TEST-PROJECT",
-                field_id="project-field-1",
-                can_be_empty=True,
-                empty_field_text="Updated text",
-                is_public=False,
-            )
-
-            assert result["status"] == "success"
-            assert "updated successfully" in result["message"]
-            assert result["data"]["emptyFieldText"] == "Updated text"
-
-    @pytest.mark.asyncio
-    async def test_update_custom_field_no_changes(self, project_manager, auth_manager):
-        """Test custom field update with no changes provided."""
-        result = await project_manager.update_custom_field(
-            project_id="TEST-PROJECT",
-            field_id="project-field-1",
-        )
-
-        assert result["status"] == "error"
-        assert "No updates provided" in result["message"]
-
-    @pytest.mark.asyncio
-    async def test_detach_custom_field_success(self, project_manager, auth_manager):
-        """Test successful custom field removal."""
-        with patch("youtrack_cli.projects.get_client_manager") as mock_get_client_manager:
-            mock_response = Mock()
-            mock_response.status_code = 200
-
-            mock_client_manager = Mock()
-            mock_client_manager.make_request = AsyncMock(return_value=mock_response)
-            mock_get_client_manager.return_value = mock_client_manager
-
-            result = await project_manager.detach_custom_field(
-                project_id="TEST-PROJECT",
-                field_id="project-field-1",
-            )
-
-            assert result["status"] == "success"
-            assert "removed" in result["message"]
-
-    @pytest.mark.asyncio
-    async def test_detach_custom_field_not_found(self, project_manager, auth_manager):
-        """Test removing a custom field that doesn't exist."""
-        with patch("youtrack_cli.projects.get_client_manager") as mock_get_client_manager:
-            mock_response = Mock()
-            mock_response.status_code = 404
-
-            mock_client_manager = Mock()
-            mock_client_manager.make_request = AsyncMock(side_effect=httpx.HTTPError("Not found"))
-            mock_get_client_manager.return_value = mock_client_manager
-
-            result = await project_manager.detach_custom_field(
-                project_id="TEST-PROJECT",
-                field_id="nonexistent-field",
-            )
-
-            assert result["status"] == "error"
-            assert "not found" in result["message"].lower()
-
     def test_display_custom_fields_table_empty(self):
         """Test displaying empty custom fields table."""
         auth_manager = Mock()
@@ -1089,37 +943,9 @@ class TestProjectCustomFieldsCLI:
         assert result.exit_code == 0
         assert "custom fields" in result.output.lower()
 
-    def test_projects_fields_list_help(self):
-        """Test projects fields list command help."""
-        runner = CliRunner()
-        result = runner.invoke(main, ["projects", "fields", "list", "--help"])
-        assert result.exit_code == 0
-        assert "List custom fields" in result.output
-
-    def test_projects_fields_attach_help(self):
-        """Test projects fields attach command help."""
-        runner = CliRunner()
-        result = runner.invoke(main, ["projects", "fields", "attach", "--help"])
-        assert result.exit_code == 0
-        assert "Attach an existing custom field" in result.output
-
-    def test_projects_fields_update_help(self):
-        """Test projects fields update command help."""
-        runner = CliRunner()
-        result = runner.invoke(main, ["projects", "fields", "update", "--help"])
-        assert result.exit_code == 0
-        assert "Update settings of a custom field" in result.output
-
-    def test_projects_fields_detach_help(self):
-        """Test projects fields detach command help."""
-        runner = CliRunner()
-        result = runner.invoke(main, ["projects", "fields", "detach", "--help"])
-        assert result.exit_code == 0
-        assert "Remove a custom field from a project" in result.output
-
     @patch("youtrack_cli.projects.ProjectManager")
-    def test_projects_fields_list_command(self, mock_project_manager_class):
-        """Test projects fields list command execution."""
+    def test_projects_fields_command(self, mock_project_manager_class):
+        """Test projects fields command execution."""
         mock_project_manager = Mock()
         mock_project_manager_class.return_value = mock_project_manager
 
@@ -1139,28 +965,6 @@ class TestProjectCustomFieldsCLI:
         with patch("asyncio.run", return_value=mock_result):
             with patch("youtrack_cli.auth.AuthManager"):
                 runner = CliRunner()
-                result = runner.invoke(main, ["projects", "fields", "list", "TEST-PROJECT"])
+                result = runner.invoke(main, ["projects", "fields", "TEST-PROJECT"])
 
                 assert result.exit_code in [0, 1]  # May fail on auth but command exists
-
-    @patch("youtrack_cli.projects.ProjectManager")
-    def test_projects_fields_attach_command(self, mock_project_manager_class):
-        """Test projects fields attach command execution."""
-        mock_project_manager = Mock()
-        mock_project_manager_class.return_value = mock_project_manager
-
-        mock_result = {
-            "status": "success",
-            "data": {"field": {"name": "Priority"}},
-            "message": "Custom field attached successfully",
-        }
-
-        with patch("asyncio.run", return_value=mock_result):
-            with patch("youtrack_cli.auth.AuthManager"):
-                runner = CliRunner()
-                result = runner.invoke(
-                    main,
-                    ["projects", "fields", "attach", "TEST-PROJECT", "field-123", "--type", "EnumProjectCustomField"],
-                )
-
-                assert result.exit_code in [0, 1]

--- a/youtrack_cli/commands/projects.py
+++ b/youtrack_cli/commands/projects.py
@@ -502,7 +502,8 @@ def archive(
         raise click.ClickException("Failed to archive project") from e
 
 
-@click.command(name="list")
+# Rename fields_list to just fields and make it a direct command
+@click.command(name="fields")
 @click.argument("project_id")
 @click.option(
     "--fields",
@@ -522,14 +523,29 @@ def archive(
     help="Output format",
 )
 @click.pass_context
-def fields_list(
+def fields_command(
     ctx: click.Context,
     project_id: str,
     fields: Optional[str],
     top: Optional[int],
     format: str,
 ) -> None:
-    """List custom fields for a project."""
+    """List custom fields for a project.
+
+    This command lists all custom fields attached to the specified project.
+    Field management operations (attach/update/detach) should be performed
+    through the YouTrack web interface.
+
+    Examples:
+        # List all custom fields for a project
+        yt projects fields PROJECT-ID
+
+        # List fields with specific attributes
+        yt projects fields PROJECT-ID --fields name,fieldType,canBeEmpty
+
+        # Output as JSON
+        yt projects fields PROJECT-ID --format json
+    """
     from ..managers.projects import ProjectManager
 
     console = get_console()
@@ -560,236 +576,5 @@ def fields_list(
         raise click.ClickException("Failed to list custom fields") from e
 
 
-@click.command(name="attach")
-@click.argument("project_id")
-@click.argument("field_id")
-@click.option(
-    "--type",
-    "field_type",
-    required=True,
-    type=click.Choice(
-        [
-            "EnumProjectCustomField",
-            "MultiEnumProjectCustomField",
-            "SingleUserProjectCustomField",
-            "MultiUserProjectCustomField",
-            "SimpleProjectCustomField",
-            "VersionProjectCustomField",
-            "MultiVersionProjectCustomField",
-            "DateProjectCustomField",
-            "IntegerProjectCustomField",
-            "FloatProjectCustomField",
-            "BooleanProjectCustomField",
-        ]
-    ),
-    help="Type of project custom field to create",
-)
-@click.option(
-    "--required",
-    is_flag=True,
-    help="Make the field required (cannot be empty)",
-)
-@click.option(
-    "--empty-text",
-    help="Text to display when field is empty",
-)
-@click.option(
-    "--private",
-    is_flag=True,
-    help="Make the field private (not visible to all users)",
-)
-@click.pass_context
-def fields_attach(
-    ctx: click.Context,
-    project_id: str,
-    field_id: str,
-    field_type: str,
-    required: bool,
-    empty_text: Optional[str],
-    private: bool,
-) -> None:
-    """Attach an existing custom field to a project.
-
-    PROJECT_ID: The project ID or short name
-    FIELD_ID: The global custom field ID to attach
-    """
-    from ..managers.projects import ProjectManager
-
-    console = get_console()
-    auth_manager = AuthManager(ctx.obj.get("config"))
-    project_manager = ProjectManager(auth_manager)
-
-    console.print(f"🔗 Attaching custom field '{field_id}' to project '{project_id}'...", style="blue")
-
-    try:
-        result = asyncio.run(
-            project_manager.attach_custom_field(
-                project_id=project_id,
-                field_id=field_id,
-                field_type=field_type,
-                can_be_empty=not required,
-                empty_field_text=empty_text,
-                is_public=not private,
-            )
-        )
-
-        if result["status"] == "success":
-            console.print(f"✅ {result['message']}", style="green")
-            field_data = result["data"]
-            field_name = field_data.get("field", {}).get("name", "N/A")
-            console.print(f"Field Name: {field_name}", style="blue")
-            console.print(f"Required: {'Yes' if not field_data.get('canBeEmpty', True) else 'No'}", style="blue")
-        else:
-            console.print(f"❌ {result['message']}", style="red")
-            raise click.ClickException("Failed to attach custom field")
-
-    except Exception as e:
-        console.print(f"❌ Error attaching custom field: {e}", style="red")
-        raise click.ClickException("Failed to attach custom field") from e
-
-
-@click.command(name="update")
-@click.argument("project_id")
-@click.argument("field_id")
-@click.option(
-    "--required/--optional",
-    default=None,
-    help="Make the field required or optional",
-)
-@click.option(
-    "--empty-text",
-    help="Text to display when field is empty",
-)
-@click.option(
-    "--public/--private",
-    default=None,
-    help="Make the field public or private",
-)
-@click.pass_context
-def fields_update(
-    ctx: click.Context,
-    project_id: str,
-    field_id: str,
-    required: Optional[bool],
-    empty_text: Optional[str],
-    public: Optional[bool],
-) -> None:
-    """Update settings of a custom field in a project.
-
-    PROJECT_ID: The project ID or short name
-    FIELD_ID: The project custom field ID to update
-    """
-    from ..managers.projects import ProjectManager
-
-    console = get_console()
-    auth_manager = AuthManager(ctx.obj.get("config"))
-    project_manager = ProjectManager(auth_manager)
-
-    if required is None and empty_text is None and public is None:
-        console.print("❌ No updates specified.", style="red")
-        console.print(
-            "Use --required/--optional, --empty-text, or --public/--private options.",
-            style="blue",
-        )
-        return
-
-    console.print(f"⚙️  Updating custom field '{field_id}' in project '{project_id}'...", style="blue")
-
-    try:
-        result = asyncio.run(
-            project_manager.update_custom_field(
-                project_id=project_id,
-                field_id=field_id,
-                can_be_empty=not required if required is not None else None,
-                empty_field_text=empty_text,
-                is_public=public,
-            )
-        )
-
-        if result["status"] == "success":
-            console.print(f"✅ {result['message']}", style="green")
-            field_data = result["data"]
-            field_name = field_data.get("field", {}).get("name", "N/A")
-            console.print(f"Field Name: {field_name}", style="blue")
-            console.print(f"Required: {'Yes' if not field_data.get('canBeEmpty', True) else 'No'}", style="blue")
-            console.print(f"Visibility: {'Public' if field_data.get('isPublic', True) else 'Private'}", style="blue")
-        else:
-            console.print(f"❌ {result['message']}", style="red")
-            raise click.ClickException("Failed to update custom field")
-
-    except Exception as e:
-        console.print(f"❌ Error updating custom field: {e}", style="red")
-        raise click.ClickException("Failed to update custom field") from e
-
-
-@click.command(name="detach")
-@click.argument("project_id")
-@click.argument("field_id")
-@click.option(
-    "--force",
-    is_flag=True,
-    help="Skip confirmation prompt",
-)
-@click.pass_context
-def fields_detach(
-    ctx: click.Context,
-    project_id: str,
-    field_id: str,
-    force: bool,
-) -> None:
-    """Remove a custom field from a project.
-
-    PROJECT_ID: The project ID or short name
-    FIELD_ID: The project custom field ID to remove
-    """
-    from ..managers.projects import ProjectManager
-
-    console = get_console()
-    auth_manager = AuthManager(ctx.obj.get("config"))
-    project_manager = ProjectManager(auth_manager)
-
-    if not force:
-        confirmation_msg = f"Are you sure you want to remove custom field '{field_id}' from project '{project_id}'?"
-        if not click.confirm(confirmation_msg):
-            console.print("Operation cancelled.", style="yellow")
-            return
-
-    console.print(f"🗑️  Removing custom field '{field_id}' from project '{project_id}'...", style="blue")
-
-    try:
-        result = asyncio.run(project_manager.detach_custom_field(project_id, field_id))
-
-        if result["status"] == "success":
-            console.print(f"✅ {result['message']}", style="green")
-        else:
-            console.print(f"❌ {result['message']}", style="red")
-            raise click.ClickException("Failed to remove custom field")
-
-    except Exception as e:
-        console.print(f"❌ Error removing custom field: {e}", style="red")
-        raise click.ClickException("Failed to remove custom field") from e
-
-
-# Create a simple fields group
-@click.group()
-def fields() -> None:
-    """Manage project custom fields.
-
-    This command group provides access to project custom field operations
-    including listing, attaching, updating, and removing custom fields.
-
-    Example:
-        yt projects fields list PROJECT-ID
-        yt projects fields attach PROJECT-ID FIELD-ID
-    """
-    pass
-
-
-# Add all the commands to the group
-fields.add_command(fields_list)
-fields.add_command(fields_attach)
-fields.add_command(fields_update)
-fields.add_command(fields_detach)
-
-# Add the fields command group to the projects group
-projects.add_command(fields)
+# Add the fields command directly to the projects group
+projects.add_command(fields_command)


### PR DESCRIPTION
## Summary

This PR implements issue #523 by simplifying the `yt projects fields` command group to only provide listing functionality, removing the attach/update/detach subcommands.

## Changes Made

- **BREAKING CHANGE**: Removed `attach`, `update`, and `detach` subcommands from `yt projects fields`
- Simplified command structure from `yt projects fields list PROJECT-ID` to `yt projects fields PROJECT-ID`
- Updated help text and documentation to reflect read-only nature of field operations
- Removed corresponding tests for deleted subcommands
- Updated documentation in `docs/commands/projects.rst` and `docs/custom-fields.rst`
- Added breaking change entry to `CHANGELOG.md`

## Benefits

- Simpler, more focused CLI interface
- Reduces maintenance burden by removing complex field management operations
- Prevents accidental field modifications through CLI
- Field management operations should now be performed through YouTrack web interface

## Testing

- ✅ All existing tests pass (1338 passed, 77 skipped)
- ✅ CLI testing agent validated all functionality works correctly
- ✅ Pre-commit hooks pass (linting, formatting, type checking)
- ✅ Documentation builds successfully
- ✅ Removed commands properly return error messages
- ✅ New simplified command structure works as expected

## Breaking Change Notice

Users currently using the following commands will need to use the YouTrack web interface instead:
- `yt projects fields attach PROJECT-ID FIELD-ID --type TYPE`
- `yt projects fields update PROJECT-ID FIELD-ID [OPTIONS]`
- `yt projects fields detach PROJECT-ID FIELD-ID`

The new command structure is:
- `yt projects fields PROJECT-ID [OPTIONS]` (previously `yt projects fields list PROJECT-ID`)

🤖 Generated with [Claude Code](https://claude.ai/code)