### PR TITLE
🐛 Fix broken CI type-check: pin ty + correct two return-type annotations

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,9 @@ commands =
     ruff format --check
 
 [testenv:type]
-deps = ty
+# Pin ty: it is pre-release alpha software, so an unpinned dep lets a new
+# release break CI unexpectedly. Keep in sync with the version in uv.lock.
+deps = ty==0.0.1a14
 commands = ty check --ignore call-non-callable --ignore unresolved-attribute --ignore invalid-assignment --ignore invalid-argument-type --ignore unresolved-import --ignore invalid-method-override youtrack_cli
 
 [testenv:format]

--- a/youtrack_cli/performance_benchmark.py
+++ b/youtrack_cli/performance_benchmark.py
@@ -22,7 +22,7 @@ class FieldSelectionBenchmark:
 
     async def benchmark_profile_performance(
         self, project_id: str | None = None, query: str | None = None, sample_size: int = 100
-    ) -> dict[str, dict[str, float]]:
+    ) -> dict[str, dict[str, float | list[float]]]:
         """Benchmark performance across different field selection profiles.
 
         Args:

--- a/youtrack_cli/utils.py
+++ b/youtrack_cli/utils.py
@@ -511,7 +511,7 @@ async def batch_get_resources(
     resource_ids: list[str],
     headers: dict[str, str] | None = None,
     max_concurrent: int = 10,
-) -> list[dict[str, Any]]:
+) -> list[dict[str, Any] | None]:
     """Batch fetch multiple resources by ID.
 
     Args:


### PR DESCRIPTION
## Summary

The `tox` type env used an unpinned `ty` (`deps = ty`). Since `ty` is pre-release alpha, a new release started flagging real type errors, breaking the `type-check` job on every fresh CI run — affecting `main` and all open dependabot PRs (#665, #666, #655).

## Changes
- **`tox.ini`**: pin `ty==0.0.1a14` (matches `uv.lock`) so alpha tooling can't break CI unexpectedly.
- **`performance_benchmark.py`**: return type now `dict[str, dict[str, float | list[float]]]` — the result dict also stores `"times": list[float]`.
- **`utils.py`**: `batch_get_resources` return type now `list[dict[str, Any] | None]` — it appends `None` for failed/non-2xx fetches.

## Verification
- `uv run tox -e type` (pinned a14): ✅ passes
- `ty@latest check`: ✅ exit 0 (the 2 `invalid-return-type` errors resolved; only warnings remain)
- `pre-commit run --all-files`: ✅ all hooks pass

Fixes #667

🤖 Generated with [Claude Code](https://claude.com/claude-code)