### PR TITLE
📝 Fix documentation to match actual CLI (full v0.23.0 review)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     Codecov default-branch baseline fresh, avoiding a redundant second run of
     the entire suite on every merge
 
+### Fixed
+- 📝 Corrected documentation to match the actual CLI (full v0.23.0 doc review) (#681)
+  - Fixed broken examples that would fail if copy-pasted: `reports generate
+    burndown` → `reports burndown`; `time report --from/--to/--assignee` →
+    `time summary`/`time list` with `--start-date`/`--end-date`/`--user-id`;
+    `issues get` → `issues show`; `config show`/`config export` → `config list`;
+    `admin fields show`, `admin maintenance clear-cache`, and `admin usage` (which
+    don't exist); `auth token update` → `auth token --update`; positional-argument
+    fixes for `projects create`, `users create`, and `time log`
+  - Removed false option claims: `--format [table|json|csv]` on `issues`
+    subcommands and `groups list` (CSV/those options aren't supported), the
+    nonexistent `--limit`/`--sort` on `issues list`/`search`, and `--format yaml`
+    references; corrected `projects archive`/`articles` `--confirm` to `--force`
+  - Fixed the global-options table (`--format`, `--no-color`, `--dry-run` are not
+    global; corrected the `--quiet` description)
+  - Documented previously-undocumented features: pagination options
+    (`--page-size`/`--all`/`--max-results`/cursors) on `issues`/`projects`/`users`/
+    `articles list`, the `admin i18n`/`locale` get/set subcommands, and assorted
+    flags (`tutorial reset --all`, `tutorial list --show-progress`,
+    `issues tag add --create-if-missing`, `config theme create --base`/`delete
+    --force`, `articles tree --enhanced`/`--show-metadata`, `attach download
+    --overwrite`)
+
 ## [0.23.0] - 2026-06-07
 
 ### Fixed

--- a/docs/commands/admin.rst
+++ b/docs/commands/admin.rst
@@ -281,6 +281,94 @@ List available locales for internationalization. This command is an alias for ``
 .. note::
    This command provides the same functionality as ``yt admin locale list`` for consistency with other i18n commands.
 
+i18n get
+~~~~~~~~
+
+View the current internationalization settings. This command is an alias for ``yt admin locale get``.
+
+.. code-block:: bash
+
+   yt admin i18n get
+
+i18n set
+~~~~~~~~
+
+Set internationalization settings.
+
+.. code-block:: bash
+
+   yt admin i18n set [OPTIONS]
+
+**Options:**
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Option
+     - Description
+   * - ``--language, -l``
+     - Locale ID to set (e.g., ``en_US``, ``de_DE``, ``fr_FR``)
+   * - ``--timezone, -tz``
+     - Timezone to set (reserved; not implemented in this version)
+   * - ``--date-format, -df``
+     - Date format to set (reserved; not implemented in this version)
+
+**Examples:**
+
+.. code-block:: bash
+
+   # Set the system locale to German
+   yt admin i18n set --language de_DE
+
+Locale Management
+-----------------
+
+locale list
+~~~~~~~~~~~
+
+List available locales (same as ``yt admin i18n list``).
+
+.. code-block:: bash
+
+   yt admin locale list
+
+locale get
+~~~~~~~~~~
+
+View the current system language locale.
+
+.. code-block:: bash
+
+   yt admin locale get
+
+locale set
+~~~~~~~~~~
+
+Set the system language locale.
+
+.. code-block:: bash
+
+   yt admin locale set --language LOCALE_ID
+
+**Options:**
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Option
+     - Description
+   * - ``--language, -l``
+     - Locale ID to set, e.g. ``en_US``, ``de_DE``, ``fr_FR`` (required)
+
+**Examples:**
+
+.. code-block:: bash
+
+   # Set the system locale to French
+   yt admin locale set --language fr_FR
+
 Administrative Features
 ----------------------
 

--- a/docs/commands/alias.rst
+++ b/docs/commands/alias.rst
@@ -212,7 +212,7 @@ You can create aliases for complex command combinations:
    yt alias create criticalbugs "issues list --type Bug --priority Critical --state Open --assignee me"
 
    # Reporting with specific formatting
-   yt alias create weekreport "time report --from -7days --format csv --output weekly.csv"
+   yt alias create weekreport "time summary --start-date 2024-01-01 --format json"
 
 **Integration with Automation:**
 

--- a/docs/commands/articles.rst
+++ b/docs/commands/articles.rst
@@ -314,7 +314,19 @@ List articles with filtering and formatting options.
      - Comma-separated list of fields to return
    * - ``--top, -t``
      - integer
-     - Maximum number of articles to return
+     - Maximum number of articles to return (legacy, use ``--page-size``)
+   * - ``--page-size``
+     - integer
+     - Number of articles per page (default: 100)
+   * - ``--all``
+     - flag
+     - Fetch all results using pagination
+   * - ``--max-results``
+     - integer
+     - Maximum total number of results to fetch
+   * - ``--before-cursor`` / ``--after-cursor``
+     - string
+     - Start pagination before/after this cursor
    * - ``--query, -q``
      - string
      - Search query to filter articles
@@ -371,6 +383,12 @@ Display articles in hierarchical tree structure showing parent-child relationshi
    * - ``--top, -t``
      - integer
      - Maximum number of articles to return
+   * - ``--enhanced``
+     - flag
+     - Use the enhanced tree renderer with richer formatting
+   * - ``--show-metadata``
+     - flag
+     - Show additional article metadata in the tree
 
 **Examples:**
 
@@ -378,6 +396,9 @@ Display articles in hierarchical tree structure showing parent-child relationshi
 
    # Display articles in hierarchical tree structure
    yt articles tree
+
+   # Enhanced tree with metadata
+   yt articles tree --enhanced --show-metadata
 
    # Filter tree view by project
    yt articles tree --project-id PROJECT-123
@@ -698,7 +719,7 @@ Delete a comment (not yet implemented).
    * - Option
      - Type
      - Description
-   * - ``--confirm``
+   * - ``--force``
      - flag
      - Skip confirmation prompt
 
@@ -787,6 +808,9 @@ Download an attachment from an article (not yet implemented).
    * - ``--output, -o``
      - path
      - Output file path
+   * - ``--overwrite``
+     - flag
+     - Overwrite the output file if it already exists
 
 .. note::
    This functionality is not yet implemented and requires binary file handling.
@@ -814,7 +838,7 @@ Delete an attachment from an article (not yet implemented).
    * - Option
      - Type
      - Description
-   * - ``--confirm``
+   * - ``--force``
      - flag
      - Skip confirmation prompt
 

--- a/docs/commands/completion.rst
+++ b/docs/commands/completion.rst
@@ -200,7 +200,7 @@ Advanced completion based on YouTrack data (when implemented):
    # Context-aware examples (future enhancement)
    yt issues update PROJ-<TAB>     # Could complete issue IDs
    yt projects show <TAB>          # Could complete project names
-   yt users assign <TAB>           # Could complete usernames
+   yt users assign-role <TAB>      # Could complete usernames
 
 Installation Methods
 --------------------

--- a/docs/commands/config.rst
+++ b/docs/commands/config.rst
@@ -136,6 +136,12 @@ Create a new custom theme interactively with guided configuration.
 
    yt config theme create
 
+Use ``--base THEME`` to copy an existing theme as the starting point:
+
+.. code-block:: bash
+
+   yt config theme create --base dark
+
 current
 ^^^^^^^
 
@@ -153,6 +159,8 @@ Delete a custom theme from your configuration.
 .. code-block:: bash
 
    yt config theme delete
+
+Use ``--force`` to delete without a confirmation prompt.
 
 export
 ^^^^^^

--- a/docs/commands/groups.rst
+++ b/docs/commands/groups.rst
@@ -65,7 +65,7 @@ List all user groups in your YouTrack instance.
    yt groups list [OPTIONS]
 
 **Options:**
-  * ``--format [table|json|csv]`` - Output format (default: table)
+  * ``-h, --help`` - Show help and exit (this command takes no other options)
 
 **Examples:**
 
@@ -73,12 +73,6 @@ List all user groups in your YouTrack instance.
 
    # List all user groups
    yt groups list
-
-   # List groups in JSON format for processing
-   yt groups list --format json
-
-   # Export group list for reporting
-   yt groups list --format csv > user-groups.csv
 
 Understanding User Groups
 -------------------------

--- a/docs/commands/index.rst
+++ b/docs/commands/index.rst
@@ -49,16 +49,13 @@ These options are available for all commands:
      - Enable verbose output
    * - ``--quiet, -q``
      - flag
-     - Suppress all output except errors
+     - Enable quiet mode for automation (minimal output)
    * - ``--config, -c``
      - path
      - Path to configuration file
    * - ``--debug``
      - flag
      - Enable debug output
-   * - ``--format``
-     - choice
-     - Output format: table, json, yaml (default: table)
    * - ``--help-verbose``
      - flag
      - Show detailed help information with all options and examples
@@ -71,12 +68,12 @@ These options are available for all commands:
    * - ``--version``
      - flag
      - Show the version and exit
-   * - ``--no-color``
-     - flag
-     - Disable colored output
-   * - ``--dry-run``
-     - flag
-     - Show what would be done without making changes
+
+.. note::
+
+   ``--format`` is **not** a global option. Many subcommands accept a
+   ``--format``/``-f`` option (typically ``table`` or ``json``); check each
+   command's help for the formats it supports.
 
 Command Categories
 ------------------
@@ -287,39 +284,38 @@ Most list commands support filtering and searching:
 
 .. code-block:: bash
 
-   yt issues list --assignee me --state open
-   yt issues search --query "project:PROJECT and state:open"
+   yt issues list --assignee me --state Open
+   yt issues search "project:PROJECT state:Open"
 
 Output Formatting
 ~~~~~~~~~~~~~~~~~
 
-All commands support multiple output formats:
+Most list commands support multiple output formats (``table`` and ``json``):
 
 .. code-block:: bash
 
    yt issues list --format json
-   yt projects list --format yaml
+   yt projects list --format json
    yt users list --format table
 
 Batch Operations
 ~~~~~~~~~~~~~~~~
 
-Many commands support batch operations:
+Several commands support batch operations from a CSV or JSON file:
 
 .. code-block:: bash
 
-   yt issues update ISSUE-1 ISSUE-2 ISSUE-3 --state "Fixed"
-   yt users create --from-file users.csv
+   yt issues batch update --file updates.csv
+   yt issues batch create --file new_issues.csv
 
 Interactive Mode
 ~~~~~~~~~~~~~~~~
 
-Some commands provide interactive prompts:
+The setup wizard runs interactively to guide first-time configuration:
 
 .. code-block:: bash
 
-   yt issues create --interactive
-   yt projects configure PROJECT-ID --interactive
+   yt setup
 
 Examples
 --------
@@ -329,15 +325,15 @@ Common command combinations and workflows:
 .. code-block:: bash
 
    # Daily workflow
-   yt issues list --assignee me --state open
+   yt issues list --assignee me --state Open
    yt issues update ISSUE-123 --state "In Progress"
-   yt time log ISSUE-123 --duration "2h" --description "Fixed bug"
+   yt time log ISSUE-123 "2h" --description "Fixed bug"
 
    # Project setup
-   yt projects create --name "New Project" --key "NP"
-   yt users create --username "john.doe" --email "john@example.com"
-   yt projects configure NP --add-user "john.doe"
+   yt projects create "New Project" NP
+   yt users create john.doe "John Doe" john@example.com
+   yt projects configure NP --leader john.doe
 
    # Reporting
-   yt time report --project "PROJECT-ID" --from "2024-01-01"
-   yt reports generate burndown --project "PROJECT-ID" --sprint "Sprint-1"
+   yt time summary --start-date "2024-01-01"
+   yt reports burndown PROJECT-ID --sprint "Sprint-1"

--- a/docs/commands/issues.rst
+++ b/docs/commands/issues.rst
@@ -97,15 +97,19 @@ List and filter issues with advanced options.
   * ``-s, --state TEXT`` - Filter by issue state
   * ``-a, --assignee TEXT`` - Filter by assignee
   * ``-f, --fields TEXT`` - Comma-separated list of fields to return
-  * ``-t, --top INTEGER`` - Maximum number of issues to return (legacy)
-  * ``--max-results INTEGER`` - Maximum number of results to fetch (default: 10,000)
+  * ``--profile [minimal|standard|full]`` - Field selection profile (default: standard)
+  * ``-t, --top INTEGER`` - Maximum number of issues to return (legacy, use ``--page-size``)
+  * ``--page-size INTEGER`` - Number of issues per page (default: 100)
+  * ``--max-results INTEGER`` - Maximum total number of results to fetch
   * ``--after-cursor TEXT`` - Start listing after this cursor position
   * ``--before-cursor TEXT`` - Start listing before this cursor position
+  * ``--all`` - Fetch all results automatically (respects max-results limit)
   * ``--paginated`` - Display results with interactive pagination
   * ``--display-page-size INTEGER`` - Items per page for interactive display (default: 50)
-  * ``--all`` - Fetch all results automatically (respects max-results limit)
+  * ``--show-all`` - Show all results without interactive pagination
+  * ``--start-page INTEGER`` - Page number to start displaying from
   * ``-q, --query TEXT`` - Advanced query filter using YouTrack syntax
-  * ``--format [table|json|csv]`` - Output format (default: table)
+  * ``--format [table|json]`` - Output format (default: table)
 
 .. note::
    The assignee column in table output displays both the user's full name and username
@@ -125,8 +129,8 @@ List and filter issues with advanced options.
    # List issues in JSON format with cursor pagination
    yt issues list --format json --max-results 50
 
-   # Export issues to CSV format for spreadsheet analysis
-   yt issues list --format csv --limit 100
+   # Limit the number of issues returned
+   yt issues list -p PROJ-1 --page-size 100
 
    # Navigate through pages using cursors
    yt issues list -p PROJ-1 --after-cursor "cursor_token_here"
@@ -216,14 +220,15 @@ Advanced issue search with YouTrack query language.
 
 **Options:**
   * ``-p, --project-id TEXT`` - Filter by project ID
-  * ``-t, --top INTEGER`` - Maximum number of results (legacy)
-  * ``--max-results INTEGER`` - Maximum number of results to fetch (default: 10,000)
+  * ``-t, --top INTEGER`` - Maximum number of results (legacy, use ``--page-size``)
+  * ``--page-size INTEGER`` - Number of results per page (default: 100)
+  * ``--max-results INTEGER`` - Maximum total number of results to fetch
   * ``--after-cursor TEXT`` - Start searching after this cursor position
   * ``--before-cursor TEXT`` - Start searching before this cursor position
-  * ``--paginated`` - Display results with interactive pagination
-  * ``--display-page-size INTEGER`` - Items per page for interactive display (default: 50)
   * ``--all`` - Fetch all results automatically (respects max-results limit)
-  * ``--format [table|json|csv]`` - Output format
+  * ``-f, --fields TEXT`` - Comma-separated list of fields to return
+  * ``--profile [minimal|standard|full]`` - Field selection profile (default: standard)
+  * ``--format [table|json]`` - Output format
 
 **Examples:**
 
@@ -329,7 +334,9 @@ Manage issue tags.
 
 .. code-block:: bash
 
-   yt issues tag add ISSUE_ID TAG_NAME
+   yt issues tag add ISSUE_ID TAG_NAME [--create-if-missing]
+
+Use ``--create-if-missing`` to create the tag automatically if it does not already exist.
 
 **Remove Tags:**
 
@@ -414,7 +421,7 @@ List Comments
    yt issues comments list ISSUE_ID [OPTIONS]
 
 **Options:**
-  * ``--format [table|json|csv]`` - Output format
+  * ``-h, --help`` - Show help and exit (this command takes no other options)
 
 Update Comments
 ~~~~~~~~~~~~~~~
@@ -471,7 +478,7 @@ List all attachments for an issue, displaying attachment IDs needed for download
    yt issues attach list ISSUE_ID [OPTIONS]
 
 **Options:**
-  * ``--format [table|json|csv]`` - Output format
+  * ``-h, --help`` - Show help and exit (this command takes no other options)
 
 **Output:** Displays attachment ID, name, size, author, and creation date. The attachment ID can be used with the ``download`` and ``delete`` commands.
 
@@ -528,7 +535,7 @@ List Links
    yt issues links list ISSUE_ID [OPTIONS]
 
 **Options:**
-  * ``--format [table|json|csv]`` - Output format
+  * ``-h, --help`` - Show help and exit (this command takes no other options)
 
 Delete Links
 ~~~~~~~~~~~~
@@ -550,7 +557,7 @@ Display available link types in your YouTrack instance.
    yt issues links types [OPTIONS]
 
 **Options:**
-  * ``--format [table|json|csv]`` - Output format
+  * ``-h, --help`` - Show help and exit (this command takes no other options)
 
 Show Related Issues
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/commands/projects.rst
+++ b/docs/commands/projects.rst
@@ -52,7 +52,19 @@ List all projects with filtering and formatting options.
      - Comma-separated list of project fields to return
    * - ``--top, -t``
      - integer
-     - Maximum number of projects to return
+     - Maximum number of projects to return (legacy, use ``--page-size``)
+   * - ``--page-size``
+     - integer
+     - Number of projects per page (default: 100)
+   * - ``--all``
+     - flag
+     - Fetch all results using pagination
+   * - ``--max-results``
+     - integer
+     - Maximum total number of results to fetch
+   * - ``--before-cursor`` / ``--after-cursor``
+     - string
+     - Start pagination before/after this cursor
    * - ``--show-archived``
      - flag
      - Include archived projects in the list
@@ -272,7 +284,7 @@ Archive a project to mark it as inactive.
    * - Option
      - Type
      - Description
-   * - ``--confirm``
+   * - ``--force``
      - flag
      - Skip confirmation prompt
 
@@ -284,7 +296,7 @@ Archive a project to mark it as inactive.
    yt projects archive PROJECT_KEY
 
    # Archive a project without confirmation prompt
-   yt projects archive PROJECT_KEY --confirm
+   yt projects archive PROJECT_KEY --force
 
 Project Features
 ----------------
@@ -421,7 +433,7 @@ Project Lifecycle Management
    yt projects list
 
    # Archive completed projects
-   yt projects archive OLD_PROJECT --confirm
+   yt projects archive OLD_PROJECT --force
 
    # View all projects including archived
    yt projects list --show-archived
@@ -613,7 +625,7 @@ Bulk Operations
 
    # Archive multiple old projects
    for project in OLD1 OLD2 OLD3; do
-     yt projects archive "$project" --confirm
+     yt projects archive "$project" --force
    done
 
    # Update descriptions for multiple projects

--- a/docs/commands/setup.rst
+++ b/docs/commands/setup.rst
@@ -157,7 +157,7 @@ After completing setup, verify your configuration:
    yt projects list
 
    # Check configuration
-   yt config show
+   yt config list
 
 Configuration Storage
 ---------------------
@@ -253,11 +253,8 @@ Setup integrates with configuration management:
    yt setup
 
    # View and modify configuration later
-   yt config show
+   yt config list
    yt config set key value
-
-   # Export configuration for backup
-   yt config export config-backup.json
 
 Automation and Scripting
 -------------------------

--- a/docs/commands/tutorial.rst
+++ b/docs/commands/tutorial.rst
@@ -39,12 +39,18 @@ List all available tutorials and their current progress status.
 
    yt tutorial list [OPTIONS]
 
+**Options:**
+  * ``--show-progress`` - Show completion progress for each tutorial
+
 **Examples:**
 
 .. code-block:: bash
 
    # List all available tutorials
    yt tutorial list
+
+   # List tutorials with completion progress
+   yt tutorial list --show-progress
 
    # Shows tutorial names, descriptions, and completion status
 
@@ -114,7 +120,10 @@ Reset progress for specific tutorials to start over.
    yt tutorial reset TUTORIAL_NAME [OPTIONS]
 
 **Arguments:**
-  * ``TUTORIAL_NAME`` - The name of the tutorial to reset
+  * ``TUTORIAL_NAME`` - The name of the tutorial to reset (optional when using ``--all``)
+
+**Options:**
+  * ``--all`` - Reset progress for all tutorials
 
 **Examples:**
 
@@ -125,6 +134,9 @@ Reset progress for specific tutorials to start over.
 
    # Reset setup tutorial to start over
    yt tutorial reset setup
+
+   # Reset progress for all tutorials
+   yt tutorial reset --all
 
 Provide Tutorial Feedback
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/commands/users.rst
+++ b/docs/commands/users.rst
@@ -52,7 +52,19 @@ List all users with filtering and search capabilities.
      - Comma-separated list of user fields to return
    * - ``--top, -t``
      - integer
-     - Maximum number of users to return
+     - Maximum number of users to return (legacy, use ``--page-size``)
+   * - ``--page-size``
+     - integer
+     - Number of users per page (default: 100)
+   * - ``--all``
+     - flag
+     - Fetch all results using pagination
+   * - ``--max-results``
+     - integer
+     - Maximum total number of results to fetch
+   * - ``--before-cursor`` / ``--after-cursor``
+     - string
+     - Start pagination before/after this cursor
    * - ``--query, -q``
      - string
      - Search query to filter users

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -198,7 +198,7 @@ Display Settings
      - Description
    * - ``display.output_format``
      - string
-     - Output format: table, json, yaml (default: table)
+     - Output format: table or json (default: table)
    * - ``display.max_results``
      - integer
      - Maximum results to display (default: 50)

--- a/docs/custom-fields.rst
+++ b/docs/custom-fields.rst
@@ -158,11 +158,8 @@ System-level custom field management:
 
 .. code-block:: bash
 
-    # List all custom fields in the system
+    # List all custom fields in the system (includes type and details)
     yt admin fields list
-
-    # View custom field details
-    yt admin fields show FIELD-ID
 
 Best Practices
 ==============

--- a/docs/learning-path.rst
+++ b/docs/learning-path.rst
@@ -93,10 +93,10 @@ Module 1.2: Understanding YouTrack Concepts (45 minutes)
       yt projects list
 
       # Look at issues in a project (replace PROJECT-KEY with actual project)
-      yt issues list --project PROJECT-KEY --limit 5
+      yt issues list --project-id PROJECT-KEY --top 5
 
       # Examine one issue in detail
-      yt issues get ISSUE-ID
+      yt issues show ISSUE-ID
 
 2. **Understand the data structure**:
 
@@ -276,11 +276,11 @@ Module 2.2: Time Tracking and Reporting (45 minutes)
 
 .. code-block:: bash
 
-   # Personal time report
-   yt time report --from "2024-01-01" --to "2024-01-07" --assignee me
+   # Personal time summary
+   yt time summary --start-date "2024-01-01" --end-date "2024-01-07" --user-id me
 
-   # Project time report
-   yt time report --project PROJECT-KEY --from "this-week"
+   # Time summary grouped by issue
+   yt time summary --start-date "2024-01-01" --group-by issue
 
 **Success Criteria**: You can track and report time spent on development work.
 
@@ -443,7 +443,7 @@ Module 3.1: Automation and Scripting (90 minutes)
    $(yt issues search "state:\"In Progress\" updated:today" --format json | jq 'length') issues
 
    ## Time Logged
-   $(yt time report --from today --to today --format json | jq '[.[] | .duration] | add // 0') hours
+   $(yt time list --start-date 2024-01-15 --end-date 2024-01-15 --format json | jq '[.[] | .duration] | add // 0') hours
    EOF
 
    echo "Report generated: $REPORT_FILE"

--- a/docs/progress-indicators.rst
+++ b/docs/progress-indicators.rst
@@ -149,9 +149,9 @@ Admin
 
 Administrative operations with progress:
 
-- ``yt admin maintenance clear-cache`` - Spinner for cache clearing operations
+- ``yt admin fields list`` - Spinner while loading custom fields
 - ``yt admin health check`` - Progress bar for multi-step diagnostics
-- ``yt admin usage users report`` - Progress bar for report generation
+- ``yt admin license usage`` - Progress bar while fetching license usage
 
 Best Practices
 ---------------

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -142,7 +142,7 @@ Generate time reports:
 
 .. code-block:: bash
 
-   yt time report --from "2024-01-01" --to "2024-01-31" --assignee "me"
+   yt time summary --start-date "2024-01-01" --end-date "2024-01-31" --user-id me
 
 5. Configuration
 ----------------

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -852,7 +852,7 @@ Several commands have interactive behavior that prompts for additional informati
 
 **Authentication Commands**:
   - ``yt auth login`` - Interactive authentication setup
-  - ``yt auth token update`` - Interactive token updating
+  - ``yt auth token --update`` - Interactive token updating
 
 **Tutorial Command**:
   ``yt tutorial run`` provides interactive learning modules.

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -23,8 +23,8 @@ Morning Standup Workflow
    # 2. Check recently completed issues (last 7 days)
    yt issues search "assignee:me resolved:today .. -7d"
 
-   # 3. View time spent yesterday
-   yt time report --from yesterday --to today --assignee me
+   # 3. View time you logged for a date range
+   yt time summary --start-date 2024-01-15 --end-date 2024-01-16 --user-id me
 
    # 4. Check upcoming deadlines
    yt issues search "assignee:me has:due-date due:today .. +7d"
@@ -73,8 +73,8 @@ Bug Fix Workflow
    # 7. Mark as resolved and ready for QA
    yt issues update WEB-567 --state "Fixed" --assignee "qa-lead"
 
-   # 8. Generate time report for the bug
-   yt time report --issue WEB-567
+   # 8. List time entries logged against the bug
+   yt time list --issue WEB-567
 
 Feature Development Workflow
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -178,7 +178,7 @@ Sprint Planning Workflow
    # Sprint setup:
    # 1. List backlog issues for planning
    yt issues search "project:WEB-FRONTEND state:Open priority:{High,Medium}" \
-     --sort "priority,created" --limit 20
+     --top 20
 
    # 2. Assign issues to sprint (using tags)
    yt issues update WEB-123 --tags "sprint-15,frontend"
@@ -194,9 +194,9 @@ Sprint Planning Workflow
    # 4. Check sprint progress
    yt issues search "tag:sprint-15 state:{\"In Progress\",Open,\"In Review\"}"
 
-   # 5. Generate sprint burndown data
-   yt time report --from "2024-01-01" --to "2024-01-14" \
-     --project WEB-FRONTEND --format json
+   # 5. Generate sprint time summary
+   yt time summary --start-date "2024-01-01" --end-date "2024-01-14" \
+     --format json
 
    # Sprint retrospective:
    # 6. Review completed vs planned
@@ -407,8 +407,8 @@ Reporting and Analytics Workflow
 .. code-block:: bash
 
    # 1. Team productivity report
-   yt time report --from "2024-01-01" --to "2024-01-31" \
-     --project WEB-FRONTEND --format json > team-time.json
+   yt time summary --start-date "2024-01-01" --end-date "2024-01-31" \
+     --group-by user --format json > team-time.json
 
    # 2. Issue velocity analysis
    yt issues search "project:WEB-FRONTEND resolved:this-month" \
@@ -515,7 +515,7 @@ Script Safety Tips
    set -e  # Exit on any error
 
    # 2. Test with limited scope first
-   yt issues search "project:TEST-PROJECT" --limit 5
+   yt issues search "project:TEST-PROJECT" --top 5
 
    # 3. Use dry-run when available
    # Preview batch operations before executing
@@ -541,7 +541,7 @@ Performance Optimization
 .. code-block:: bash
 
    # 1. Use specific filters to reduce data transfer
-   yt issues search "project:WEB created:today" --limit 50
+   yt issues search "project:WEB created:today" --top 50
 
    # 2. Batch operations when possible
    # Instead of individual updates:
@@ -584,7 +584,7 @@ Error Handling Patterns
 .. code-block:: bash
 
    # 1. Check if issue exists before updating
-   if yt issues get WEB-123 >/dev/null 2>&1; then
+   if yt issues show WEB-123 >/dev/null 2>&1; then
      yt issues update WEB-123 --state "In Progress"
    else
      echo "Issue WEB-123 not found"

--- a/docs/youtrack-concepts.rst
+++ b/docs/youtrack-concepts.rst
@@ -178,8 +178,8 @@ Here's how YouTrack concepts map to CLI commands:
    # Log work time
    yt time log ISSUE-ID "2h 30m" --description "Fixed the bug"
 
-   # Generate time report
-   yt time report --from "2024-01-01" --to "2024-01-31"
+   # Generate time summary
+   yt time summary --start-date "2024-01-01" --end-date "2024-01-31"
 
 Getting Started Tips
 --------------------


### PR DESCRIPTION
Closes #681

## Summary
A full review comparing every file in `docs/` against the actual CLI command tree (recursively extracted from `--help` on v0.23.0). The dedicated command-reference pages were largely accurate; the drift was concentrated in cross-cutting prose (`index.rst`, `workflows.rst`, `learning-path.rst`, `quickstart.rst`, `youtrack-concepts.rst`) and in missing/incorrect option documentation.

## Broken examples fixed (would fail if copy-pasted)
- `yt reports generate burndown` → `yt reports burndown`
- `yt time report --from/--to/--assignee` → `yt time summary`/`yt time list` with `--start-date`/`--end-date`/`--user-id` (no `report` subcommand exists; those flags don't exist)
- `yt issues get` → `yt issues show`
- `yt config show`/`yt config export` → `yt config list` (no such subcommands)
- `yt admin fields show`, `yt admin maintenance clear-cache`, `yt admin usage` → removed/replaced (don't exist)
- `yt auth token update` → `yt auth token --update`
- Positional-argument fixes for `yt projects create`, `yt users create`, `yt time log`

## False option claims removed
- `--format [table|json|csv]` on `issues` subcommands and `groups list` (CSV/those options aren't supported; several have no `--format` at all)
- Nonexistent `--limit`/`--sort` on `issues list`/`search`; stray `--format yaml` references
- `projects archive` / `articles` `--confirm` → `--force` (actual flag name)
- Global-options table: `--format`, `--no-color`, `--dry-run` are **not** global; corrected `--quiet` description

## Newly documented (features existed, docs omitted them)
- Pagination options (`--page-size`/`--all`/`--max-results`/cursors) on `issues`/`projects`/`users`/`articles list`
- `admin i18n`/`locale` get/set subcommands
- `tutorial reset --all`, `tutorial list --show-progress`, `issues tag add --create-if-missing`, `config theme create --base`/`delete --force`, `articles tree --enhanced`/`--show-metadata`, `attach download --overwrite`

## Verification
- Re-ran an automated CLI-tree vs docs option-coverage scan → no remaining gaps
- `pre-commit run --all-files` passes (ruff, ty, 1371 tests, Sphinx docs build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)