### PR TITLE
👷 Replace softprops/action-gh-release with gh release create

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,8 +79,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
 
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v2
-      with:
-        files: dist/*
-        draft: false
-        prerelease: false
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TAG: ${{ github.ref_name }}
+      run: gh release create "$TAG" dist/* --verify-tag --generate-notes


### PR DESCRIPTION
## Summary

zizmor's `superfluous-actions` audit (surfaced by the zizmor bump in #659) flags `softprops/action-gh-release` in `release.yml` — the `gh` CLI on the runner already provides this functionality.

This replaces the `Create GitHub Release` step with a `gh release create` script step:
- `--generate-notes` produces an auto-generated changelog from merged PRs/commits (previously the release body was empty).
- The tag is passed via the `TAG` env var rather than interpolated into the `run:` script, avoiding a `template-injection` finding.
- The `pypi` job already declares `contents: write`, which `gh release create` requires.

## Verification
- `zizmor 1.25.2 .github/workflows/`: ✅ "No findings to report"
- `pre-commit run --all-files` (incl. full pytest + zizmor): ✅ all pass

## Note
Merging touches `.github/workflows/`, which my `gh` token can't push — this will need a web-UI merge (like #655/#666).

Fixes #669

🤖 Generated with [Claude Code](https://claude.com/claude-code)