### PR TITLE
📝 Prepare CHANGELOG for 0.23.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,6 @@ test_runner.py
 
 # Claude configuration
 .claude/settings.local.json
+
+# Scratch article files
+DOCS-A-789.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.23.0] - 2026-06-07
 
 ### Fixed
 - 🐛 `--format json` (and `--format csv`) no longer pollute stdout with status messages (#648)


### PR DESCRIPTION
## Summary
Prepares the changelog for the upcoming **0.23.0** release.

- Converts the `## [Unreleased]` section to `## [0.23.0] - 2026-06-07`
- Adds the scratch `DOCS-A-789.md` article file to `.gitignore`

This is the changelog prep step ahead of running `just release 0.23.0` on main.

### 0.23.0 contents
- **Fixed:** `--format json`/`--format csv` no longer pollute stdout with status messages (#648)
- **Added:** CI/tox testing against Python 3.14 free-threaded (`3.14t`) (#616)

🤖 Generated with [Claude Code](https://claude.com/claude-code)