### PR TITLE
Implement: Add markdown file article ID insertion (Fixes #583)

### DIFF
--- a/docs/commands/articles.rst
+++ b/docs/commands/articles.rst
@@ -71,6 +71,9 @@ Create a new article in YouTrack.
    * - ``--visibility``
      - choice
      - Article visibility: public, private, project (default: public)
+   * - ``--no-article-id``
+     - flag
+     - Skip inserting/updating ArticleID comment in markdown file (only applies when using --file)
 
 **Examples:**
 
@@ -93,6 +96,27 @@ Create a new article in YouTrack.
 
    # Create an article with inline content (traditional approach)
    yt articles create "API Documentation" --content "API usage guide" --project-id FPU
+
+   # Create an article from a file without ArticleID insertion
+   yt articles create "Clean Article" --file clean.md --project-id FPU --no-article-id
+
+**ArticleID Management:**
+
+When creating articles from markdown files, the CLI automatically inserts or updates an ArticleID comment in the file. This helps maintain references between local files and their corresponding YouTrack articles.
+
+.. code-block:: markdown
+
+   <!-- ArticleID: FPU-A-123 -->
+
+   # My Article Title
+   Article content here...
+
+The ArticleID comment:
+
+* Is automatically inserted at the beginning of the file after successful article creation
+* Contains the readable article ID (e.g., ``FPU-A-123``)
+* Allows you to track which local files correspond to which YouTrack articles
+* Can be disabled using the ``--no-article-id`` flag
 
 edit
 ~~~~
@@ -121,7 +145,10 @@ Edit an existing article's properties.
      - New article title
    * - ``--content, -c``
      - string
-     - New article content
+     - New article content (required if --file not specified)
+   * - ``--file, -f``
+     - path
+     - Path to markdown file containing article content (required if --content not specified)
    * - ``--summary, -s``
      - string
      - New article summary
@@ -131,6 +158,9 @@ Edit an existing article's properties.
    * - ``--show-details``
      - flag
      - Show detailed article information
+   * - ``--no-article-id``
+     - flag
+     - Skip inserting/updating ArticleID comment in markdown file (only applies when using --file)
 
 **Examples:**
 
@@ -147,6 +177,21 @@ Edit an existing article's properties.
 
    # View detailed article information
    yt articles edit ARTICLE-123 --show-details
+
+   # Update article from a markdown file
+   yt articles edit ARTICLE-123 --file updated-content.md
+
+   # Update article from file without ArticleID insertion
+   yt articles edit ARTICLE-123 --file updated.md --no-article-id
+
+**ArticleID Management:**
+
+When editing articles with markdown files, the CLI automatically manages ArticleID comments:
+
+* If the file doesn't have an ArticleID comment, one is added
+* If the file has a different ArticleID, a warning is displayed
+* The ArticleID helps track the relationship between local files and YouTrack articles
+* Use ``--no-article-id`` to disable this behavior
 
 publish
 ~~~~~~~

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -950,7 +950,7 @@ class TestArticleIDCommandIntegration:
             temp_file = f.name
 
         try:
-            with patch("youtrack_cli.commands.articles.AuthManager") as mock_auth:
+            with patch("youtrack_cli.auth.AuthManager") as mock_auth:
                 with patch("youtrack_cli.articles.ArticleManager") as mock_manager_class:
                     # Setup mocks
                     mock_auth_instance = MagicMock()
@@ -1001,7 +1001,7 @@ class TestArticleIDCommandIntegration:
             temp_file = f.name
 
         try:
-            with patch("youtrack_cli.commands.articles.AuthManager") as mock_auth:
+            with patch("youtrack_cli.auth.AuthManager") as mock_auth:
                 with patch("youtrack_cli.articles.ArticleManager") as mock_manager_class:
                     # Setup mocks
                     mock_auth_instance = MagicMock()
@@ -1053,7 +1053,7 @@ class TestArticleIDCommandIntegration:
             temp_file = f.name
 
         try:
-            with patch("youtrack_cli.commands.articles.AuthManager") as mock_auth:
+            with patch("youtrack_cli.auth.AuthManager") as mock_auth:
                 with patch("youtrack_cli.articles.ArticleManager") as mock_manager_class:
                     # Setup mocks
                     mock_auth_instance = MagicMock()

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -843,3 +843,239 @@ class TestArticleSortFunctions:
 
         # Test edge cases
         assert _sort_articles([], "title", False, False) == []
+
+
+@pytest.mark.unit
+class TestArticleIDManagement:
+    """Test cases for ArticleID comment management in markdown files."""
+
+    def test_extract_article_id_from_content(self):
+        """Test extracting ArticleID from markdown content."""
+        from youtrack_cli.articles import extract_article_id_from_content
+
+        # Test with valid ArticleID
+        content = "<!-- ArticleID: DOCS-A-123 -->\n# My Article\nContent here"
+        assert extract_article_id_from_content(content) == "DOCS-A-123"
+
+        # Test with whitespace variations
+        content = "<!--   ArticleID:   DOCS-A-456   -->\n# Article"
+        assert extract_article_id_from_content(content) == "DOCS-A-456"
+
+        # Test with no ArticleID
+        content = "# My Article\nNo ID here"
+        assert extract_article_id_from_content(content) is None
+
+        # Test with malformed ArticleID
+        content = "<!-- ArticleID: -->\n# Article"
+        assert extract_article_id_from_content(content) is None
+
+        # Test with ArticleID in middle of content
+        content = "# Title\nSome content\n<!-- ArticleID: MID-123 -->\nMore content"
+        assert extract_article_id_from_content(content) == "MID-123"
+
+    def test_insert_or_update_article_id(self):
+        """Test inserting or updating ArticleID in markdown content."""
+        from youtrack_cli.articles import insert_or_update_article_id
+
+        # Test inserting new ArticleID
+        content = "# My Article\nContent here"
+        result = insert_or_update_article_id(content, "NEW-123")
+        assert "<!-- ArticleID: NEW-123 -->" in result
+        assert result.startswith("<!-- ArticleID: NEW-123 -->")
+        assert "# My Article" in result
+
+        # Test updating existing ArticleID
+        content = "<!-- ArticleID: OLD-123 -->\n# My Article\nContent"
+        result = insert_or_update_article_id(content, "NEW-456")
+        assert "<!-- ArticleID: NEW-456 -->" in result
+        assert "<!-- ArticleID: OLD-123 -->" not in result
+        assert "# My Article" in result
+
+        # Test with empty content
+        content = ""
+        result = insert_or_update_article_id(content, "EMPTY-123")
+        assert result == "<!-- ArticleID: EMPTY-123 -->\n"
+
+        # Test with whitespace variations
+        content = "<!--  ArticleID:  OLD-789  -->\n# Title"
+        result = insert_or_update_article_id(content, "NEW-789")
+        assert "<!-- ArticleID: NEW-789 -->" in result
+        assert "OLD-789" not in result
+
+    def test_remove_article_id_comment(self):
+        """Test removing ArticleID comment from markdown content."""
+        from youtrack_cli.articles import remove_article_id_comment
+
+        # Test removing ArticleID at beginning
+        content = "<!-- ArticleID: DOCS-123 -->\n\n# My Article\nContent"
+        result = remove_article_id_comment(content)
+        assert "ArticleID" not in result
+        assert result.startswith("# My Article")
+
+        # Test removing ArticleID in middle
+        content = "# Title\n<!-- ArticleID: MID-456 -->\nContent"
+        result = remove_article_id_comment(content)
+        assert "ArticleID" not in result
+        assert "# Title\nContent" in result
+
+        # Test with no ArticleID
+        content = "# My Article\nNo ID here"
+        result = remove_article_id_comment(content)
+        assert result == content
+
+        # Test with multiple newlines after ArticleID
+        content = "<!-- ArticleID: TEST-789 -->\n\n\n# Title"
+        result = remove_article_id_comment(content)
+        assert result.startswith("# Title")
+
+
+@pytest.mark.unit
+class TestArticleIDCommandIntegration:
+    """Test cases for ArticleID management in create and edit commands."""
+
+    def test_create_command_with_file_and_article_id(self):
+        """Test create command with file and ArticleID insertion."""
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from click.testing import CliRunner
+
+        from youtrack_cli.commands.articles import create
+
+        runner = CliRunner()
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write("# Test Article\nThis is test content.")
+            temp_file = f.name
+
+        try:
+            with patch("youtrack_cli.commands.articles.AuthManager") as mock_auth:
+                with patch("youtrack_cli.articles.ArticleManager") as mock_manager_class:
+                    # Setup mocks
+                    mock_auth_instance = MagicMock()
+                    mock_auth.return_value = mock_auth_instance
+
+                    mock_manager = MagicMock()
+                    mock_manager_class.return_value = mock_manager
+
+                    # Mock successful creation
+                    mock_manager.create_article = AsyncMock(
+                        return_value={
+                            "status": "success",
+                            "message": "Article created",
+                            "data": {"id": "123-456", "idReadable": "DOCS-A-789"},
+                        }
+                    )
+
+                    # Run command
+                    runner.invoke(
+                        create, ["Test Article", "--file", temp_file, "--project-id", "TEST"], obj={"config": {}}
+                    )
+
+                    # Check the file was updated with ArticleID
+                    with open(temp_file) as f:
+                        updated_content = f.read()
+
+                    assert "<!-- ArticleID: DOCS-A-789 -->" in updated_content
+                    assert "# Test Article" in updated_content
+
+        finally:
+            Path(temp_file).unlink()
+
+    def test_create_command_with_no_article_id_flag(self):
+        """Test create command with --no-article-id flag."""
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from click.testing import CliRunner
+
+        from youtrack_cli.commands.articles import create
+
+        runner = CliRunner()
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            original_content = "# Test Article\nThis is test content."
+            f.write(original_content)
+            temp_file = f.name
+
+        try:
+            with patch("youtrack_cli.commands.articles.AuthManager") as mock_auth:
+                with patch("youtrack_cli.articles.ArticleManager") as mock_manager_class:
+                    # Setup mocks
+                    mock_auth_instance = MagicMock()
+                    mock_auth.return_value = mock_auth_instance
+
+                    mock_manager = MagicMock()
+                    mock_manager_class.return_value = mock_manager
+
+                    # Mock successful creation
+                    mock_manager.create_article = AsyncMock(
+                        return_value={
+                            "status": "success",
+                            "message": "Article created",
+                            "data": {"id": "123-456", "idReadable": "DOCS-A-789"},
+                        }
+                    )
+
+                    # Run command with --no-article-id
+                    runner.invoke(
+                        create,
+                        ["Test Article", "--file", temp_file, "--project-id", "TEST", "--no-article-id"],
+                        obj={"config": {}},
+                    )
+
+                    # Check the file was NOT updated with ArticleID
+                    with open(temp_file) as f:
+                        content = f.read()
+
+                    assert "<!-- ArticleID:" not in content
+                    assert content == original_content
+
+        finally:
+            Path(temp_file).unlink()
+
+    def test_edit_command_with_file(self):
+        """Test edit command with file option."""
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from click.testing import CliRunner
+
+        from youtrack_cli.commands.articles import edit
+
+        runner = CliRunner()
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write("# Updated Article\nUpdated content.")
+            temp_file = f.name
+
+        try:
+            with patch("youtrack_cli.commands.articles.AuthManager") as mock_auth:
+                with patch("youtrack_cli.articles.ArticleManager") as mock_manager_class:
+                    # Setup mocks
+                    mock_auth_instance = MagicMock()
+                    mock_auth.return_value = mock_auth_instance
+
+                    mock_manager = MagicMock()
+                    mock_manager_class.return_value = mock_manager
+
+                    # Mock successful update
+                    mock_manager.update_article = AsyncMock(
+                        return_value={"status": "success", "message": "Article updated"}
+                    )
+
+                    # Run command
+                    runner.invoke(edit, ["DOCS-A-789", "--file", temp_file], obj={"config": {}})
+
+                    # Check the file was updated with ArticleID
+                    with open(temp_file) as f:
+                        updated_content = f.read()
+
+                    assert "<!-- ArticleID: DOCS-A-789 -->" in updated_content
+                    assert "# Updated Article" in updated_content
+
+        finally:
+            Path(temp_file).unlink()

--- a/youtrack_cli/articles.py
+++ b/youtrack_cli/articles.py
@@ -1240,3 +1240,81 @@ class ArticleManager:
                 }
         except Exception as e:
             return {"status": "error", "message": f"Error deleting attachment: {str(e)}"}
+
+
+# Helper functions for ArticleID management in markdown files
+def extract_article_id_from_content(content: str) -> Optional[str]:
+    """Extract ArticleID from markdown content.
+
+    Looks for a comment in the format: <!-- ArticleID: actual-article-id -->
+
+    Args:
+        content: The markdown content to search
+
+    Returns:
+        The article ID if found, None otherwise
+    """
+    import re
+
+    # Pattern to match <!-- ArticleID: some-id -->
+    pattern = r"<!--\s*ArticleID:\s*([^\s]+)\s*-->"
+    match = re.search(pattern, content)
+
+    if match:
+        return match.group(1)
+    return None
+
+
+def insert_or_update_article_id(content: str, article_id: str) -> str:
+    """Insert or update ArticleID comment in markdown content.
+
+    If an ArticleID comment exists, it will be updated.
+    If not, it will be inserted at the beginning of the file.
+
+    Args:
+        content: The markdown content
+        article_id: The article ID to insert or update
+
+    Returns:
+        The updated content with the ArticleID comment
+    """
+    import re
+
+    # Pattern to match existing ArticleID comment
+    pattern = r"<!--\s*ArticleID:\s*[^\s]+\s*-->"
+    article_id_comment = f"<!-- ArticleID: {article_id} -->"
+
+    # Check if ArticleID already exists
+    if re.search(pattern, content):
+        # Update existing ArticleID
+        updated_content = re.sub(pattern, article_id_comment, content, count=1)
+    else:
+        # Insert ArticleID at the beginning
+        # Check if content starts with a comment or whitespace
+        lines = content.splitlines(keepends=True) if content else []
+
+        # Insert the ArticleID comment at the very beginning
+        if lines:
+            updated_content = article_id_comment + "\n\n" + content
+        else:
+            updated_content = article_id_comment + "\n"
+
+    return updated_content
+
+
+def remove_article_id_comment(content: str) -> str:
+    """Remove ArticleID comment from markdown content.
+
+    Args:
+        content: The markdown content
+
+    Returns:
+        The content with ArticleID comment removed
+    """
+    import re
+
+    # Pattern to match ArticleID comment with optional surrounding whitespace
+    pattern = r"<!--\s*ArticleID:\s*[^\s]+\s*-->\n*"
+    cleaned_content = re.sub(pattern, "", content)
+
+    return cleaned_content


### PR DESCRIPTION
## Summary

This PR adds ArticleID comment management functionality to the `yt articles create` and `yt articles edit` commands, allowing users to track the relationship between local markdown files and their corresponding YouTrack articles.

## Changes Made

### New Features
- **ArticleID Comment Management**: Automatically inserts/updates `<\!-- ArticleID: actual-id -->` comments in markdown files
- **--file option for edit command**: Added ability to update articles from markdown files  
- **--no-article-id flag**: Optional flag to skip ArticleID insertion for both create and edit commands

### Implementation Details
- Added helper functions for ArticleID management: 
  - `extract_article_id_from_content()` - Extract existing ArticleID
  - `insert_or_update_article_id()` - Insert or update ArticleID comment
  - `remove_article_id_comment()` - Remove ArticleID comment (utility function)
- Modified `create` command to insert ArticleID after successful article creation
- Added `--file` option to `edit` command with content reading capability
- Modified `edit` command to manage ArticleID comments with conflict detection
- Updated documentation to explain ArticleID behavior and comment format

## Testing
- [x] Unit tests added for ArticleID helper functions
- [x] Integration tests added for create/edit commands with file handling
- [x] Manual testing completed with local YouTrack instance
- [x] Security review completed - no sensitive data exposed
- [x] Pre-commit hooks passing (linting, formatting, type checking)
- [x] CLI testing agent validated all command variations

## Documentation
- [x] Code comments added where needed
- [x] Documentation updated (docs/commands/articles.rst) 
- [x] Example usage included in documentation

## Usage Examples

### Create article with ArticleID insertion:
```bash
yt articles create "My Article" --file article.md --project-id FPU
# File is updated with: <\!-- ArticleID: FPU-A-123 -->
```

### Create article without ArticleID:
```bash
yt articles create "My Article" --file article.md --project-id FPU --no-article-id
# File remains unchanged
```

### Edit article from file:
```bash
yt articles edit FPU-A-123 --file updated.md
# File is updated with ArticleID if not present
```

## Breaking Changes
None - all changes are backward compatible.

Fixes #583

🤖 Generated with [Claude Code](https://claude.ai/code)