### PR TITLE
📝 Fix short RST title underlines for a warning-free docs build

### DIFF
--- a/docs/commands/admin.rst
+++ b/docs/commands/admin.rst
@@ -53,13 +53,13 @@ List all global YouTrack settings.
    yt admin global-settings list
 
 License Management
------------------
+------------------
 
 .. note::
    The license show command has been deprecated and is no longer available.
 
 license usage
-~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 Show detailed license usage statistics and capacity information.
 
@@ -120,7 +120,7 @@ System Health Monitoring
 ------------------------
 
 health check
-~~~~~~~~~~~
+~~~~~~~~~~~~
 
 Run comprehensive system health diagnostics and display system status.
 
@@ -142,10 +142,10 @@ Run comprehensive system health diagnostics and display system status.
    yt admin health check
 
 User Groups Management
----------------------
+----------------------
 
 user-groups list
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 List all user groups in the YouTrack system with filtering options.
 
@@ -180,7 +180,7 @@ List all user groups in the YouTrack system with filtering options.
    yt admin user-groups list --fields "id,name,description,users(fullName)"
 
 user-groups create
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 Create a new user group with specified settings.
 
@@ -222,7 +222,7 @@ Custom Fields Management
 ------------------------
 
 fields list
-~~~~~~~~~~
+~~~~~~~~~~~
 
 List all custom fields configured across YouTrack projects.
 
@@ -370,10 +370,10 @@ Set the system language locale.
    yt admin locale set --language fr_FR
 
 Administrative Features
-----------------------
+-----------------------
 
 Global Settings
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 **System Configuration**
   Manage server-wide settings including performance, security, and feature configurations.
@@ -388,7 +388,7 @@ Global Settings
   Adjust system performance parameters and resource limits.
 
 License Management
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 **License Information**
   View license details including expiration dates, feature limits, and user capacity.
@@ -400,7 +400,7 @@ License Management
   Monitor license compliance and usage patterns.
 
 System Maintenance
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 **Cache Management**
   Note: Cache clearing is not available through the REST API. Use the YouTrack administrative UI or server-side tools for cache management.
@@ -412,7 +412,7 @@ System Maintenance
   Tools for system performance analysis and optimization.
 
 User and Group Management
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **User Groups**
   Create and manage user groups for permission and access control.
@@ -424,7 +424,7 @@ User and Group Management
   Set up user groups that reflect organizational hierarchy.
 
 Custom Fields
-~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 **Field Management**
   View and manage custom fields across all projects.
@@ -436,10 +436,10 @@ Custom Fields
   Ensure custom field consistency across projects.
 
 Common Administrative Workflows
-------------------------------
+-------------------------------
 
 System Health Monitoring
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -462,7 +462,7 @@ System Health Monitoring
    yt admin license usage
 
 Regular Maintenance
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -480,7 +480,7 @@ Regular Maintenance
    echo "Maintenance completed at $(date)"
 
 User Group Management
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -501,7 +501,7 @@ User Group Management
    yt admin user-groups list --fields "name,description"
 
 System Configuration
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -516,7 +516,7 @@ System Configuration
    yt admin global-settings list
 
 License Monitoring
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -562,10 +562,10 @@ Best Practices
 10. **Capacity Planning**: Monitor usage trends for capacity planning and license management.
 
 Security Considerations
-----------------------
+-----------------------
 
 Administrative Access
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 * **Limited Access**: Restrict administrative access to authorized personnel only
 * **Audit Trail**: Maintain audit logs of administrative actions
@@ -573,7 +573,7 @@ Administrative Access
 * **Regular Review**: Regularly review and update administrative permissions
 
 System Security
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 * **Setting Validation**: Validate all configuration changes for security implications
 * **Secure Defaults**: Use secure default values for system settings
@@ -581,10 +581,10 @@ System Security
 * **Access Monitoring**: Monitor administrative access and actions
 
 Troubleshooting
---------------
+---------------
 
 Common Issues and Solutions
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Permission Denied Errors**
   Verify administrative privileges and check authentication status.
@@ -611,7 +611,7 @@ Common Issues and Solutions
   The command will automatically try fallback endpoints and provide specific guidance based on the error type.
 
 System Diagnostics
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -638,7 +638,7 @@ System Diagnostics
    echo "Diagnostics completed"
 
 Error Recovery
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -658,10 +658,10 @@ Error Recovery
    yt admin global-settings list
 
 Integration Examples
--------------------
+--------------------
 
 Monitoring Integration
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -680,7 +680,7 @@ Monitoring Integration
    echo "youtrack_license_usage_percent 75"
 
 Backup Integration
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -702,7 +702,7 @@ Backup Integration
    echo "Administrative backup completed: $BACKUP_DIR"
 
 Automation Scripts
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 

--- a/docs/commands/articles.rst
+++ b/docs/commands/articles.rst
@@ -904,7 +904,7 @@ Draft to Publication Workflow
    yt articles publish ARTICLE-123
 
 Content Management
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 

--- a/docs/commands/completion.rst
+++ b/docs/commands/completion.rst
@@ -56,7 +56,7 @@ Supported Shells
 ----------------
 
 Bash Completion
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 Generate and install bash completion:
 
@@ -84,7 +84,7 @@ After installation, restart your shell or run:
    source ~/.bashrc
 
 Zsh Completion
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 Generate and install zsh completion:
 
@@ -116,7 +116,7 @@ Add to your ``~/.zshrc``:
    fpath=(~/.zsh/completions $fpath)
 
 Fish Completion
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 Generate and install fish completion:
 
@@ -140,7 +140,7 @@ Fish automatically loads completions from the completions directory. Restart you
    fish_config reload
 
 PowerShell Completion
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 Generate PowerShell completion:
 
@@ -167,7 +167,7 @@ Completion Features
 -------------------
 
 Command Completion
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 Tab completion works for all CLI commands and subcommands:
 
@@ -179,7 +179,7 @@ Tab completion works for all CLI commands and subcommands:
    yt pro<TAB>       # Completes to: yt projects
 
 Option Completion
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 Complete option names and flags:
 
@@ -191,7 +191,7 @@ Complete option names and flags:
    yt config set --h<TAB>       # Completes to: --help
 
 Context-Aware Completion
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 Advanced completion based on YouTrack data (when implemented):
 
@@ -206,7 +206,7 @@ Installation Methods
 --------------------
 
 Automatic Installation
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 Use the ``--install`` flag for automatic installation:
 
@@ -294,7 +294,7 @@ Include completion setup in container environments:
    RUN echo "source /etc/bash_completion.d/yt" >> /etc/bash.bashrc
 
 CI/CD Integration
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 Include completion setup in development environment automation:
 
@@ -315,7 +315,7 @@ Troubleshooting
 ---------------
 
 Common Installation Issues
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Permission Denied:**
   * Try manual installation to user directories instead of system-wide
@@ -382,7 +382,7 @@ For advanced users, completion scripts can be customized:
    # Then source or install the customized version
 
 Multiple CLI Tool Integration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Integrate YouTrack CLI completion with other development tools:
 
@@ -397,7 +397,7 @@ Performance Considerations
 --------------------------
 
 Completion Performance
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 Large projects or extensive command histories might affect completion performance:
 
@@ -406,7 +406,7 @@ Large projects or extensive command histories might affect completion performanc
 * **Filtering:** Completion results are filtered based on current input
 
 Optimization Tips
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 * Restart shells periodically to clear completion caches
 * Update completion scripts when CLI is updated

--- a/docs/commands/config.rst
+++ b/docs/commands/config.rst
@@ -224,10 +224,10 @@ Set the active theme for YouTrack CLI output and appearance.
    yt config theme delete
 
 Common Configuration Keys
-------------------------
+-------------------------
 
 Project Settings
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 .. list-table::
    :widths: 30 20 50
@@ -247,7 +247,7 @@ Project Settings
      - Default project filter for searches
 
 Display Settings
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 .. list-table::
    :widths: 30 20 50
@@ -270,7 +270,7 @@ Display Settings
      - Default timezone for date displays
 
 Issue Management
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 .. list-table::
    :widths: 30 20 50
@@ -313,7 +313,7 @@ Time Tracking
      - Round time entries to nearest X minutes
 
 Connection Settings
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :widths: 30 20 50
@@ -333,10 +333,10 @@ Connection Settings
      - Enable response caching
 
 Configuration Examples
----------------------
+----------------------
 
 Basic Setup
-~~~~~~~~~~
+~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -350,7 +350,7 @@ Basic Setup
    yt config list
 
 Development Environment
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -366,7 +366,7 @@ Development Environment
    yt config set ROUND_TIME "15"
 
 Team Lead Configuration
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -381,7 +381,7 @@ Team Lead Configuration
    yt config set GROUP_BY_ASSIGNEE "true"
 
 Project Manager Setup
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -399,7 +399,7 @@ Environment-Specific Configuration
 ----------------------------------
 
 Multiple Environments
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -416,7 +416,7 @@ Multiple Environments
    yt --config ~/.config/yt-prod.env config set BASE_URL "https://youtrack.company.com"
 
 Project-Specific Settings
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -434,7 +434,7 @@ Configuration Workflows
 -----------------------
 
 Initial Setup
-~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -458,7 +458,7 @@ Initial Setup
    yt config list
 
 Team Onboarding
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -488,7 +488,7 @@ Team Onboarding
    echo "Team configuration applied!"
 
 Configuration Migration
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -538,10 +538,10 @@ Best Practices
 10. **Testing**: Test configuration changes in non-production environments first.
 
 Configuration File Management
-----------------------------
+-----------------------------
 
 File Locations
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -557,7 +557,7 @@ File Locations
    ~/.config/youtrack-cli/production.env
 
 File Format
-~~~~~~~~~~
+~~~~~~~~~~~
 
 Configuration files use environment variable format:
 
@@ -572,7 +572,7 @@ Configuration files use environment variable format:
    DEFAULT_WORK_TYPE=Development
 
 Backup and Restore
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -586,10 +586,10 @@ Backup and Restore
    yt config list | grep -v "token\|password\|secret" > team_config.txt
 
 Advanced Configuration
----------------------
+----------------------
 
 Custom Configuration Templates
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -613,7 +613,7 @@ Custom Configuration Templates
    echo "Configuration template created: $TEMPLATE_FILE"
 
 Configuration Validation
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -642,7 +642,7 @@ Configuration Validation
    fi
 
 Dynamic Configuration
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -685,10 +685,10 @@ Common error scenarios and solutions:
   CLI will create directory automatically on first use.
 
 Integration Examples
--------------------
+--------------------
 
 Shell Integration
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -705,7 +705,7 @@ Shell Integration
    }
 
 Configuration Scripts
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -727,7 +727,7 @@ Configuration Scripts
    echo "Configuration deployment complete"
 
 Monitoring and Auditing
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 

--- a/docs/commands/groups.rst
+++ b/docs/commands/groups.rst
@@ -30,7 +30,7 @@ Group Management Commands
 -------------------------
 
 Create User Groups
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 Create a new user group for organizing users and permissions.
 
@@ -56,7 +56,7 @@ Create a new user group for organizing users and permissions.
    yt groups create --name "Web Project Contributors" --description "Contributors to web development project"
 
 List User Groups
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 List all user groups in your YouTrack instance.
 
@@ -139,7 +139,7 @@ Use Cases and Applications
 --------------------------
 
 Team Organization
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 Organize users by functional teams and roles:
 
@@ -157,7 +157,7 @@ Organize users by functional teams and roles:
   * Streamlined onboarding for new team members
 
 Project Access Control
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 Create project-specific groups for access management:
 
@@ -174,7 +174,7 @@ Create project-specific groups for access management:
   * Support for project-based team structures
 
 Permission Management
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 Organize users by permission levels and access requirements:
 
@@ -269,7 +269,7 @@ Automation and Integration
 --------------------------
 
 Automated Group Management
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Automate group creation for consistent organizational structures:
 
@@ -309,7 +309,7 @@ Generate reports on group structure and membership:
    ' > groups-report.csv
 
 Integration with User Management
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Combine group management with user operations:
 
@@ -322,7 +322,7 @@ Combine group management with user operations:
    # This demonstrates the integration pattern even if specific commands aren't implemented yet
 
 Directory Services Integration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For enterprise environments, groups often integrate with directory services:
 

--- a/docs/commands/projects.rst
+++ b/docs/commands/projects.rst
@@ -411,7 +411,7 @@ Project Setup
    yt projects list
 
 Project Maintenance
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -425,7 +425,7 @@ Project Maintenance
    yt projects configure PROJECT_KEY --show-details
 
 Project Lifecycle Management
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -442,7 +442,7 @@ Project Lifecycle Management
    yt projects list --format json > projects_report.json
 
 Project Discovery and Reporting
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -477,10 +477,10 @@ Best Practices
 9. **Lifecycle Planning**: Plan for project phases including creation, active development, and archival.
 
 Project Templates
-----------------
+-----------------
 
 Scrum Template
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 The Scrum template configures projects for Scrum methodology:
 
@@ -499,7 +499,7 @@ The Scrum template configures projects for Scrum methodology:
      --description "Agile development using Scrum methodology"
 
 Kanban Template
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 The Kanban template configures projects for Kanban workflow:
 
@@ -581,7 +581,7 @@ Common error scenarios and solutions:
   Some projects may have restrictions preventing archival. Check project dependencies.
 
 Integration Examples
--------------------
+--------------------
 
 Scripting and Automation
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -605,7 +605,7 @@ Scripting and Automation
    yt projects configure "$PROJECT_KEY" --show-details
 
 Project Reporting
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -619,7 +619,7 @@ Project Reporting
      jq '.[] | select(.archived == true)'
 
 Bulk Operations
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 

--- a/docs/commands/setup.rst
+++ b/docs/commands/setup.rst
@@ -108,7 +108,7 @@ First-Time Setup Workflow
 --------------------------
 
 Initial Installation
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 After installing YouTrack CLI, start with the setup command:
 
@@ -163,7 +163,7 @@ Configuration Storage
 ---------------------
 
 Secure Credential Storage
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The setup wizard ensures secure handling of your credentials:
 
@@ -208,7 +208,7 @@ The wizard will:
 * **Validate Changes:** Test new configuration before saving
 
 Partial Reconfiguration
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
 For specific configuration changes, consider these alternatives to full setup:
 
@@ -227,7 +227,7 @@ Integration with Other Commands
 -------------------------------
 
 Authentication Integration
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Setup works seamlessly with authentication commands:
 

--- a/docs/commands/tutorial.rst
+++ b/docs/commands/tutorial.rst
@@ -93,7 +93,7 @@ Run a specific tutorial module with interactive guidance.
    yt tutorial run time
 
 Show Tutorial Progress
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 Show detailed progress information for all tutorials.
 
@@ -111,7 +111,7 @@ Show detailed progress information for all tutorials.
    # Displays completion percentage, current step, and next actions
 
 Reset Tutorial Progress
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Reset progress for specific tutorials to start over.
 
@@ -160,7 +160,7 @@ Available Tutorial Modules
 ---------------------------
 
 Setup Tutorial
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 Learn authentication and configuration fundamentals:
 
@@ -184,7 +184,7 @@ Learn authentication and configuration fundamentals:
   * Troubleshoot common setup issues
 
 Issues Tutorial
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 Master issue management workflows:
 
@@ -208,7 +208,7 @@ Master issue management workflows:
   * Collaborate effectively using comments and attachments
 
 Projects Tutorial
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 Learn project management and configuration:
 
@@ -232,7 +232,7 @@ Learn project management and configuration:
   * Generate useful project reports and insights
 
 Time Tracking Tutorial
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 Master time tracking and reporting workflows:
 
@@ -259,7 +259,7 @@ Tutorial Features and Benefits
 ------------------------------
 
 Interactive Learning Experience
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Tutorials provide hands-on, interactive learning:
 
@@ -276,7 +276,7 @@ Tutorials provide hands-on, interactive learning:
   * Include troubleshooting tips for common issues
 
 Progress Tracking and Resume
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Advanced progress management features:
 
@@ -293,7 +293,7 @@ Advanced progress management features:
   * Bookmark important sections for future reference
 
 Beginner-Friendly Design
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 Tutorials are designed for users at all skill levels:
 
@@ -313,7 +313,7 @@ Using Tutorials Effectively
 ---------------------------
 
 Getting Started
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 Begin your learning journey with the tutorials:
 
@@ -335,7 +335,7 @@ Begin your learning journey with the tutorials:
   4. **Time Tutorial** - Advanced productivity and reporting features
 
 Maximizing Learning Value
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Get the most from your tutorial experience:
 
@@ -352,7 +352,7 @@ Get the most from your tutorial experience:
   * Share tutorial insights with team members
 
 Troubleshooting Learning Issues
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you encounter problems during tutorials:
 
@@ -377,7 +377,7 @@ Team and Enterprise Usage
 --------------------------
 
 Team Onboarding
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 Use tutorials for consistent team training:
 
@@ -397,7 +397,7 @@ Use tutorials for consistent team training:
   * Self-service learning reduces training overhead
 
 Enterprise Training Programs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Integrate tutorials into larger training initiatives:
 
@@ -416,7 +416,7 @@ Feedback and Continuous Improvement
 -----------------------------------
 
 Providing Feedback
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 Help improve tutorials through feedback:
 
@@ -439,7 +439,7 @@ Help improve tutorials through feedback:
   * Include error messages or unexpected behavior
 
 Community Contributions
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Contribute to tutorial improvement:
 
@@ -480,7 +480,7 @@ Troubleshooting
 ---------------
 
 Common Tutorial Issues
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 **Tutorial Won't Start:**
   * Verify you have authentication configured properly
@@ -498,7 +498,7 @@ Common Tutorial Issues
   * Check that you have appropriate data and permissions in YouTrack
 
 Recovery and Reset
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 If tutorials become corrupted or stuck:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -5,7 +5,7 @@ YouTrack CLI can be configured through multiple methods, allowing you to customi
 its behavior to match your workflow.
 
 Configuration Sources
---------------------
+---------------------
 
 YouTrack CLI reads configuration from multiple sources in this order (later sources override earlier ones):
 

--- a/docs/learning-path.rst
+++ b/docs/learning-path.rst
@@ -1,5 +1,5 @@
 Learning Path Guide
-==================
+===================
 
 This guide provides a structured approach to learning YouTrack CLI, from complete beginner to advanced user.
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -1150,7 +1150,7 @@ Version Management Issues
    uv sync --dev
 
 CI/CD Integration Issues
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Problem**: GitHub Actions workflow not triggering.
 


### PR DESCRIPTION
## Summary
Every Sphinx docs build emitted ~113 `Title underline too short` warnings — section underlines (`---`, `~~~`, etc.) that were one or more characters shorter than their title text. This extends each to match its title length.

## Scope
113 underlines across 11 files: `commands/admin.rst`, `commands/config.rst`, `commands/tutorial.rst`, `commands/completion.rst`, `commands/projects.rst`, `commands/groups.rst`, `commands/setup.rst`, `commands/articles.rst`, plus `configuration.rst`, `learning-path.rst`, and `troubleshooting.rst`.

## Safety
- Only underline lines were modified — verified that all 113 added lines are pure-punctuation underline characters (no prose/table/transition lines touched).
- The Sphinx build is now **warning-free** (`sphinx-build -b html` reports 0 warnings, down from ~113).

🤖 Generated with [Claude Code](https://claude.com/claude-code)