### PR TITLE
✨ Remove deprecated admin commands and add i18n list alias (Fixes #553, #554, #555, #556, #557)

### DIFF
--- a/docs/commands/admin.rst
+++ b/docs/commands/admin.rst
@@ -32,86 +32,31 @@ Base Command
 Global Settings Management
 --------------------------
 
-global-settings get
-~~~~~~~~~~~~~~~~~~
+.. note::
+   The global-settings commands have been deprecated and are no longer available.
+   Use the global-settings list command to view settings.
 
-Retrieve global YouTrack settings and configuration values.
+global-settings list
+~~~~~~~~~~~~~~~~~~~~
+
+List all global YouTrack settings.
 
 .. code-block:: bash
 
-   yt admin global-settings get [SETTING_KEY]
-
-**Arguments:**
-
-* ``SETTING_KEY`` - Specific setting key to retrieve (optional, if omitted returns all settings)
+   yt admin global-settings list
 
 **Examples:**
 
 .. code-block:: bash
 
-   # Get all global settings
-   yt admin global-settings get
-
-   # Get a specific setting
-   yt admin global-settings get server.name
-
-   # Get server configuration
-   yt admin global-settings get server.maxUploadFileSize
-
-   # Get authentication settings
-   yt admin global-settings get auth.sessionTimeout
-
-global-settings set
-~~~~~~~~~~~~~~~~~~
-
-Set or update global YouTrack settings.
-
-.. code-block:: bash
-
-   yt admin global-settings set SETTING_KEY VALUE
-
-**Arguments:**
-
-* ``SETTING_KEY`` - The setting key to update (required)
-* ``VALUE`` - The new value for the setting (required)
-
-**Examples:**
-
-.. code-block:: bash
-
-   # Set server name
-   yt admin global-settings set server.name "My YouTrack Instance"
-
-   # Set maximum upload file size
-   yt admin global-settings set server.maxUploadFileSize "50MB"
-
-   # Configure session timeout
-   yt admin global-settings set auth.sessionTimeout "3600"
-
-   # Set email notification settings
-   yt admin global-settings set notifications.enabled "true"
+   # List all global settings
+   yt admin global-settings list
 
 License Management
 -----------------
 
-license show
-~~~~~~~~~~~
-
-Display comprehensive license information including expiration, features, and usage limits.
-
-.. code-block:: bash
-
-   yt admin license show
-
-**Examples:**
-
-.. code-block:: bash
-
-   # Display license information
-   yt admin license show
-
-   # Review license before renewal
-   yt admin license show
+.. note::
+   The license show command has been deprecated and is no longer available.
 
 license usage
 ~~~~~~~~~~~~
@@ -135,45 +80,15 @@ Show detailed license usage statistics and capacity information.
 System Maintenance
 ------------------
 
-maintenance clear-cache
-~~~~~~~~~~~~~~~~~~~~~~
-
 .. note::
-   This command is not functional as cache clearing is not available through the YouTrack REST API.
+   The maintenance clear-cache command has been deprecated and is no longer available.
    Cache management must be performed through:
 
    * The YouTrack administrative UI
    * Server restart procedures
    * Direct server access
 
-   Please consult your YouTrack administrator or the JetBrains support team for alternative methods.
-
-.. code-block:: bash
-
-   yt admin maintenance clear-cache [OPTIONS]
-
-**Options:**
-
-.. list-table::
-   :widths: 20 20 60
-   :header-rows: 1
-
-   * - Option
-     - Type
-     - Description
-   * - ``--force``
-     - flag
-     - Skip confirmation prompt
-
-**Examples:**
-
-.. code-block:: bash
-
-   # Attempting to clear caches will show an informative error message
-   yt admin maintenance clear-cache
-
-   # The command will explain that this functionality is not available
-   yt admin maintenance clear-cache --force
+   Please consult your YouTrack administrator or the JetBrains support team for cache management.
 
 System Health Monitoring
 ------------------------
@@ -315,6 +230,31 @@ List all custom fields configured across YouTrack projects.
    # List field types and usage
    yt admin fields list --fields "name,fieldType(presentation),projects(name)"
 
+Internationalization (i18n) Management
+--------------------------------------
+
+i18n list
+~~~~~~~~~
+
+List available locales for internationalization. This command is an alias for ``yt admin locale list``.
+
+.. code-block:: bash
+
+   yt admin i18n list
+
+**Examples:**
+
+.. code-block:: bash
+
+   # List all available locales
+   yt admin i18n list
+
+   # Same functionality as locale list
+   yt admin locale list
+
+.. note::
+   This command provides the same functionality as ``yt admin locale list`` for consistency with other i18n commands.
+
 Administrative Features
 ----------------------
 
@@ -400,7 +340,7 @@ System Health Monitoring
    # Check license status
    echo ""
    echo "=== License Status ==="
-   yt admin license show
+   yt admin license usage
 
    # Check license usage
    echo ""
@@ -417,7 +357,7 @@ Regular Maintenance
 
    # Note: Cache clearing is not available through the REST API
    echo "Cache clearing must be done through the YouTrack UI or server tools"
-   # yt admin maintenance clear-cache --force  # This will show an informative error
+   # Cache clearing commands have been deprecated
 
    # Health check after maintenance
    echo "Post-maintenance health check..."
@@ -454,19 +394,12 @@ System Configuration
    # Configure system settings for new installation
    echo "Configuring YouTrack system settings..."
 
-   # Set basic server information
-   yt admin global-settings set server.name "Company YouTrack"
-   yt admin global-settings set server.maxUploadFileSize "100MB"
-
-   # Configure authentication
-   yt admin global-settings set auth.sessionTimeout "7200"
-
-   # Enable notifications
-   yt admin global-settings set notifications.enabled "true"
+   # Note: Global settings configuration commands have been deprecated
+   echo "System settings must be configured through the YouTrack web interface"
 
    # Verify configuration
    echo "Verifying configuration..."
-   yt admin global-settings get
+   yt admin global-settings list
 
 License Monitoring
 ~~~~~~~~~~~~~~~~~
@@ -481,11 +414,8 @@ License Monitoring
    echo ""
 
    # Get license information
-   LICENSE_INFO=$(yt admin license show)
    USAGE_INFO=$(yt admin license usage)
 
-   echo "$LICENSE_INFO"
-   echo ""
    echo "$USAGE_INFO"
 
    # Alert if usage is high (example threshold: 80%)
@@ -589,7 +519,7 @@ System Diagnostics
 
    # Check license status
    echo "3. License status..."
-   yt admin license show
+   yt admin license usage
 
    echo "Diagnostics completed"
 
@@ -611,8 +541,7 @@ Error Recovery
 
    # Check critical settings
    echo "Verifying critical settings..."
-   yt admin global-settings get server.name
-   yt admin global-settings get auth.sessionTimeout
+   yt admin global-settings list
 
 Integration Examples
 -------------------
@@ -648,7 +577,7 @@ Backup Integration
    mkdir -p "$BACKUP_DIR"
 
    # Export global settings
-   yt admin global-settings get > "$BACKUP_DIR/global_settings.txt"
+   yt admin global-settings list > "$BACKUP_DIR/global_settings.txt"
 
    # Export user groups
    yt admin user-groups list --fields "id,name,description" > "$BACKUP_DIR/user_groups.txt"

--- a/youtrack_cli/main.py
+++ b/youtrack_cli/main.py
@@ -376,83 +376,6 @@ def groups_create(ctx: click.Context, name: str, description: Optional[str]) -> 
     asyncio.run(run_create_group())
 
 
-@main.group()
-def settings() -> None:
-    """Manage global YouTrack settings.
-
-    This is a flatter alternative to 'yt admin global-settings'.
-    You can also use 'yt admin global-settings' for the same functionality.
-    """
-    pass
-
-
-@settings.command(name="get")
-@click.option("--name", "-n", help="Specific setting name to retrieve")
-@click.pass_context
-def settings_get(ctx: click.Context, name: Optional[str]) -> None:
-    """Get global settings."""
-    auth_manager = AuthManager(ctx.obj.get("config"))
-    admin_manager = AdminManager(auth_manager)
-    console = get_console()
-
-    async def run_get_settings() -> None:
-        result = await admin_manager.get_global_settings(name)
-
-        if result["status"] == "error":
-            console.print(f"[red]Error:[/red] {result['message']}")
-            return
-
-        settings = result["data"]
-        if name:
-            admin_manager.display_global_settings(settings)
-        else:
-            admin_manager.display_global_settings(settings)
-
-    asyncio.run(run_get_settings())
-
-
-@settings.command(name="set")
-@click.argument("name")
-@click.argument("value")
-@click.pass_context
-def settings_set(ctx: click.Context, name: str, value: str) -> None:
-    """Set a global setting."""
-    auth_manager = AuthManager(ctx.obj.get("config"))
-    admin_manager = AdminManager(auth_manager)
-    console = get_console()
-
-    async def run_set_setting() -> None:
-        result = await admin_manager.set_global_setting(name, value)
-
-        if result["status"] == "error":
-            console.print(f"[red]Error:[/red] {result['message']}")
-            return
-
-        console.print(f"[green]Success:[/green] {result['message']}")
-
-    asyncio.run(run_set_setting())
-
-
-@settings.command(name="list")
-@click.pass_context
-def settings_list(ctx: click.Context) -> None:
-    """List all global settings."""
-    auth_manager = AuthManager(ctx.obj.get("config"))
-    admin_manager = AdminManager(auth_manager)
-    console = get_console()
-
-    async def run_list_settings() -> None:
-        result = await admin_manager.get_global_settings()
-
-        if result["status"] == "error":
-            console.print(f"[red]Error:[/red] {result['message']}")
-            return
-
-        admin_manager.display_global_settings(result["data"])
-
-    asyncio.run(run_list_settings())
-
-
 @main.command(name="audit")
 @click.option(
     "--limit",
@@ -2101,54 +2024,6 @@ def global_settings() -> None:
     pass
 
 
-@global_settings.command(name="get")
-@click.option("--name", "-n", help="Specific setting name to retrieve")
-@click.pass_context
-def get_settings(ctx: click.Context, name: Optional[str]) -> None:
-    """Get global settings."""
-    auth_manager = AuthManager(ctx.obj.get("config"))
-    admin_manager = AdminManager(auth_manager)
-    console = get_console()
-
-    async def run_get_settings() -> None:
-        result = await admin_manager.get_global_settings(name)
-
-        if result["status"] == "error":
-            console.print(f"[red]Error:[/red] {result['message']}")
-            return
-
-        settings = result["data"]
-        if name:
-            # For specific setting requests, the data should be the setting itself
-            admin_manager.display_global_settings(settings)
-        else:
-            admin_manager.display_global_settings(settings)
-
-    asyncio.run(run_get_settings())
-
-
-@global_settings.command(name="set")
-@click.argument("name")
-@click.argument("value")
-@click.pass_context
-def set_setting(ctx: click.Context, name: str, value: str) -> None:
-    """Set a global setting."""
-    auth_manager = AuthManager(ctx.obj.get("config"))
-    admin_manager = AdminManager(auth_manager)
-    console = get_console()
-
-    async def run_set_setting() -> None:
-        result = await admin_manager.set_global_setting(name, value)
-
-        if result["status"] == "error":
-            console.print(f"[red]Error:[/red] {result['message']}")
-            return
-
-        console.print(f"[green]Success:[/green] {result['message']}")
-
-    asyncio.run(run_set_setting())
-
-
 @global_settings.command(name="list")
 @click.pass_context
 def list_settings(ctx: click.Context) -> None:
@@ -2177,26 +2052,6 @@ def license() -> None:
 
 @license.command()
 @click.pass_context
-def show(ctx: click.Context) -> None:
-    """Display license information."""
-    auth_manager = AuthManager(ctx.obj.get("config"))
-    admin_manager = AdminManager(auth_manager)
-    console = get_console()
-
-    async def run_license_info() -> None:
-        result = await admin_manager.get_license_info()
-
-        if result["status"] == "error":
-            console.print(f"[red]Error:[/red] {result['message']}")
-            return
-
-        admin_manager.display_license_info(result["data"])
-
-    asyncio.run(run_license_info())
-
-
-@license.command()
-@click.pass_context
 def usage(ctx: click.Context) -> None:
     """Show license usage statistics."""
     auth_manager = AuthManager(ctx.obj.get("config"))
@@ -2219,33 +2074,6 @@ def usage(ctx: click.Context) -> None:
 def maintenance() -> None:
     """System maintenance operations."""
     pass
-
-
-@maintenance.command(name="clear-cache")
-@click.option("--force", is_flag=True, help="Skip confirmation prompt")
-@click.pass_context
-def clear_cache(ctx: click.Context, force: bool) -> None:
-    """Clear system caches."""
-    auth_manager = AuthManager(ctx.obj.get("config"))
-    admin_manager = AdminManager(auth_manager)
-    console = get_console()
-
-    if not force:
-        console.print("[yellow]Warning:[/yellow] This will clear all system caches.")
-        if not click.confirm("Continue?"):
-            console.print("Operation cancelled.")
-            return
-
-    async def run_clear_cache() -> None:
-        result = await admin_manager.clear_caches()
-
-        if result["status"] == "error":
-            console.print(f"[red]Error:[/red] {result['message']}")
-            return
-
-        console.print(f"[green]Success:[/green] {result['message']}")
-
-    asyncio.run(run_clear_cache())
 
 
 @admin.group()
@@ -2446,6 +2274,26 @@ def get_i18n(ctx: click.Context) -> None:
         admin_manager.display_locale_settings(result["data"])
 
     asyncio.run(run_get_i18n())
+
+
+@i18n.command(name="list")
+@click.pass_context
+def list_i18n(ctx: click.Context) -> None:
+    """List available locales (same as locale list)."""
+    auth_manager = AuthManager(ctx.obj.get("config"))
+    admin_manager = AdminManager(auth_manager)
+    console = get_console()
+
+    async def run_list_i18n() -> None:
+        result = await admin_manager.get_available_locales()
+
+        if result["status"] == "error":
+            console.print(f"[red]Error:[/red] {result['message']}")
+            return
+
+        admin_manager.display_available_locales(result["data"], result.get("message"))
+
+    asyncio.run(run_list_i18n())
 
 
 @i18n.command(name="set")


### PR DESCRIPTION
## Summary

This PR implements multiple admin command improvements by removing deprecated non-functional commands and adding a new i18n list alias command.

## Related Issues
This PR addresses the following issues:
- #553: Remove `admin global-settings get` command
- #554: Remove `admin global-settings set` command  
- #555: Remove `admin license show` command
- #556: Remove `admin maintenance clear-cache` command
- #557: Add `admin i18n list` as an alias for `admin locale list`

## Changes Made

### Deprecated Command Removals
- **Removed `admin global-settings get` command** - This command was not functional and has been removed
- **Removed `admin global-settings set` command** - This command was not functional and has been removed
- **Removed `admin license show` command** - This command was not functional and has been removed
- **Removed `admin maintenance clear-cache` command** - This command was not functional and has been removed
- **Removed flatter alternatives** - Removed the `settings` command group that provided shortcuts like `yt settings get/set`

### New Functionality
- **Added `admin i18n list` command** - New alias for `admin locale list` command for consistency with other i18n commands

### Test Updates
- Removed tests for deprecated commands that are no longer available
- Added test for new `admin i18n list` command
- Updated CLI command tests to reflect the changes

### Documentation Updates
- Updated `docs/commands/admin.rst` with deprecation notes for removed commands
- Added documentation for new `admin i18n list` command
- Updated workflow examples to use available commands instead of deprecated ones

## Testing
- [ ] Unit tests added/updated for new functionality
- [x] All existing tests pass
- [x] Integration tests pass  
- [x] Pre-commit hooks pass (linting, formatting, type checking)
- [x] Documentation builds successfully

## Breaking Changes
⚠️  **This PR contains breaking changes:**
- The following commands are no longer available:
  - `yt admin global-settings get`
  - `yt admin global-settings set`
  - `yt admin license show`
  - `yt admin maintenance clear-cache`
  - `yt settings get`
  - `yt settings set`
  - `yt settings list`

## Migration Guide
For users who were using the removed commands:
- **Global settings**: Use `yt admin global-settings list` to view settings (configuration must be done through YouTrack web interface)
- **License information**: Use `yt admin license usage` to view license statistics  
- **Cache clearing**: Use YouTrack web interface or server-side tools (was never functional via CLI)
- **Settings shortcuts**: Use full `yt admin global-settings list` command instead of `yt settings` shortcuts

## Verification
Commands verified to work correctly:
```bash
# Available commands
yt admin --help
yt admin global-settings --help  # Only shows 'list' command
yt admin license --help          # Only shows 'usage' command  
yt admin maintenance --help      # No subcommands available
yt admin i18n --help             # Shows new 'list' command

# New functionality
yt admin i18n list               # New alias works correctly
```

🤖 Generated with [Claude Code](https://claude.ai/code)