### PR TITLE
✨ Group related issues under clear relationship type headings (Fixes #599)

### DIFF
--- a/youtrack_cli/managers/issues.py
+++ b/youtrack_cli/managers/issues.py
@@ -783,7 +783,7 @@ class IssueManager:
 
         from collections import defaultdict
 
-        from rich.table import Table
+        from rich.text import Text
 
         # Group links by relationship type and direction
         relationships_by_type = defaultdict(list)
@@ -829,22 +829,36 @@ class IssueManager:
                     }
                 )
 
-        # Create table with relationship type grouping
-        table = Table(title="Issue Relationships")
-        table.add_column("Relationship Type", style="cyan", no_wrap=True)
-        table.add_column("Direction", style="magenta", no_wrap=True)
-        table.add_column("Related Issue", style="green")
-        table.add_column("Summary", style="white")
+        # Display relationships with clear visual grouping
+        self.console.print("\n[bold cyan]Issue Relationships[/bold cyan]\n")
 
-        for relationship_type, related_issues in relationships_by_type.items():
-            for i, related_issue in enumerate(related_issues):
-                # Only show the relationship type for the first issue in each group
-                type_display = relationship_type if i == 0 else ""
+        for i, (relationship_type, related_issues) in enumerate(relationships_by_type.items()):
+            # Add spacing between groups (except for the first one)
+            if i > 0:
+                self.console.print()
+
+            # Display section header with visual separator
+            header_text = f" {relationship_type} "
+            separator = "═" * (len(header_text) + 10)
+            self.console.print(f"[bold blue]{separator}[/bold blue]")
+            self.console.print(f"[bold blue]═════{header_text}═════[/bold blue]")
+            self.console.print(f"[bold blue]{separator}[/bold blue]")
+
+            # Create a simple table for this relationship type
+            for related_issue in related_issues:
                 direction_symbol = "→" if related_issue["direction"] == "OUTWARD" else "←"
 
-                table.add_row(type_display, direction_symbol, related_issue["issue_id"], related_issue["summary"])
+                # Format the output line
+                issue_line = Text()
+                issue_line.append(f"{direction_symbol} ", style="magenta")
+                issue_line.append(f"{related_issue['issue_id']}", style="green")
+                issue_line.append("    ", style="")
+                issue_line.append(f"{related_issue['summary']}", style="white")
 
-        self.console.print(table)
+                self.console.print(issue_line)
+
+        # Add a final newline for better readability
+        self.console.print()
 
     async def move_issue(
         self, issue_id: str, state: Optional[str] = None, project_id: Optional[str] = None


### PR DESCRIPTION
## Summary

Improves the visual grouping of related issues in the `yt i related --format table` command output by replacing the flat table format with clearly separated sections for each relationship type.

## Changes Made

- **Enhanced visual grouping**: Replace flat table with section headers using visual separators (`═` characters)
- **Clear relationship type headings**: Each relationship type now has its own prominent section header
- **Improved readability**: Direction symbols (`→` `←`) are displayed clearly next to issue IDs
- **Better spacing**: Added appropriate spacing between different relationship type groups
- **Maintained functionality**: All existing functionality preserved, only improved the display format

## Before and After

### Before (flat table format)
```
Relationship Type    Direction    Related Issue    Summary
depends on           →            DEMO-1           First dependency
                     →            DEMO-2           Second dependency  
is required for      ←            DEMO-3           First requirement
                     ←            DEMO-4           Second requirement
```

### After (grouped format)
```
Issue Relationships

═══════════════════
═════ depends on ═════
═══════════════════
→ DEMO-1    First dependency
→ DEMO-2    Second dependency

══════════════════════
═════ is required for ═════
══════════════════════
← DEMO-3    First requirement
← DEMO-4    Second requirement
```

## Testing

- [x] Tested with local YouTrack instance using `yt i related FPU-1 --format table`
- [x] Verified visual formatting and color coding work correctly
- [x] Confirmed no relationships display shows only header appropriately
- [x] All unit and integration tests pass
- [x] Pre-commit hooks pass (linting, type checking, security checks)

## Documentation

No documentation updates needed as this is a visual enhancement that maintains the same command interface.

Fixes #599

🤖 Generated with [Claude Code](https://claude.ai/code)