### PR TITLE
✅ Implement article comments update command (Fixes #511)

### DIFF
--- a/docs/commands/articles.rst
+++ b/docs/commands/articles.rst
@@ -539,19 +539,27 @@ List comments on an article.
 comments update
 ~~~~~~~~~~~~~~~
 
-Update an existing comment (not yet implemented).
+Update an existing comment on an article.
 
 .. code-block:: bash
 
-   yt articles comments update COMMENT_ID TEXT
+   yt articles comments update ARTICLE_ID COMMENT_ID TEXT
 
 **Arguments:**
 
-* ``COMMENT_ID`` - The ID of the comment (required)
+* ``ARTICLE_ID`` - The ID of the article containing the comment (required)
+* ``COMMENT_ID`` - The ID of the comment to update (required)
 * ``TEXT`` - The new comment text (required)
 
-.. note::
-   This functionality is not yet implemented and requires additional API endpoints.
+**Example:**
+
+.. code-block:: bash
+
+   yt articles comments update FPU-A-1 8-0 "This is my updated comment text"
+
+**Permissions:**
+
+Requires "Update Comment" permission for your own comments or "Update Not Own Comment" permission for comments by other users.
 
 comments delete
 ~~~~~~~~~~~~~~~

--- a/youtrack_cli/articles.py
+++ b/youtrack_cli/articles.py
@@ -613,6 +613,35 @@ class ArticleManager:
         except Exception as e:
             return {"status": "error", "message": str(e)}
 
+    async def update_comment(self, article_id: str, comment_id: str, text: str) -> dict[str, Any]:
+        """Update an existing comment on an article."""
+        credentials = self.auth_manager.load_credentials()
+        if not credentials:
+            return {
+                "status": "error",
+                "message": "Not authenticated. Run 'yt auth login' first.",
+            }
+
+        comment_data = {"text": text}
+
+        url = f"{credentials.base_url.rstrip('/')}/api/articles/{article_id}/comments/{comment_id}"
+        headers = {
+            "Authorization": f"Bearer {credentials.token}",
+            "Content-Type": "application/json",
+        }
+
+        try:
+            client_manager = get_client_manager()
+            response = await client_manager.make_request("POST", url, headers=headers, json_data=comment_data)
+            data = self._safe_json_parse(response)
+            return {
+                "status": "success",
+                "message": "Comment updated successfully",
+                "data": data,
+            }
+        except Exception as e:
+            return {"status": "error", "message": str(e)}
+
     async def get_article_attachments(self, article_id: str) -> dict[str, Any]:
         """Get attachments for an article."""
         credentials = self.auth_manager.load_credentials()

--- a/youtrack_cli/commands/articles.py
+++ b/youtrack_cli/commands/articles.py
@@ -938,14 +938,32 @@ def list_comments(
 
 
 @comments.command(name="update")
+@click.argument("article_id")
 @click.argument("comment_id")
 @click.argument("text")
 @click.pass_context
-def update_comment(ctx: click.Context, comment_id: str, text: str) -> None:
+def update_comment(ctx: click.Context, article_id: str, comment_id: str, text: str) -> None:
     """Update an existing comment."""
+    from ..articles import ArticleManager
+
     console = get_console()
-    console.print("⚠️  Comment update functionality not yet implemented", style="yellow")
-    console.print("This feature requires additional API endpoints", style="blue")
+    auth_manager = AuthManager(ctx.obj.get("config"))
+    article_manager = ArticleManager(auth_manager)
+
+    console.print(f"💬 Updating comment '{comment_id}' on article '{article_id}'...", style="blue")
+
+    try:
+        result = asyncio.run(article_manager.update_comment(article_id, comment_id, text))
+
+        if result["status"] == "success":
+            console.print(f"✅ {result['message']}", style="green")
+        else:
+            console.print(f"❌ {result['message']}", style="red")
+            raise click.ClickException("Failed to update comment")
+
+    except Exception as e:
+        console.print(f"❌ Error updating comment: {e}", style="red")
+        raise click.ClickException("Failed to update comment") from e
 
 
 @comments.command(name="delete")


### PR DESCRIPTION
## Summary

Implemented the previously placeholder `yt articles comments update` command with full functionality to update existing article comments using the YouTrack REST API.

## Changes Made

- **API Integration**: Added `update_comment(article_id, comment_id, text)` method to `ArticleManager` using POST `/api/articles/{articleID}/comments/{commentID}` endpoint
- **CLI Command**: Updated command signature from `COMMENT_ID TEXT` to `ARTICLE_ID COMMENT_ID TEXT` to match API requirements
- **Implementation**: Replaced "not yet implemented" placeholder with fully functional async implementation
- **Error Handling**: Added comprehensive error handling for authentication, invalid IDs, and API errors
- **Documentation**: Updated `docs/commands/articles.rst` with correct syntax, examples, and permissions requirements

## API Research

✅ Confirmed YouTrack API supports comment updates via `POST /api/articles/{articleID}/comments/{commentID}`
✅ Requires "Update Comment" permission for own comments or "Update Not Own Comment" permission
✅ Request body format: `{"text": "new comment text"}`
✅ Comment IDs remain stable after updates (no ID change)

## Testing

- [x] Basic functionality tested against local YouTrack instance
- [x] Error handling validated (invalid article/comment IDs, authentication)
- [x] Integration with existing `yt articles comments list` and `add` commands verified
- [x] CLI testing agent confirmed all functionality works correctly
- [x] All pre-commit checks pass (linting, type checking, tests, documentation build)
- [x] Manual testing confirms successful comment updates

## Breaking Changes

⚠️ **Command signature changed** from `yt articles comments update COMMENT_ID TEXT` to `yt articles comments update ARTICLE_ID COMMENT_ID TEXT`

This is technically a breaking change, but since the command was never functional (always showed "not yet implemented"), no existing workflows are affected.

## Documentation

- [x] Updated `docs/commands/articles.rst` with new syntax and examples
- [x] Added permissions requirements and usage guidance
- [x] Example command: `yt articles comments update FPU-A-1 8-0 "Updated comment text"`

Fixes #511

🤖 Generated with [Claude Code](https://claude.ai/code)