### PR TITLE
👷 Add Python 3.14 free-threaded (3.14t) to CI and tox (Fixes #616)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
 
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- 👷 Test against Python 3.14 free-threaded (`3.14t`) in CI and tox (#616)
+  - Note: Python 3.13 free-threaded (`3.13t`) is intentionally not supported,
+    as `cffi` (a transitive dependency via `cryptography`) does not support the
+    free-threaded build of CPython 3.13. Free-threaded support starts at 3.14t.
+
 ## [0.22.2] - 2025-03-20
 
 ### Added

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-env_list = py{310,311,312,313,314}, lint, type
+env_list = py{310,311,312,313,314,314t}, lint, type
 runner = uv
 # Enable tox-uv optimizations
 uv_seed = true


### PR DESCRIPTION
## Summary

Adds Python 3.14 free-threaded (`3.14t`) to the CI test matrix and tox environments.

This completes issue #616. The other versions requested in the issue have a status update:
- **Python 3.14 standard** — already added in PR #671.
- **Python 3.14t (free-threaded)** — added here. ✅
- **Python 3.13t (free-threaded)** — intentionally **not** added (see below).

### Why 3.13t is excluded
`cffi` (a transitive dependency via `cryptography`) does not support the free-threaded
build of CPython 3.13 and explicitly refuses to build:

> CFFI does not support the free-threaded build of CPython 3.13. Upgrade to free-threaded 3.14 or newer to use CFFI with the free-threaded build.

This is an upstream decision, not a temporary gap — free-threaded support begins at 3.14t.
This was verified empirically against the current dependency set (`cffi` 2.0.0).

## Changes Made
- `.github/workflows/ci.yml`: add `3.14t` to the test matrix
- `tox.ini`: add `py314t` to `env_list`
- `CHANGELOG.md`: document 3.14t support and the 3.13t exclusion rationale

## Testing
- [x] Full suite passes on 3.14t via the real CI path: `tox -e py314t` → **1362 passed, 81 skipped**
- [x] Dependencies (cffi 2.0.0, cryptography 48.0.0, pydantic-core 2.46.4) install cleanly on 3.14t
- [x] `pre-commit run --all-files` passes (pytest, ruff, zizmor)

## Documentation
- [x] CHANGELOG.md updated

Fixes #616

🤖 Generated with [Claude Code](https://claude.com/claude-code)