### PR TITLE
Implement: Tags displayed alphabetically with visibility (Fixes #594)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Command now extracts article ID from file's ArticleID comment when no ID is provided
   - Added clear error messages when article ID is missing from both command line and file
   - Shows warning when file contains different ArticleID than the one provided as argument
+- 📋 Improve 'yt a tag' command to display tags alphabetically with visibility state (#594)
+  - Tags are now displayed in alphabetical order for better readability
+  - Each tag now shows its visibility state (public, restricted, etc.)
+  - Enhanced interactive tag selection with clearer visibility information
 
 ## [0.18.1] - 2025-08-09
 

--- a/docs/commands/articles.rst
+++ b/docs/commands/articles.rst
@@ -482,7 +482,8 @@ Add tags to an article for better organization and categorization.
 
 When no tag names are provided, the command enters interactive mode where you can:
 
-* View all available tags in the system
+* View all available tags in the system, sorted alphabetically
+* See the visibility state of each tag (public, restricted, etc.)
 * Select multiple tags using numbered indices
 * Confirm your selection before applying
 
@@ -506,11 +507,11 @@ When no tag names are provided, the command enters interactive mode where you ca
    🔍 Fetching available tags...
 
    📋 Available tags:
-     1. bug (ID: 1-0)
-     2. documentation (ID: 2-0)
-     3. feature (ID: 3-0)
-     4. urgent (ID: 4-0)
-     5. review (ID: 5-0)
+     1. bug (public)
+     2. documentation (public)
+     3. feature (restricted to Developers)
+     4. review (public)
+     5. urgent (restricted to Managers, Admins)
 
    💡 Enter tag numbers separated by spaces (e.g., 1 3 5) or 'q' to quit:
    1 2 4
@@ -786,7 +787,7 @@ Common Workflows
 ----------------
 
 Creating Documentation Structure
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 

--- a/youtrack_cli/commands/articles.py
+++ b/youtrack_cli/commands/articles.py
@@ -864,10 +864,28 @@ def tag_article(ctx: click.Context, article_id: str, tags: tuple[str, ...]) -> N
                 console.print("No tags available.", style="yellow")
                 return
 
+            # Sort tags alphabetically by name
+            available_tags = sorted(available_tags, key=lambda x: x.get("name", "").lower())
+
             # Show interactive selection
             console.print("\n📋 Available tags:", style="green")
             for i, tag in enumerate(available_tags, 1):
-                console.print(f"  {i}. {tag.get('name', 'Unknown')} (ID: {tag.get('id', 'N/A')})")
+                # Determine visibility state
+                visible_for = tag.get("visibleFor")
+                if not visible_for or len(visible_for) == 0:
+                    visibility = "public"
+                else:
+                    # Tag has restricted visibility
+                    visibility = "restricted"
+                    if visible_for and len(visible_for) > 0:
+                        # Try to get more specific visibility info
+                        visibility_names = [vf.get("name", "") for vf in visible_for if vf.get("name")]
+                        if visibility_names:
+                            visibility = f"restricted to {', '.join(visibility_names[:2])}"
+                            if len(visibility_names) > 2:
+                                visibility += f" and {len(visibility_names) - 2} more"
+
+                console.print(f"  {i}. {tag.get('name', 'Unknown')} ({visibility})")
 
             # Get user selection
             console.print("\n💡 Enter tag numbers separated by spaces (e.g., 1 3 5) or 'q' to quit:")
@@ -909,6 +927,8 @@ def tag_article(ctx: click.Context, article_id: str, tags: tuple[str, ...]) -> N
                 return
 
             available_tags = tags_result["data"]
+            # Sort tags alphabetically by name
+            available_tags = sorted(available_tags, key=lambda x: x.get("name", "").lower())
             tag_map = {tag.get("name", "").lower(): tag.get("id") for tag in available_tags}
 
             # Find matching tags


### PR DESCRIPTION
## Summary

Improved the `yt articles tag` command to display tags in alphabetical order with visibility state information for better usability.

## Changes Made
- Tags are now sorted alphabetically when displayed in interactive mode
- Each tag shows its visibility state (public, restricted to specific groups, etc.)
- Updated documentation to reflect the new behavior
- Updated CHANGELOG.md with the improvements

## Testing
- [x] Manual testing completed with local YouTrack instance
- [x] Pre-commit hooks pass
- [x] Type checking passes with ty
- [x] Documentation builds successfully

## Documentation
- [x] Updated command documentation in docs/commands/articles.rst
- [x] CHANGELOG.md updated with changes

Fixes #594