### PR TITLE
🐛 Fix broken links and cross-reference flagged by just docs-check

### DIFF
--- a/docs/commands/setup.rst
+++ b/docs/commands/setup.rst
@@ -389,4 +389,4 @@ See Also
 * :doc:`auth` - Authentication management and login
 * :doc:`config` - CLI configuration and settings management
 * Getting Started guide for complete setup instructions
-* :doc:`troubleshooting` - Common issues and solutions
+* :doc:`/troubleshooting` - Common issues and solutions

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -1201,7 +1201,6 @@ If this guide doesn't resolve your issue:
 
 1. **Check existing issues**: `GitHub Issues <https://github.com/ryancheley/yt-cli/issues>`_
 2. **Create new issue**: Include error messages, command used, and system info
-3. **Join discussions**: `GitHub Discussions <https://github.com/ryancheley/yt-cli/discussions>`_
 
 When reporting issues, include:
 

--- a/youtrack_cli/utils.py
+++ b/youtrack_cli/utils.py
@@ -515,7 +515,7 @@ async def batch_get_resources(
     """Batch fetch multiple resources by ID.
 
     Args:
-        base_url: Base URL pattern with {id} placeholder (e.g., "https://api.com/issues/{id}")
+        base_url: Base URL pattern with {id} placeholder (e.g., "https://youtrack.example.com/api/issues/{id}")
         resource_ids: List of resource IDs to fetch
         headers: Optional request headers
         max_concurrent: Maximum number of concurrent requests


### PR DESCRIPTION
## Summary
`just docs-check` (Sphinx linkcheck) was failing. Fixed the three issues it surfaced:

1. **`https://api.com/issues`** — a placeholder URL in the `batch_get_resources` docstring (`youtrack_cli/utils.py`) that Sphinx autodoc rendered as a real, broken external link (DNS failure). Changed to `https://youtrack.example.com/api/issues/{id}`, which matches the existing `linkcheck_ignore` pattern and is YouTrack-appropriate.
2. **`https://github.com/ryancheley/yt-cli/discussions`** — returned 404 because GitHub Discussions isn't enabled for the repo (`has_discussions: false`). Removed the dead "Join discussions" bullet from `troubleshooting.rst` (the Issues link above it already covers getting help).
3. **`setup.rst:392: unknown document: 'troubleshooting'`** — the `:doc:` reference resolved relative to `docs/commands/`, but `troubleshooting.rst` is in `docs/`. Changed to an absolute `:doc:`/troubleshooting`` reference.

## Verification
`just docs-check` now exits 0 with zero broken links. The remaining linkcheck warnings are pre-existing RST style issues (title underline lengths, a docstring definition-list formatting nit) unrelated to links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)