### PR TITLE
📝 Document missing global CLI options (Fixes #576)

### DIFF
--- a/docs/commands/burndown.rst
+++ b/docs/commands/burndown.rst
@@ -67,7 +67,7 @@ A burndown report is a visual representation of work completed versus time remai
 * **Time Axis:** The timeframe being analyzed (sprint duration or project timeline)
 
 Report Components
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 Burndown reports typically include:
 

--- a/docs/commands/index.rst
+++ b/docs/commands/index.rst
@@ -50,12 +50,27 @@ These options are available for all commands:
    * - ``--quiet, -q``
      - flag
      - Suppress all output except errors
-   * - ``--config``
+   * - ``--config, -c``
      - path
      - Path to configuration file
+   * - ``--debug``
+     - flag
+     - Enable debug output
    * - ``--format``
      - choice
      - Output format: table, json, yaml (default: table)
+   * - ``--help-verbose``
+     - flag
+     - Show detailed help information with all options and examples
+   * - ``--no-progress``
+     - flag
+     - Disable progress indicators
+   * - ``--secure``
+     - flag
+     - Enable enhanced security mode (prevents credential logging)
+   * - ``--version``
+     - flag
+     - Show the version and exit
    * - ``--no-color``
      - flag
      - Disable colored output


### PR DESCRIPTION
## Summary

Documents missing global CLI options in the Global Options table in docs/commands/index.rst, improving documentation completeness and user experience.

## Changes Made
- Added `--debug` option to Global Options table - Enable debug output
- Added `--help-verbose` option to Global Options table - Show detailed help information with all options and examples
- Added `--no-progress` option to Global Options table - Disable progress indicators  
- Added `--secure` option to Global Options table - Enable enhanced security mode (prevents credential logging)
- Added `--version` option to Global Options table - Show the version and exit
- Updated `--config` option to include `-c` short form
- Fixed title underline in burndown.rst documentation (pre-existing issue)

## Testing
- [x] Documentation builds successfully without errors
- [x] Pre-commit hooks all pass
- [x] All tests pass (1331 passed, 77 skipped)
- [x] Coverage maintained at 60.34%
- [x] Verified all documented options exist in actual CLI help output

## Documentation
- [x] Updated docs/commands/index.rst with missing global options
- [x] Maintained consistent table formatting
- [x] Descriptions match actual CLI help text
- [x] Documentation builds without warnings for added content

Fixes #576

🤖 Generated with [Claude Code](https://claude.ai/code)