### PR TITLE
✨ Improve 'yt a edit' command to check for article ID in file when using --file flag (Fixes #591)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- 🔄 Improve 'yt a edit' command to check for article ID in file when using --file flag (#591)
+  - Made ARTICLE_ID argument optional when using --file flag
+  - Command now extracts article ID from file's ArticleID comment when no ID is provided
+  - Added clear error messages when article ID is missing from both command line and file
+  - Shows warning when file contains different ArticleID than the one provided as argument
+
 ## [0.18.1] - 2025-08-09
 
 ### Changed

--- a/docs/commands/articles.rst
+++ b/docs/commands/articles.rst
@@ -125,11 +125,11 @@ Edit an existing article's properties.
 
 .. code-block:: bash
 
-   yt articles edit ARTICLE_ID [OPTIONS]
+   yt articles edit [ARTICLE_ID] [OPTIONS]
 
 **Arguments:**
 
-* ``ARTICLE_ID`` - The ID of the article to edit (required)
+* ``ARTICLE_ID`` - The ID of the article to edit (optional when using --file with ArticleID comment)
 
 **Options:**
 
@@ -178,20 +178,26 @@ Edit an existing article's properties.
    # View detailed article information
    yt articles edit ARTICLE-123 --show-details
 
-   # Update article from a markdown file
+   # Update article from a markdown file with explicit ID
    yt articles edit ARTICLE-123 --file updated-content.md
 
    # Update article from file without ArticleID insertion
    yt articles edit ARTICLE-123 --file updated.md --no-article-id
 
+   # Update article from file using ArticleID in the file
+   # (file must contain <!-- ArticleID: ARTICLE-123 --> comment)
+   yt articles edit --file updated-content.md
+
 **ArticleID Management:**
 
 When editing articles with markdown files, the CLI automatically manages ArticleID comments:
 
-* If the file doesn't have an ArticleID comment, one is added
-* If the file has a different ArticleID, a warning is displayed
+* The article ID can be provided as an argument or extracted from the file's ArticleID comment
+* If no article ID is provided as an argument, the CLI looks for an ArticleID comment in the file
+* If the file doesn't have an ArticleID comment, one is added after successful update
+* If the file has a different ArticleID than the argument, a warning is displayed
 * The ArticleID helps track the relationship between local files and YouTrack articles
-* Use ``--no-article-id`` to disable this behavior
+* Use ``--no-article-id`` to disable automatic ArticleID insertion/updating
 
 publish
 ~~~~~~~


### PR DESCRIPTION
## Summary

Improves the `yt a edit` command to allow extracting article IDs from file content when using the `--file` flag, eliminating the need to specify the article ID as a command argument when it's already present in the file.

## Changes Made

- **Made ARTICLE_ID argument optional** when using `--file` flag
- **Command now extracts article ID** from file's `ArticleID` comment when no ID is provided as argument
- **Added clear error messages** when article ID is missing from both command line and file
- **Shows warning** when file contains different ArticleID than the one provided as argument
- **Added comprehensive tests** for all new functionality scenarios
- **Updated documentation** to reflect the new behavior and provide examples
- **Updated CHANGELOG** with details of the enhancement

## Testing

- ✅ Unit tests for all scenarios (extracting ID from file, missing ID error, conflicting IDs warning)
- ✅ Manual CLI testing with various file configurations
- ✅ All existing tests continue to pass
- ✅ Pre-commit checks pass (linting, formatting, type checking, docs build)

## Examples

```bash
# New: Edit article using ArticleID from file
# (file contains <\!-- ArticleID: FPU-A-123 --> comment)
yt articles edit --file updated-content.md

# Existing: Edit article with explicit ID (still works)
yt articles edit FPU-A-123 --file updated-content.md

# Error case: No ID in argument or file
yt articles edit --file no-id-file.md
# Shows helpful error with usage instructions
```

Fixes #591

🤖 Generated with [Claude Code](https://claude.ai/code)