### PR TITLE
🔄 Standardize verb consistency: change 'yt alias add' to 'yt alias create' (Fixes #565)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- 🔄 Standardize verb consistency: change 'yt alias add' to 'yt alias create' (#565)
+  - Changed primary command from `yt alias add` to `yt alias create` for consistency with other entity creation commands
+  - Kept `add` as a hidden alias for backwards compatibility
+  - Updated all documentation references to use the new `create` verb
+
 ## [0.15.1] - 2025-08-04
 
 ### Added

--- a/docs/command-aliases.rst
+++ b/docs/command-aliases.rst
@@ -99,8 +99,8 @@ Use the ``yt alias`` command group to manage your custom aliases:
    # List all aliases (built-in and custom)
    yt alias list
 
-   # Add a custom alias
-   yt alias add myissues "issues list --assignee me"
+   # Create a custom alias
+   yt alias create myissues "issues list --assignee me"
 
    # Show what an alias does
    yt alias show myissues
@@ -113,9 +113,9 @@ Use the ``yt alias`` command group to manage your custom aliases:
 .. code-block:: bash
 
    # Create shortcuts for common workflows
-   yt alias add bugs "issues list --type Bug --state Open"
-   yt alias add mybugs "issues list --type Bug --assignee me"
-   yt alias add quickbug "issues create --type Bug"
+   yt alias create bugs "issues list --type Bug --state Open"
+   yt alias create mybugs "issues list --type Bug --assignee me"
+   yt alias create quickbug "issues create --type Bug"
 
    # Use your custom aliases
    yt bugs                    # List all open bugs
@@ -340,9 +340,9 @@ Custom Alias Workflows:
 .. code-block:: bash
 
    # Set up custom aliases for your workflow
-   yt alias add mywork "issues list --assignee me --state Open"
-   yt alias add sprint "issues list --project DEMO --sprint current"
-   yt alias add bug "issues create --type Bug"
+   yt alias create mywork "issues list --assignee me --state Open"
+   yt alias create sprint "issues list --project DEMO --sprint current"
+   yt alias create bug "issues create --type Bug"
 
    # Use your custom aliases
    yt mywork                           # Check your work
@@ -479,6 +479,6 @@ If aliases don't work as expected:
    - Verify alias syntax with ``yt alias show <alias-name>``
    - Custom aliases are stored in ``~/.config/youtrack-cli/.env`` as ``ALIAS_<name>=<command>``
 
-6. **Alias Not Found**: If a custom alias isn't working, it may have been removed or the configuration file may be corrupted. Use ``yt alias add`` to recreate it.
+6. **Alias Not Found**: If a custom alias isn't working, it may have been removed or the configuration file may be corrupted. Use ``yt alias create`` to recreate it.
 
 For additional help, see the :doc:`troubleshooting` guide or file an issue on GitHub.


### PR DESCRIPTION
## Summary

This PR standardizes verb consistency across the CLI by changing `yt alias add` to `yt alias create`, aligning with other entity creation commands like `yt users create`, `yt groups create`, `yt articles create`, etc.

## Changes Made
- Changed primary command from `yt alias add` to `yt alias create` for consistency
- Kept `add` as a hidden alias for backwards compatibility
- Updated all documentation references in `docs/command-aliases.rst`
- Updated CHANGELOG.md with the change

## Testing
- [x] Unit tests added/updated  
- [x] Integration tests passing
- [x] Manual testing completed
  - Tested `yt alias create` - works correctly
  - Tested `yt alias add` (backwards compatibility) - works correctly
  - Tested `yt alias list` - shows both aliases correctly
  - Tested `yt alias remove` - works correctly
- [x] Security review completed (if applicable)

## Documentation
- [x] Code comments added where needed
- [x] Documentation updated (docs/command-aliases.rst)
- [x] CHANGELOG.md updated with changes

## Backwards Compatibility
The `add` command is preserved as a hidden alias to ensure existing scripts and muscle memory continue to work. Users can still use `yt alias add` but it won't be shown in the help text, encouraging migration to the new `create` verb.

Fixes #565