### PR TITLE
📖 Document missing subcommands in issues command (Fixes #577)

### DIFF
--- a/docs/commands/issues.rst
+++ b/docs/commands/issues.rst
@@ -315,6 +315,38 @@ Manage issue tags.
    # List all tags on an issue
    yt issues tag list PROJ-123
 
+Benchmark Performance
+~~~~~~~~~~~~~~~~~~~~~
+
+Benchmark field selection performance improvements to measure API optimization benefits.
+
+.. code-block:: bash
+
+   yt issues benchmark [OPTIONS]
+
+**Options:**
+  * ``-p, --project-id TEXT`` - Project ID to benchmark with
+  * ``--sample-size INTEGER`` - Number of issues to fetch for benchmarking (default: 50)
+
+**Examples:**
+
+.. code-block:: bash
+
+   # Run benchmark with default settings
+   yt issues benchmark
+
+   # Benchmark specific project with custom sample size
+   yt issues benchmark -p FPU --sample-size 100
+
+   # Benchmark with minimal sample for quick testing
+   yt issues benchmark --sample-size 10
+
+.. note::
+   This command runs performance tests comparing minimal, standard, and full
+   field selection profiles to demonstrate the optimization benefits. It helps
+   understand the performance impact of different field selection strategies
+   when working with large datasets.
+
 Comment Management
 ------------------
 
@@ -479,6 +511,44 @@ Display available link types in your YouTrack instance.
 **Options:**
   * ``--format [table|json|csv]`` - Output format
 
+Show Related Issues
+~~~~~~~~~~~~~~~~~~~
+
+Display all issue relationships dynamically based on YouTrack instance configuration.
+
+.. code-block:: bash
+
+   yt issues related ISSUE_ID [OPTIONS]
+
+**Arguments:**
+  * ``ISSUE_ID`` - The ID of the issue to show relationships for
+
+**Options:**
+  * ``--format [tree|table]`` - Output format for related issues display (default: tree)
+  * ``--show-status`` - Show status indicators in tree view (default: true)
+
+**Examples:**
+
+.. code-block:: bash
+
+   # Show all relationships in tree format (default)
+   yt issues related DEMO-123
+
+   # Show relationships in table format
+   yt issues related DEMO-123 --format table
+
+   # Hide status indicators in tree view
+   yt issues related DEMO-123 --show-status false
+
+   # Show relationships for complex issues with many links
+   yt issues related PROJ-456 --format tree
+
+.. note::
+   This command shows all relationship types for an issue, not just dependencies.
+   Relationship types are fetched dynamically from the YouTrack instance, so it
+   adapts to custom relationship types in different YouTrack configurations.
+   This provides a comprehensive view of how issues are connected in your project.
+
 Batch Operations
 ----------------
 
@@ -503,7 +573,7 @@ Create multiple issues from a CSV or JSON file.
 **CSV File Format:**
 The CSV file should have the following columns:
 
-.. code-block:: csv
+.. code-block:: text
 
    project_id,summary,description,type,priority,assignee
    FPU,Fix login bug,Login fails on mobile devices,Bug,High,john.doe
@@ -567,7 +637,7 @@ Update multiple issues from a CSV or JSON file.
 **CSV File Format:**
 The CSV file should include ``issue_id`` and any fields to update:
 
-.. code-block:: csv
+.. code-block:: text
 
    issue_id,summary,description,state,type,priority,assignee
    FPU-1,Updated summary,,In Progress,,High,


### PR DESCRIPTION
## Summary

Added comprehensive documentation for two missing subcommands in the issues command group that were available in the CLI but not documented in `docs/commands/issues.rst`:

- `benchmark` - Benchmark field selection performance improvements
- `related` - Show all issue relationships dynamically based on YouTrack configuration

## Changes Made

- **Added `benchmark` subcommand documentation** in Issue Management Commands section
  - Detailed command usage and options
  - Multiple usage examples (default, custom project/sample size)  
  - Explanatory note about performance comparison benefits
  
- **Added `related` subcommand documentation** in Issue Relationships section
  - Complete command syntax with required arguments
  - Format options (tree/table) and status display controls
  - Usage examples for different output formats
  - Note explaining dynamic relationship type detection

- **Fixed CSV lexer compatibility issues** by changing `.. code-block:: csv` to `.. code-block:: text`

## Testing

- [x] Documentation builds successfully with Sphinx
- [x] All pre-commit hooks pass including RST validation
- [x] Unit and integration tests continue to pass
- [x] Manual validation of command help text accuracy

## Documentation

- [x] Added comprehensive RST documentation following existing format
- [x] Included usage examples and command options
- [x] Added explanatory notes for both commands
- [x] Maintained consistency with existing documentation style

Fixes #577

🤖 Generated with [Claude Code](https://claude.ai/code)