### PR TITLE
⚡ Speed up CI and stop per-run readthedocs.io link checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs on the same ref so new pushes don't queue behind stale ones.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -109,10 +114,8 @@ jobs:
       with:
         python-version: "3.11"
 
-    - name: Install dependencies and run security check
-      run: |
-        uv sync --dev
-        uv run zizmor .github/workflows/
+    - name: Run security check
+      run: uvx zizmor .github/workflows/
 
   documentation:
     runs-on: ubuntu-latest
@@ -135,11 +138,10 @@ jobs:
 
     - name: Install dependencies and build documentation
       run: |
-        uv sync --dev --group docs
+        uv sync --no-default-groups --group docs
         uv run python -c "import sphinx; print('Sphinx version:', sphinx.__version__)"
         uv run python -m sphinx -b html docs docs/_build/html --keep-going
         uv run python -m sphinx -b doctest docs docs/_build/doctest
-        uv run python -m sphinx -b linkcheck docs docs/_build/linkcheck || true
         echo "Documentation testing infrastructure is in place"
         echo "RST files found:" && find docs/ -name "*.rst" | wc -l
 

--- a/.github/workflows/docs-linkcheck.yml
+++ b/.github/workflows/docs-linkcheck.yml
@@ -1,0 +1,41 @@
+name: Docs Link Check
+
+# Validates external links in the documentation (including readthedocs.io).
+# Runs on a weekly schedule instead of on every push/PR so regular CI does not
+# make outbound network requests on each run. Can also be triggered manually.
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # Mondays at 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linkcheck:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
+      with:
+        persist-credentials: false
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v4
+      with:
+        version: "latest"
+        enable-cache: true
+        cache-dependency-glob: "uv.lock"
+
+    - name: Set up Python
+      uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v5
+      with:
+        python-version: "3.11"
+
+    - name: Check documentation links
+      run: |
+        uv sync --no-default-groups --group docs
+        uv run python -m sphinx -b linkcheck docs docs/_build/linkcheck


### PR DESCRIPTION
## Summary

Speeds up CI and stops every push/PR run from making outbound requests to readthedocs.io (and other external sites).

### Changes
- **Concurrency cancellation** (`ci.yml`): added a `concurrency` group so a new push to a ref cancels the superseded in-flight run instead of queueing behind it.
- **`security` job**: run zizmor via `uvx zizmor` instead of `uv sync --dev` + `uv run zizmor`. No reason to install the whole package + dev deps just to lint workflows.
- **`documentation` job**: install only the docs group (`uv sync --no-default-groups --group docs`) instead of the full dev group, and **removed the Sphinx `linkcheck` step**.
- **New `docs-linkcheck.yml`**: runs `linkcheck` on a weekly cron (Mondays 06:00 UTC) plus manual `workflow_dispatch`, so broken external links are still caught — just not on every push/PR.

### Why
The per-run `sphinx -b linkcheck` was hitting every external URL in the docs (including `yt-cli.readthedocs.io`) on each CI run, with a 30s timeout and retries — slow, flaky, and unnecessary network traffic on every commit.

### Verification
- `pre-commit run --all-files` passes: ruff, ruff-format, ty, pydocstyle, 1371 tests passed / 81 skipped, zizmor clean, package build, docs build
- zizmor reports no findings on both `ci.yml` and the new `docs-linkcheck.yml`
- Docs HTML build confirmed working with the slimmed `--no-default-groups --group docs` install

🤖 Generated with [Claude Code](https://claude.com/claude-code)