### PR TITLE
🐛 Route status messages to stderr for json/csv output (Fixes #648)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- 🐛 `--format json` (and `--format csv`) no longer pollute stdout with status messages (#648)
+  - Progress/status lines such as `🔍 Fetching issues...` are now written to stderr
+    when a machine-readable format is selected, so stdout contains only the structured
+    payload and can be piped or parsed directly (e.g. `yt issues list --format json | jq`)
+  - Applies consistently across `issues`, `articles`, `users`, `projects`, `boards`,
+    and `time` list/search commands
+  - Combine with `--quiet` to suppress the stderr status messages as well
+
 ### Added
 - 👷 Test against Python 3.14 free-threaded (`3.14t`) in CI and tox (#616)
   - Note: Python 3.13 free-threaded (`3.13t`) is intentionally not supported,

--- a/docs/progress-indicators.rst
+++ b/docs/progress-indicators.rst
@@ -1,5 +1,5 @@
 Progress Indicators
-==================
+===================
 
 The YouTrack CLI provides visual progress indicators for long-running operations to improve user experience and provide feedback during bulk operations.
 
@@ -55,6 +55,29 @@ You can disable progress indicators globally using the ``--no-progress`` flag:
 
    # Disable for all subcommands
    yt --no-progress issues list --project PROJECT-1
+
+Machine-Readable Output (JSON and CSV)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a machine-readable output format is requested with ``--format json`` or
+``--format csv``, status and progress messages (for example
+``🔍 Fetching issues...``) are written to **stderr** instead of stdout. This
+guarantees that stdout contains only the structured payload, so the output can
+be piped or parsed directly without any manual filtering:
+
+.. code-block:: bash
+
+   # stdout contains only valid JSON; the status line goes to stderr
+   yt issues list --query "project:FOO type: Epic" --format json | jq '.[].id'
+
+   # Discard the status messages entirely by redirecting stderr
+   yt issues list --format json 2>/dev/null > issues.json
+
+To suppress the status messages on stderr as well, combine with ``--quiet``:
+
+.. code-block:: bash
+
+   yt --quiet issues list --format json
 
 Environment Compatibility
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/commands/test_users.py
+++ b/tests/commands/test_users.py
@@ -134,7 +134,8 @@ class TestListUsersCommand:
         assert result.exit_code == 0
         mock_manager.list_users.assert_called_once()
         mock_manager.display_users_table.assert_called_once_with(sample_users)
-        assert "👥 Fetching users..." in result.output
+        # For table format the status message is routed to stdout via the console.
+        mock_console_instance.print.assert_any_call("👥 Fetching users...", style="blue")
 
     @patch("youtrack_cli.managers.users.UserManager")
     @patch("youtrack_cli.auth.AuthManager")

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -5,15 +5,19 @@ from rich.console import Console
 from rich.theme import Theme
 
 from youtrack_cli.console import (
+    MACHINE_READABLE_FORMATS,
     THEMES,
     ConsoleManager,
     get_available_themes,
     get_console,
     get_console_theme,
     get_default_theme,
+    get_error_console,
     get_theme_by_name,
+    print_status,
     reset_console_theme,
     set_console_theme,
+    set_quiet_mode,
     set_theme_by_name,
 )
 
@@ -275,3 +279,66 @@ class TestThemeContent:
         for theme_name, theme in THEMES.items():
             theme_keys = set(theme.styles.keys())
             assert theme_keys == default_keys, f"Theme '{theme_name}' has different keys than default"
+
+
+@pytest.mark.unit
+class TestPrintStatus:
+    """Test the print_status helper and stderr console routing."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_quiet_mode(self):
+        """Ensure quiet mode does not leak between tests."""
+        set_quiet_mode(False)
+        yield
+        set_quiet_mode(False)
+
+    def test_machine_readable_formats(self):
+        """JSON and CSV are treated as machine-readable formats."""
+        assert "json" in MACHINE_READABLE_FORMATS
+        assert "csv" in MACHINE_READABLE_FORMATS
+        assert "table" not in MACHINE_READABLE_FORMATS
+
+    def test_error_console_writes_to_stderr(self):
+        """The error console writes to stderr."""
+        error_console = get_error_console()
+        assert error_console.stderr is True
+
+    def test_error_console_is_not_stdout_console(self):
+        """The error console is a distinct instance from the stdout console."""
+        assert get_error_console() is not get_console()
+
+    def test_status_goes_to_stdout_for_table(self, capsys):
+        """Status messages go to stdout for human-readable formats."""
+        print_status("fetching", output_format="table")
+
+        captured = capsys.readouterr()
+        assert "fetching" in captured.out
+        assert "fetching" not in captured.err
+
+    def test_status_goes_to_stdout_when_no_format(self, capsys):
+        """Status messages default to stdout when no format is given."""
+        print_status("fetching")
+
+        captured = capsys.readouterr()
+        assert "fetching" in captured.out
+        assert "fetching" not in captured.err
+
+    @pytest.mark.parametrize("output_format", ["json", "csv"])
+    def test_status_goes_to_stderr_for_machine_formats(self, capsys, output_format):
+        """Status messages go to stderr for machine-readable formats."""
+        print_status("fetching", output_format=output_format)
+
+        captured = capsys.readouterr()
+        assert "fetching" not in captured.out
+        assert "fetching" in captured.err
+
+    def test_quiet_mode_suppresses_status(self, capsys):
+        """In quiet mode nothing is printed to stdout or stderr."""
+        set_quiet_mode(True)
+
+        print_status("fetching", output_format="table")
+        print_status("fetching", output_format="json")
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == ""

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -1370,6 +1370,29 @@ class TestIssuesCLI:
             assert result.exit_code == 0
             assert "fetching issues" in result.output.lower()
 
+    def test_issues_list_json_does_not_pollute_stdout(self):
+        """`issues list --format json` keeps status off stdout (issue #648)."""
+        from youtrack_cli.main import main
+
+        runner = CliRunner(mix_stderr=False)
+
+        with patch("youtrack_cli.main.asyncio.run") as mock_run:
+            mock_run.return_value = {
+                "status": "success",
+                "data": [{"id": "PROJ-123", "summary": "Test"}],
+                "count": 1,
+            }
+
+            result = runner.invoke(main, ["issues", "list", "-p", "PROJ", "--format", "json"])
+
+        assert result.exit_code == 0
+        # The progress message must not pollute the JSON payload on stdout.
+        assert "fetching issues" not in result.stdout.lower()
+        # It is still emitted, but on stderr so stdout can be piped/parsed.
+        assert "fetching issues" in result.stderr.lower()
+        # The actual data is written to stdout.
+        assert "PROJ-123" in result.stdout
+
     def test_issues_update_command(self):
         """Test the issues update CLI command."""
         from youtrack_cli.main import main

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -1374,7 +1374,12 @@ class TestIssuesCLI:
         """`issues list --format json` keeps status off stdout (issue #648)."""
         from youtrack_cli.main import main
 
-        runner = CliRunner(mix_stderr=False)
+        # Click < 8.2 mixes stderr into stdout unless ``mix_stderr=False``; Click >= 8.2
+        # removed the argument and always captures stderr separately.
+        try:
+            runner = CliRunner(mix_stderr=False)
+        except TypeError:
+            runner = CliRunner()
 
         with patch("youtrack_cli.main.asyncio.run") as mock_run:
             mock_run.return_value = {

--- a/youtrack_cli/commands/articles.py
+++ b/youtrack_cli/commands/articles.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import click
 
 from ..auth import AuthManager
-from ..console import get_console
+from ..console import get_console, print_status
 
 
 @click.group()
@@ -635,7 +635,7 @@ def list_articles(
     auth_manager = AuthManager(ctx.obj.get("config"))
     article_manager = ArticleManager(auth_manager)
 
-    console.print("📚 Fetching articles...", style="blue")
+    print_status("📚 Fetching articles...", output_format=format)
 
     try:
         # Determine pagination settings
@@ -798,7 +798,7 @@ def search(
     auth_manager = AuthManager(ctx.obj.get("config"))
     article_manager = ArticleManager(auth_manager)
 
-    console.print(f"🔍 Searching articles for '{query}'...", style="blue")
+    print_status(f"🔍 Searching articles for '{query}'...", output_format=format)
 
     try:
         result = asyncio.run(
@@ -853,7 +853,7 @@ def draft(
     auth_manager = AuthManager(ctx.obj.get("config"))
     article_manager = ArticleManager(auth_manager)
 
-    console.print("📝 Fetching draft articles...", style="blue")
+    print_status("📝 Fetching draft articles...", output_format=format)
 
     try:
         result = asyncio.run(
@@ -1192,7 +1192,7 @@ def list_comments(
     auth_manager = AuthManager(ctx.obj.get("config"))
     article_manager = ArticleManager(auth_manager)
 
-    console.print(f"💬 Fetching comments for article '{article_id}'...", style="blue")
+    print_status(f"💬 Fetching comments for article '{article_id}'...", output_format=format)
 
     try:
         result = asyncio.run(article_manager.get_article_comments(article_id))
@@ -1445,7 +1445,7 @@ def list_attachments(
     auth_manager = AuthManager(ctx.obj.get("config"))
     article_manager = ArticleManager(auth_manager)
 
-    console.print(f"📎 Fetching attachments for article '{article_id}'...", style="blue")
+    print_status(f"📎 Fetching attachments for article '{article_id}'...", output_format=format)
 
     try:
         result = asyncio.run(article_manager.get_article_attachments(article_id))

--- a/youtrack_cli/commands/boards.py
+++ b/youtrack_cli/commands/boards.py
@@ -5,7 +5,7 @@ import asyncio
 import click
 
 from ..auth import AuthManager
-from ..console import get_console
+from ..console import get_console, print_status
 
 
 @click.group()
@@ -39,7 +39,7 @@ def list_boards(
     auth_manager = AuthManager(ctx.obj.get("config"))
     board_manager = BoardManager(auth_manager)
 
-    console.print("📋 Listing boards...", style="blue")
+    print_status("📋 Listing boards...", output_format=format)
 
     try:
         result = asyncio.run(board_manager.list_boards(project_id=project_id))
@@ -77,7 +77,7 @@ def show_board(
     auth_manager = AuthManager(ctx.obj.get("config"))
     board_manager = BoardManager(auth_manager)
 
-    console.print(f"👀 Viewing board {board_id}...", style="blue")
+    print_status(f"👀 Viewing board {board_id}...", output_format=format)
 
     try:
         result = asyncio.run(board_manager.view_board(board_id))

--- a/youtrack_cli/commands/issues.py
+++ b/youtrack_cli/commands/issues.py
@@ -14,7 +14,7 @@ import click
 
 from ..auth import AuthManager
 from ..cli_utils import AliasedGroup, validate_issue_id_format, validate_project_id_format
-from ..console import get_console
+from ..console import get_console, print_status
 
 
 def _format_issues_as_csv(issues):
@@ -560,7 +560,7 @@ def list_issues(
     auth_manager = AuthManager(ctx.obj.get("config"))
     issue_manager = IssueManager(auth_manager)
 
-    console.print("🔍 Fetching issues...", style="blue")
+    print_status("🔍 Fetching issues...", output_format=format)
 
     try:
         # Determine pagination settings
@@ -568,8 +568,9 @@ def list_issues(
 
         # Handle conflicting parameters
         if top and page_size != 100:
-            console.print(
+            print_status(
                 "⚠️  Warning: Both --top and --page-size specified. Using --top for backward compatibility.",
+                output_format=format,
                 style="yellow",
             )
 
@@ -887,7 +888,7 @@ def search(
     auth_manager = AuthManager(ctx.obj.get("config"))
     issue_manager = IssueManager(auth_manager)
 
-    console.print(f"🔍 Searching issues for '{query}'...", style="blue")
+    print_status(f"🔍 Searching issues for '{query}'...", output_format=format)
 
     try:
         # Determine pagination settings
@@ -895,8 +896,9 @@ def search(
 
         # Handle conflicting parameters
         if top and page_size != 100:
-            console.print(
+            print_status(
                 "⚠️  Warning: Both --top and --page-size specified. Using --top for backward compatibility.",
+                output_format=format,
                 style="yellow",
             )
 
@@ -1317,7 +1319,7 @@ def list_issue_comments(
     auth_manager = AuthManager(ctx.obj.get("config"))
     issue_manager = IssueManager(auth_manager)
 
-    console.print(f"💬 Fetching comments for issue '{issue_id}'...", style="blue")
+    print_status(f"💬 Fetching comments for issue '{issue_id}'...", output_format=format)
 
     try:
         result = asyncio.run(issue_manager.list_comments(issue_id))
@@ -1512,16 +1514,7 @@ def list_attachments(
     auth_manager = AuthManager(ctx.obj.get("config"))
     issue_manager = IssueManager(auth_manager)
 
-    # Print progress message to stderr when JSON format is used to avoid polluting JSON output
-    if format == "json":
-        import sys
-
-        from rich.console import Console
-
-        stderr_console = Console(file=sys.stderr)
-        stderr_console.print(f"📎 Fetching attachments for issue '{issue_id}'...", style="blue")
-    else:
-        console.print(f"📎 Fetching attachments for issue '{issue_id}'...", style="blue")
+    print_status(f"📎 Fetching attachments for issue '{issue_id}'...", output_format=format)
 
     try:
         result = asyncio.run(issue_manager.list_attachments(issue_id))
@@ -1644,7 +1637,7 @@ def list_links(
     auth_manager = AuthManager(ctx.obj.get("config"))
     issue_manager = IssueManager(auth_manager)
 
-    console.print(f"🔗 Fetching links for issue '{issue_id}'...", style="blue")
+    print_status(f"🔗 Fetching links for issue '{issue_id}'...", output_format=format)
 
     try:
         result = asyncio.run(issue_manager.list_links(issue_id))
@@ -1726,7 +1719,7 @@ def types(ctx: click.Context, format: str) -> None:
     auth_manager = AuthManager(ctx.obj.get("config"))
     issue_manager = IssueManager(auth_manager)
 
-    console.print("🔗 Fetching available link types...", style="blue")
+    print_status("🔗 Fetching available link types...", output_format=format)
 
     try:
         result = asyncio.run(issue_manager.list_link_types())

--- a/youtrack_cli/commands/projects.py
+++ b/youtrack_cli/commands/projects.py
@@ -9,7 +9,7 @@ import asyncio
 import click
 
 from ..auth import AuthManager
-from ..console import get_console
+from ..console import get_console, print_status
 
 
 def show_projects_verbose_help(ctx):
@@ -174,7 +174,7 @@ def projects_list(
     auth_manager = AuthManager(ctx.obj.get("config"))
     project_manager = ProjectManager(auth_manager)
 
-    console.print("📋 Fetching projects...", style="blue")
+    print_status("📋 Fetching projects...", output_format=format)
 
     try:
         # Determine pagination settings
@@ -264,7 +264,7 @@ def projects_show(
     auth_manager = AuthManager(ctx.obj.get("config"))
     project_manager = ProjectManager(auth_manager)
 
-    console.print(f"📋 Fetching project '{project_id}' details...", style="blue")
+    print_status(f"📋 Fetching project '{project_id}' details...", output_format=format)
 
     try:
         result = asyncio.run(project_manager.get_project(project_id, fields=fields))
@@ -556,7 +556,7 @@ def fields_command(
     auth_manager = AuthManager(ctx.obj.get("config"))
     project_manager = ProjectManager(auth_manager)
 
-    console.print(f"📋 Fetching custom fields for project '{project_id}'...", style="blue")
+    print_status(f"📋 Fetching custom fields for project '{project_id}'...", output_format=format)
 
     try:
         result = asyncio.run(project_manager.list_custom_fields(project_id=project_id, fields=fields, top=top))

--- a/youtrack_cli/commands/time_tracking.py
+++ b/youtrack_cli/commands/time_tracking.py
@@ -5,7 +5,7 @@ import asyncio
 import click
 
 from ..auth import AuthManager
-from ..console import get_console
+from ..console import get_console, print_status
 
 
 @click.group()
@@ -79,7 +79,7 @@ def list(
     auth_manager = AuthManager(ctx.obj.get("config"))
     time_manager = TimeManager(auth_manager)
 
-    console.print("📋 Listing time entries...", style="blue")
+    print_status("📋 Listing time entries...", output_format=format)
 
     try:
         result = asyncio.run(
@@ -128,7 +128,7 @@ def work_types(
     auth_manager = AuthManager(ctx.obj.get("config"))
     time_manager = TimeManager(auth_manager)
 
-    console.print("📋 Fetching work types...", style="blue")
+    print_status("📋 Fetching work types...", output_format=format)
 
     try:
         result = asyncio.run(time_manager.get_work_types(issue_id=issue))
@@ -181,7 +181,7 @@ def summary(
     auth_manager = AuthManager(ctx.obj.get("config"))
     time_manager = TimeManager(auth_manager)
 
-    console.print("📋 Generating time summary...", style="blue")
+    print_status("📋 Generating time summary...", output_format=format)
 
     try:
         result = asyncio.run(

--- a/youtrack_cli/commands/users.py
+++ b/youtrack_cli/commands/users.py
@@ -6,7 +6,7 @@ import click
 from rich.prompt import Prompt
 
 from ..auth import AuthManager
-from ..console import get_console
+from ..console import get_console, print_status
 
 
 def show_users_verbose_help(ctx):
@@ -178,7 +178,7 @@ def list_users(
     auth_manager = AuthManager(ctx.obj.get("config"))
     user_manager = UserManager(auth_manager)
 
-    console.print("👥 Fetching users...", style="blue")
+    print_status("👥 Fetching users...", output_format=format)
 
     try:
         # Determine pagination settings
@@ -518,7 +518,7 @@ def users_groups(ctx: click.Context, user_id: str, format: str) -> None:
     auth_manager = AuthManager(ctx.obj.get("config"))
     user_manager = UserManager(auth_manager)
 
-    console.print(f"👥 Fetching groups for user '{user_id}'...", style="blue")
+    print_status(f"👥 Fetching groups for user '{user_id}'...", output_format=format)
 
     try:
         result = asyncio.run(user_manager.get_user_groups(user_id))
@@ -570,7 +570,7 @@ def users_roles(ctx: click.Context, user_id: str, format: str) -> None:
     auth_manager = AuthManager(ctx.obj.get("config"))
     user_manager = UserManager(auth_manager)
 
-    console.print(f"🔐 Fetching roles for user '{user_id}'...", style="blue")
+    print_status(f"🔐 Fetching roles for user '{user_id}'...", output_format=format)
 
     try:
         result = asyncio.run(user_manager.get_user_roles(user_id))
@@ -661,7 +661,7 @@ def users_teams(ctx: click.Context, user_id: str, format: str) -> None:
     auth_manager = AuthManager(ctx.obj.get("config"))
     user_manager = UserManager(auth_manager)
 
-    console.print(f"🏆 Fetching teams for user '{user_id}'...", style="blue")
+    print_status(f"🏆 Fetching teams for user '{user_id}'...", output_format=format)
 
     try:
         result = asyncio.run(user_manager.get_user_teams(user_id))

--- a/youtrack_cli/console.py
+++ b/youtrack_cli/console.py
@@ -130,6 +130,7 @@ class ConsoleManager:
 
     _instance: Optional["ConsoleManager"] = None
     _console: Console | None = None
+    _error_console: Console | None = None
     _theme: Theme | None = None
     _quiet_mode: bool = False
 
@@ -170,6 +171,22 @@ class ConsoleManager:
             self._console = Console(theme=self._theme)
         return self._console
 
+    @property
+    def error_console(self) -> Console:
+        """Get the console instance that writes to stderr.
+
+        Used for status/progress messages that must not pollute machine-readable
+        output (e.g. JSON or CSV) written to stdout.
+
+        Returns:
+            Console: A Rich console writing to stderr using the active theme
+        """
+        if self._error_console is None:
+            if self._theme is None:
+                self._theme = get_default_theme()
+            self._error_console = Console(stderr=True, theme=self._theme)
+        return self._error_console
+
     def set_theme(self, theme: Theme) -> None:
         """Set a new theme for the console.
 
@@ -178,6 +195,7 @@ class ConsoleManager:
         """
         self._theme = theme
         self._console = Console(theme=self._theme)
+        self._error_console = Console(stderr=True, theme=self._theme)
 
     def reset_theme(self) -> None:
         """Reset the console theme to the default."""
@@ -219,6 +237,43 @@ def get_console() -> Console:
         Console: The configured Rich console instance
     """
     return _console_manager.console
+
+
+def get_error_console() -> Console:
+    """Get the global console instance that writes to stderr.
+
+    Returns:
+        Console: A Rich console writing to stderr using the active theme
+    """
+    return _console_manager.error_console
+
+
+#: Output formats that are intended to be consumed by other programs. Status and
+#: progress messages must not be written to stdout for these formats.
+MACHINE_READABLE_FORMATS = frozenset({"json", "csv"})
+
+
+def print_status(message: str, *, output_format: str | None = None, style: str = "blue") -> None:
+    """Print a status/progress message without corrupting machine-readable output.
+
+    Behavior:
+        * In quiet mode, nothing is printed.
+        * When ``output_format`` is a machine-readable format (``json`` or ``csv``),
+          the message is written to stderr so that stdout contains only the
+          structured payload and can be piped/parsed directly.
+        * Otherwise the message is written to stdout via the themed console.
+
+    Args:
+        message: The status message to display.
+        output_format: The output format selected for the command, if any.
+        style: The Rich style to apply to the message.
+    """
+    if is_quiet_mode():
+        return
+    if output_format in MACHINE_READABLE_FORMATS:
+        get_error_console().print(message, style=style)
+    else:
+        get_console().print(message, style=style)
 
 
 def set_console_theme(theme: Theme) -> None:


### PR DESCRIPTION
## Summary

`--format json` (and `--format csv`) previously printed status/progress messages such as `🔍 Fetching issues...` to **stdout**, polluting the structured output so it could not be piped or parsed without manual filtering. `--no-progress` only disables the spinner and `--quiet` did not suppress these `console.print(...)` status lines.

This routes status messages to **stderr** when a machine-readable format is selected, so stdout contains only the structured payload.

```bash
# stdout is now valid JSON; the status line goes to stderr
yt issues list --query "project:FOO type: Epic" --format json | jq '.[].id'
```

## Changes Made

- Add `get_error_console()` and `print_status()` helpers in `console.py`:
  - quiet mode → prints nothing
  - `json`/`csv` → writes to stderr
  - otherwise → writes to stdout (unchanged behavior)
- Apply `print_status` to list/search/show status lines across the `issues`, `articles`, `users`, `projects`, `boards`, and `time` commands.
- Refactor the pre-existing inline stderr hack in `issues attach list` to use the shared helper.

## Testing

- [x] Unit tests added/updated — `print_status` routing (quiet / json→stderr / table→stdout) in `tests/test_console.py`
- [x] CLI test asserting `issues list --format json` writes clean JSON to stdout and the status line to stderr
- [x] Full suite passing (`uv run pytest`), `ruff`, and `ty` all green via `pre-commit run --all-files`
- [ ] Manual testing against local YouTrack instance — server at `0.0.0.0:8080` was unreachable in this environment; covered by automated tests instead

## Documentation

- [x] `docs/progress-indicators.rst` — new "Machine-Readable Output (JSON and CSV)" section (and fixed a pre-existing title-underline warning)
- [x] `CHANGELOG.md` updated under Unreleased → Fixed

Fixes #648

🤖 Generated with [Claude Code](https://claude.com/claude-code)