### PR TITLE
✨ Add user's name to assignee column in 'yt i list' output (Fixes #598)

### DIFF
--- a/docs/commands/issues.rst
+++ b/docs/commands/issues.rst
@@ -79,6 +79,11 @@ List and filter issues with advanced options.
   * ``-q, --query TEXT`` - Advanced query filter using YouTrack syntax
   * ``--format [table|json|csv]`` - Output format (default: table)
 
+.. note::
+   The assignee column in table output displays both the user's full name and username
+   in the format "Full Name (username)" when both are available. This helps with user
+   identification when multiple users may share similar names.
+
 **Examples:**
 
 .. code-block:: bash

--- a/tests/managers/test_issues.py
+++ b/tests/managers/test_issues.py
@@ -509,7 +509,21 @@ class TestIssueManagerUtilities:
     def test_get_assignee_name_from_regular_field(self, issue_manager, sample_issue):
         """Test getting assignee name from regular field."""
         result = issue_manager._get_assignee_name(sample_issue)
-        assert result == "Test User"
+        assert result == "Test User (testuser)"
+
+    def test_get_assignee_name_only_login(self, issue_manager):
+        """Test getting assignee name when only login is available."""
+        issue = {"assignee": {"login": "testuser"}}
+        with patch.object(issue_manager, "_get_custom_field_value", return_value=None):
+            result = issue_manager._get_assignee_name(issue)
+            assert result == "testuser"
+
+    def test_get_assignee_name_only_fullname(self, issue_manager):
+        """Test getting assignee name when only fullName is available."""
+        issue = {"assignee": {"fullName": "Test User"}}
+        with patch.object(issue_manager, "_get_custom_field_value", return_value=None):
+            result = issue_manager._get_assignee_name(issue)
+            assert result == "Test User"
 
     def test_get_assignee_name_unassigned(self, issue_manager):
         """Test getting assignee name when unassigned."""

--- a/youtrack_cli/commands/issues.py
+++ b/youtrack_cli/commands/issues.py
@@ -44,12 +44,17 @@ def _format_issues_as_csv(issues):
         # Extract assignee info
         assignee_name = "Unassigned"
         if issue.get("assignee") and isinstance(issue["assignee"], dict):
-            assignee_name = (
-                issue["assignee"].get("fullName")
-                or issue["assignee"].get("name")
-                or issue["assignee"].get("login")
-                or "Unassigned"
-            )
+            fullName = issue["assignee"].get("fullName")
+            name = issue["assignee"].get("name")
+            login = issue["assignee"].get("login")
+
+            # If we have both fullName/name and login, show both
+            if (fullName or name) and login:
+                display_name = fullName or name
+                assignee_name = f"{display_name} ({login})"
+            else:
+                # Otherwise return what we have
+                assignee_name = fullName or name or login or "Unassigned"
 
         # Extract custom field values
         custom_fields = issue.get("customFields", [])

--- a/youtrack_cli/managers/issues.py
+++ b/youtrack_cli/managers/issues.py
@@ -55,12 +55,22 @@ class IssueManager:
         # First try the regular assignee field
         assignee = issue.get("assignee")
         if assignee and isinstance(assignee, dict):
-            if assignee.get("fullName"):
-                return assignee["fullName"]
-            if assignee.get("name"):
-                return assignee["name"]
-            if assignee.get("login"):
-                return assignee["login"]
+            fullName = assignee.get("fullName")
+            name = assignee.get("name")
+            login = assignee.get("login")
+
+            # If we have both fullName/name and login, show both
+            if (fullName or name) and login:
+                display_name = fullName or name
+                return f"{display_name} ({login})"
+
+            # Otherwise return what we have
+            if fullName:
+                return fullName
+            if name:
+                return name
+            if login:
+                return login
 
         # If not found, try the Assignee custom field
         custom_assignee = self._get_custom_field_value(issue, "Assignee")


### PR DESCRIPTION
## Summary
Enhanced the assignee column in `yt issues list` output to display both the user's full name and username when both are available, making it easier to identify users who may share similar names.

## Changes Made
- Modified `_get_assignee_name()` method in `IssueManager` to display both fullName and username in format "Full Name (username)"
- Updated CSV export functionality to use the same format for consistency
- Added comprehensive tests for all assignee display scenarios
- Updated documentation to explain the new assignee format

## Testing
- [x] Unit tests added for all display scenarios (both name and username, only name, only username, unassigned)
- [x] All existing tests passing
- [x] Manual testing completed with local YouTrack instance
- [x] Pre-commit hooks passing

## Documentation
- [x] Code comments added where needed
- [x] Documentation updated (docs/commands/issues.rst)
- [x] CHANGELOG.md will be updated upon release

Fixes #598

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>