### PR TITLE
🐛 Fix yt projects fields --fields parameter showing N/A in Name column (Fixes #545)

### DIFF
--- a/youtrack_cli/services/projects.py
+++ b/youtrack_cli/services/projects.py
@@ -304,7 +304,18 @@ class ProjectService(BaseService):
         try:
             params = {}
             if fields:
-                params["fields"] = fields
+                # Always include field(name) for table display when custom fields are specified
+                # This ensures the name is available even when users specify their own fields
+                fields_list = [f.strip() for f in fields.split(",")]
+
+                # Check if field(name) is already included in some form
+                has_field_name = any("field(" in f and "name" in f for f in fields_list)
+
+                if not has_field_name:
+                    # Add field(name) to ensure name is always available for display
+                    fields_list.append("field(name)")
+
+                params["fields"] = ",".join(fields_list)
             else:
                 params["fields"] = "id,field(name,fieldType),canBeEmpty,isPublic,ordinal"
 


### PR DESCRIPTION
## Summary

Fixes issue where using the `--fields` parameter with the `yt projects fields` command caused the Name column to display 'N/A' instead of actual field names.

## Problem Description

When users specified custom fields using `--fields name,fieldType,canBeEmpty`, the API response didn't include the nested `field(name)` structure that the display method expects, resulting in 'N/A' appearing in the Name column.

## Root Cause

The issue occurred because:
1. Default behavior includes `field(name,fieldType)` in the API request
2. Custom `--fields` parameter completely replaced the default fields
3. Without `field(name)`, the response lacked the nested structure containing field names
4. Display method expected `field.name` but found an empty or missing field object

## Solution

Automatically append `field(name)` to user-specified fields when:
- User provides custom `--fields` parameter
- The specified fields don't already include `field(...)` with `name`

This ensures field names are always available for table display while preserving backward compatibility.

## Changes Made

- Modified `get_project_custom_fields()` in `services/projects.py`
- Added logic to detect if `field(name)` is missing from custom field lists
- Automatically append `field(name)` when needed for display purposes
- Preserves all existing functionality and API behavior

## Testing

- ✅ Tested with `--fields name,fieldType,canBeEmpty` - now shows field names correctly
- ✅ Tested without `--fields` parameter - maintains existing behavior
- ✅ Tested with `--fields 'field(name),canBeEmpty'` - handles existing correct syntax
- ✅ Tested with JSON format - includes proper nested field structure
- ✅ All existing tests pass
- ✅ Pre-commit checks pass

## Before/After

**Before (showing N/A):**
```
       Project Custom Fields        
┏━━━━━━┳━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┓
┃ Name ┃ Type  ┃ Required ┃ Public ┃
┡━━━━━━╇━━━━━━━╇━━━━━━━━━━╇━━━━━━━━┩
│ N/A  │ Enum  │ Yes      │ Yes    │
│ N/A  │ State │ Yes      │ Yes    │
│ N/A  │ Enum  │ Yes      │ Yes    │
│ N/A  │ User  │ No       │ Yes    │
└──────┴───────┴──────────┴────────┘
```

**After (showing actual field names):**
```
           Project Custom Fields            
┏━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┓
┃ Name         ┃ Type  ┃ Required ┃ Public ┃
┡━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━╇━━━━━━━━┩
│ Kanban State │ Enum  │ Yes      │ Yes    │
│ Stage        │ State │ Yes      │ Yes    │
│ Priority     │ Enum  │ Yes      │ Yes    │
│ Assignee     │ User  │ No       │ Yes    │
└──────────────┴───────┴──────────┴────────┘
```

## Compatibility

- ✅ Backward compatible with existing scripts and workflows  
- ✅ No breaking changes to API or command interface
- ✅ Improves user experience by making intuitive field specs work correctly

Fixes #545

🤖 Generated with [Claude Code](https://claude.ai/code)