### PR TITLE
✨ Implement article attachment delete functionality (Fixes #514)

### DIFF
--- a/youtrack_cli/articles.py
+++ b/youtrack_cli/articles.py
@@ -1212,3 +1212,31 @@ class ArticleManager:
                 "status": "error",
                 "message": f"Error downloading attachment: {str(e)}",
             }
+
+    async def delete_attachment(self, article_id: str, attachment_id: str) -> dict[str, Any]:
+        """Delete an attachment from an article."""
+        credentials = self.auth_manager.load_credentials()
+        if not credentials:
+            return {
+                "status": "error",
+                "message": "Not authenticated. Run 'yt auth login' first.",
+            }
+
+        url = f"{credentials.base_url.rstrip('/')}/api/articles/{article_id}/attachments/{attachment_id}"
+        headers = {"Authorization": f"Bearer {credentials.token}"}
+
+        try:
+            client_manager = get_client_manager()
+            response = await client_manager.make_request("DELETE", url, headers=headers)
+            if response.status_code in [200, 204]:
+                return {
+                    "status": "success",
+                    "message": f"Attachment '{attachment_id}' deleted successfully from article '{article_id}'",
+                }
+            else:
+                return {
+                    "status": "error",
+                    "message": f"Failed to delete attachment: HTTP {response.status_code} - {response.text}",
+                }
+        except Exception as e:
+            return {"status": "error", "message": f"Error deleting attachment: {str(e)}"}

--- a/youtrack_cli/commands/articles.py
+++ b/youtrack_cli/commands/articles.py
@@ -1187,15 +1187,31 @@ def list_attachments(
 @click.pass_context
 def delete_attachment(ctx: click.Context, article_id: str, attachment_id: str, force: bool) -> None:
     """Delete an attachment from an article."""
+    from ..articles import ArticleManager
+
     console = get_console()
+    auth_manager = AuthManager(ctx.obj.get("config"))
+    article_manager = ArticleManager(auth_manager)
 
     if not force:
         if not click.confirm(f"Are you sure you want to delete attachment '{attachment_id}'?"):
             console.print("Delete cancelled.", style="yellow")
             return
 
-    console.print("⚠️  Attachment delete functionality not yet implemented", style="yellow")
-    console.print("This feature requires additional API endpoints", style="blue")
+    console.print(f"🗑️  Deleting attachment '{attachment_id}' from article '{article_id}'...", style="blue")
+
+    try:
+        result = asyncio.run(article_manager.delete_attachment(article_id, attachment_id))
+
+        if result["status"] == "success":
+            console.print(f"✅ {result['message']}", style="green")
+        else:
+            console.print(f"❌ {result['message']}", style="red")
+            raise click.ClickException("Failed to delete attachment")
+
+    except Exception as e:
+        console.print(f"❌ Error deleting attachment: {e}", style="red")
+        raise click.ClickException("Failed to delete attachment") from e
 
 
 def _sort_articles(


### PR DESCRIPTION
## Summary

Implements the article attachment delete functionality that was previously showing a "not yet implemented" message. After investigating the YouTrack API documentation, I found that the `DELETE /api/articles/{articleID}/attachments/{attachmentID}` endpoint is available and functional.

## Changes Made

- **Added `delete_attachment` method to `ArticleManager` class** (`articles.py:1216-1242`)
  - Uses `DELETE /api/articles/{articleID}/attachments/{attachmentID}` endpoint
  - Handles HTTP response codes (200, 204) for successful deletion
  - Provides comprehensive error handling and user feedback

- **Updated CLI command implementation** (`commands/articles.py:1179-1214`)
  - Replaced "not yet implemented" placeholder with actual functionality
  - Integrated with new `ArticleManager.delete_attachment` method
  - Maintains existing confirmation prompt with `--force` flag support
  - Provides clear success/error messaging with emojis

## Testing

- ✅ All existing tests pass
- ✅ Pre-commit hooks pass (linting, type checking, etc.)
- ✅ Manual testing completed:
  - Listed attachments on article FPU-A-1: found attachment ID 506-0
  - Successfully deleted attachment using `yt articles attach delete FPU-A-1 506-0 --force`
  - Verified deletion by listing attachments again: "No attachments found"
  - Help command works correctly: `yt articles attach delete --help`

## Command Usage

```bash
# Delete with confirmation prompt
yt articles attach delete ARTICLE_ID ATTACHMENT_ID

# Delete without confirmation prompt
yt articles attach delete ARTICLE_ID ATTACHMENT_ID --force

# Show help
yt articles attach delete --help
```

## API Investigation Results

The YouTrack REST API **does support** deleting article attachments via:
- **Endpoint**: `DELETE /api/articles/{articleID}/attachments/{attachmentID}`
- **Permissions**: Author can always delete their attachment, or "Delete Attachment" permission required
- **Response**: HTTP 200/204 for successful deletion

This resolves the investigation request in the issue and provides complete CRUD functionality for article attachments.

Fixes #514

🤖 Generated with [Claude Code](https://claude.ai/code)