### PR TITLE
📝 Fix invented options found by a second /deep-review pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `issues tag add --create-if-missing`, `config theme create --base`/`delete
     --force`, `articles tree --enhanced`/`--show-metadata`, `attach download
     --overwrite`)
+- 📝 Fixed more invented options found by a second `/deep-review` pass (#686)
+  - `admin fields list --fields` and `admin user-groups list --fields` do not
+    exist (those commands take no options); removed the option rows and examples
+  - `groups create`/`admin user-groups create` use a positional `NAME`, not
+    `--name`; `groups list`/`admin user-groups list` have no `--format`
+  - `issues list --project`/`--priority` → `--project-id`/`--query`;
+    `projects list --detailed` → `-f`; `projects create --name/--key` → positional
+    `NAME SHORT_NAME`; `auth login --test` → `auth status`; `config list
+    --show-file` → the default `~/.config/youtrack-cli/.env` path
+  - Replaced the fictional `yt settings` / `admin global-settings get`/`set`
+    examples in the command-aliases doc with the real `admin global-settings list`
 
 ## [0.23.0] - 2026-06-07
 

--- a/docs/command-aliases.rst
+++ b/docs/command-aliases.rst
@@ -297,12 +297,8 @@ Flatter Commands
    yt admin user-groups list
    yt groups list
 
-   # Settings - Traditional vs Flatter
-   yt admin global-settings get --name system.timeZone
-   yt settings get --name system.timeZone
-
-   yt admin global-settings set timeout 30
-   yt settings set timeout 30
+   # Global settings (view only — no flatter alias)
+   yt admin global-settings list
 
    # Audit Log - Traditional vs Flatter
    yt security audit --limit 25 --format json
@@ -372,7 +368,7 @@ Flatter Command Workflows:
 
    # Administrative tasks
    yt groups create "QA Team"                 # Create user group
-   yt settings get --name system.timeZone     # Check timezone setting
+   yt admin global-settings list              # View global settings
    yt audit --limit 10                       # Review recent actions
 
 Help and Discovery

--- a/docs/commands/admin.rst
+++ b/docs/commands/admin.rst
@@ -154,17 +154,7 @@ List all user groups in the YouTrack system with filtering options.
    yt admin user-groups list [OPTIONS]
 
 **Options:**
-
-.. list-table::
-   :widths: 20 20 60
-   :header-rows: 1
-
-   * - Option
-     - Type
-     - Description
-   * - ``--fields, -f``
-     - string
-     - Comma-separated list of fields to return
+  * ``-h, --help`` - Show help and exit (this command takes no other options)
 
 **Examples:**
 
@@ -172,12 +162,6 @@ List all user groups in the YouTrack system with filtering options.
 
    # List all user groups
    yt admin user-groups list
-
-   # List groups with specific fields
-   yt admin user-groups list --fields "id,name,description,users(login)"
-
-   # List groups with user information
-   yt admin user-groups list --fields "id,name,description,users(fullName)"
 
 user-groups create
 ~~~~~~~~~~~~~~~~~~
@@ -231,17 +215,7 @@ List all custom fields configured across YouTrack projects.
    yt admin fields list [OPTIONS]
 
 **Options:**
-
-.. list-table::
-   :widths: 20 20 60
-   :header-rows: 1
-
-   * - Option
-     - Type
-     - Description
-   * - ``--fields, -f``
-     - string
-     - Comma-separated list of fields to return
+  * ``-h, --help`` - Show help and exit (this command takes no other options)
 
 **Examples:**
 
@@ -249,12 +223,6 @@ List all custom fields configured across YouTrack projects.
 
    # List all custom fields
    yt admin fields list
-
-   # List fields with specific information
-   yt admin fields list --fields "id,name,fieldType(presentation),isPrivate"
-
-   # List field types and usage
-   yt admin fields list --fields "name,fieldType(presentation),projects(name)"
 
 Internationalization (i18n) Management
 --------------------------------------
@@ -498,7 +466,7 @@ User Group Management
      --description "Project managers for ${PROJECT_NAME} project"
 
    # List created groups
-   yt admin user-groups list --fields "name,description"
+   yt admin user-groups list
 
 System Configuration
 ~~~~~~~~~~~~~~~~~~~~
@@ -694,7 +662,7 @@ Backup Integration
    yt admin global-settings list > "$BACKUP_DIR/global_settings.txt"
 
    # Export user groups
-   yt admin user-groups list --fields "id,name,description" > "$BACKUP_DIR/user_groups.txt"
+   yt admin user-groups list > "$BACKUP_DIR/user_groups.txt"
 
    # Export custom fields
    yt admin fields list > "$BACKUP_DIR/custom_fields.txt"

--- a/docs/commands/groups.rst
+++ b/docs/commands/groups.rst
@@ -36,24 +36,26 @@ Create a new user group for organizing users and permissions.
 
 .. code-block:: bash
 
-   yt groups create [OPTIONS]
+   yt groups create [OPTIONS] NAME
+
+**Arguments:**
+  * ``NAME`` - Name of the group to create (required)
 
 **Options:**
-  * ``--name TEXT`` - Name of the group to create (required)
-  * ``--description TEXT`` - Optional description of the group's purpose
+  * ``-d, --description TEXT`` - Optional description of the group's purpose
 
 **Examples:**
 
 .. code-block:: bash
 
    # Create a basic user group
-   yt groups create --name "Development Team"
+   yt groups create "Development Team"
 
    # Create a group with description
-   yt groups create --name "QA Engineers" --description "Quality Assurance team members"
+   yt groups create "QA Engineers" --description "Quality Assurance team members"
 
    # Create project-specific groups
-   yt groups create --name "Web Project Contributors" --description "Contributors to web development project"
+   yt groups create "Web Project Contributors" --description "Contributors to web development project"
 
 List User Groups
 ~~~~~~~~~~~~~~~~
@@ -123,12 +125,12 @@ The ``yt groups`` command is functionally identical to ``yt admin user-groups``.
 .. code-block:: bash
 
    # These commands are equivalent:
-   yt groups create --name "New Team"
-   yt admin user-groups create --name "New Team"
+   yt groups create "New Team"
+   yt admin user-groups create "New Team"
 
    # These commands are equivalent:
-   yt groups list --format json
-   yt admin user-groups list --format json
+   yt groups list
+   yt admin user-groups list
 
 Choose the command style that fits your workflow:
 
@@ -146,9 +148,9 @@ Organize users by functional teams and roles:
 .. code-block:: bash
 
    # Create functional team groups
-   yt groups create --name "Frontend Developers" --description "UI and frontend development team"
-   yt groups create --name "Backend Developers" --description "API and backend development team"
-   yt groups create --name "DevOps Engineers" --description "Infrastructure and deployment team"
+   yt groups create "Frontend Developers" --description "UI and frontend development team"
+   yt groups create "Backend Developers" --description "API and backend development team"
+   yt groups create "DevOps Engineers" --description "Infrastructure and deployment team"
 
 **Benefits:**
   * Clear team structure and responsibilities
@@ -164,8 +166,8 @@ Create project-specific groups for access management:
 .. code-block:: bash
 
    # Create project-specific access groups
-   yt groups create --name "Project Phoenix Contributors" --description "All contributors to Project Phoenix"
-   yt groups create --name "Project Phoenix Reviewers" --description "Code and issue reviewers for Project Phoenix"
+   yt groups create "Project Phoenix Contributors" --description "All contributors to Project Phoenix"
+   yt groups create "Project Phoenix Reviewers" --description "Code and issue reviewers for Project Phoenix"
 
 **Applications:**
   * Granular control over project access and visibility
@@ -181,9 +183,9 @@ Organize users by permission levels and access requirements:
 .. code-block:: bash
 
    # Create permission-based groups
-   yt groups create --name "Issue Reporters" --description "Users who can create and comment on issues"
-   yt groups create --name "Issue Resolvers" --description "Users who can resolve and close issues"
-   yt groups create --name "Project Administrators" --description "Users with full project management access"
+   yt groups create "Issue Reporters" --description "Users who can create and comment on issues"
+   yt groups create "Issue Resolvers" --description "Users who can resolve and close issues"
+   yt groups create "Project Administrators" --description "Users with full project management access"
 
 **Use Cases:**
   * Hierarchical permission structures
@@ -199,8 +201,8 @@ Organize external stakeholders and client representatives:
 .. code-block:: bash
 
    # Create stakeholder groups
-   yt groups create --name "Client Stakeholders" --description "External client representatives"
-   yt groups create --name "Business Analysts" --description "Internal business analysis team"
+   yt groups create "Client Stakeholders" --description "External client representatives"
+   yt groups create "Business Analysts" --description "Internal business analysis team"
 
 **Benefits:**
   * Clear separation between internal team members and external stakeholders
@@ -226,14 +228,14 @@ Establish consistent naming patterns for groups:
 .. code-block:: bash
 
    # Team-based naming pattern
-   yt groups create --name "Frontend Development Team"
-   yt groups create --name "Backend Development Team"
-   yt groups create --name "Quality Assurance Team"
+   yt groups create "Frontend Development Team"
+   yt groups create "Backend Development Team"
+   yt groups create "Quality Assurance Team"
 
    # Project-based naming pattern
-   yt groups create --name "Project Alpha - Contributors"
-   yt groups create --name "Project Alpha - Reviewers"
-   yt groups create --name "Project Alpha - Stakeholders"
+   yt groups create "Project Alpha - Contributors"
+   yt groups create "Project Alpha - Reviewers"
+   yt groups create "Project Alpha - Stakeholders"
 
 Group Structure and Hierarchy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -286,9 +288,9 @@ Automate group creation for consistent organizational structures:
    fi
 
    # Create standard project groups
-   yt groups create --name "$PROJECT_NAME - Contributors" --description "All contributors to $PROJECT_NAME"
-   yt groups create --name "$PROJECT_NAME - Reviewers" --description "Code and issue reviewers for $PROJECT_NAME"
-   yt groups create --name "$PROJECT_NAME - Stakeholders" --description "Business stakeholders for $PROJECT_NAME"
+   yt groups create "$PROJECT_NAME - Contributors" --description "All contributors to $PROJECT_NAME"
+   yt groups create "$PROJECT_NAME - Reviewers" --description "Code and issue reviewers for $PROJECT_NAME"
+   yt groups create "$PROJECT_NAME - Stakeholders" --description "Business stakeholders for $PROJECT_NAME"
 
    echo "Groups created for project: $PROJECT_NAME"
 
@@ -300,7 +302,7 @@ Generate reports on group structure and membership:
 .. code-block:: bash
 
    # Export group information for analysis
-   yt groups list --format json > groups-export.json
+   yt groups list > groups-export.txt
 
    # Create group summary report
    cat groups-export.json | jq -r '
@@ -316,7 +318,7 @@ Combine group management with user operations:
 .. code-block:: bash
 
    # Create groups and add users in batch operations
-   yt groups create --name "New Project Team"
+   yt groups create "New Project Team"
 
    # Add multiple users to the group (would require additional user management commands)
    # This demonstrates the integration pattern even if specific commands aren't implemented yet
@@ -332,7 +334,7 @@ For enterprise environments, groups often integrate with directory services:
    # (Implementation would depend on specific directory service)
 
    # Export current groups for comparison with directory groups
-   yt groups list --format json > youtrack-groups.json
+   yt groups list > youtrack-groups.txt
 
    # Process directory information to maintain group synchronization
    # (This would be part of a larger integration solution)

--- a/docs/commands/ls.rst
+++ b/docs/commands/ls.rst
@@ -148,7 +148,7 @@ The ``yt ls`` command is functionally identical to ``yt issues list``. Both comm
 
    # These commands are equivalent:
    yt ls --project DEMO --format json
-   yt issues list --project DEMO --format json
+   yt issues list --project-id DEMO --format json
 
 Choose the command style that fits your workflow:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -454,11 +454,12 @@ Troubleshooting
 Configuration File Location
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you're unsure where your configuration file is located:
+If you're unsure where your configuration file is located, it defaults to
+``~/.config/youtrack-cli/.env``:
 
 .. code-block:: bash
 
-   yt config list --show-file
+   ls ~/.config/youtrack-cli/
 
 Permission Issues
 ~~~~~~~~~~~~~~~~~
@@ -477,7 +478,7 @@ Test your configuration by running:
 
 .. code-block:: bash
 
-   yt auth login --test
+   yt auth status
 
 Configuration Examples
 -----------------------

--- a/docs/custom-fields.rst
+++ b/docs/custom-fields.rst
@@ -131,7 +131,7 @@ The issues commands automatically handle custom fields for common use cases:
     yt issues update ISSUE-ID --priority Critical --assignee john.doe
 
     # Search issues by custom field values
-    yt issues list --project PROJECT-ID --priority High
+    yt issues list --project-id PROJECT-ID --query "Priority: High"
 
 Projects Commands
 -----------------

--- a/docs/learning-path.rst
+++ b/docs/learning-path.rst
@@ -170,7 +170,7 @@ Module 1.4: Searching and Filtering (45 minutes)
    yt issues list --state "Open"
 
    # Find issues with specific priority
-   yt issues list --priority "High"
+   yt issues list --query "priority: High"
 
 **Exercise 2: Advanced Search**
 
@@ -344,7 +344,7 @@ Module 2.4: Project Management Basics (60 minutes)
 .. code-block:: bash
 
    # List project details
-   yt projects list --detailed
+   yt projects list -f "name,shortName,description"
 
    # View project configuration
    yt projects configure PROJECT-KEY --show
@@ -755,7 +755,7 @@ Troubleshooting Learning Issues
 
 **Solutions**:
 1. Check your YouTrack CLI version: ``yt --version``
-2. Verify authentication: ``yt auth login --test``
+2. Verify authentication: ``yt auth status``
 3. Use ``--debug`` flag to see detailed error messages
 4. Consult :doc:`troubleshooting` guide
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -223,11 +223,11 @@ Configuration File Issues
 
 **Solutions**:
 
-1. **Check configuration file location**:
+1. **Check configuration file location** (defaults to ``~/.config/youtrack-cli/.env``):
 
    .. code-block:: bash
 
-      yt config list --show-file
+      ls ~/.config/youtrack-cli/
 
 2. **Verify file permissions**:
 
@@ -405,7 +405,7 @@ Empty Results
    .. code-block:: bash
 
       # Specify project explicitly
-      yt issues list --project PROJECT-KEY
+      yt issues list --project-id PROJECT-KEY
 
 Output Formatting Issues
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -539,7 +539,7 @@ YouTrack CLI provides user-friendly error messages with actionable suggestions:
 .. code-block:: bash
 
    # Example error with suggestion
-   $ yt issues list --project INVALID-PROJECT
+   $ yt issues list --project-id INVALID-PROJECT
    Error: Project 'INVALID-PROJECT' not found
    Suggestion: Check if the project exists and you have access to it
 
@@ -605,7 +605,7 @@ Verify your setup is working:
 .. code-block:: bash
 
    # Test authentication
-   yt auth login --test
+   yt auth status
 
    # Test basic operations
    yt projects list --top 1

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -478,7 +478,7 @@ JIRA Migration Workflow
    # This is a simplified example
 
    # 2. Create corresponding projects in YouTrack
-   yt projects create --name "Web Frontend" --key "WEB" \
+   yt projects create "Web Frontend" WEB \
      --description "Migrated from JIRA project WEBFRONT"
 
    # 3. Process JIRA export file


### PR DESCRIPTION
Closes #686

## Summary
Running the rewritten `/deep-review` (PR #683) a second time — to verify it works — surfaced real **invented-option** bugs that the first review and ad-hoc passes missed. Each was confirmed by invoking the command and getting a `No such option` / `missing argument` error.

## Fixes
- **`admin fields list --fields` / `admin user-groups list --fields`** — neither command has any option but `-h`. Removed the invented option-table rows and the `--fields "..."` examples (`admin.rst`).
- **`groups create --name` / `admin user-groups create --name`** — `NAME` is a positional argument; only `-d/--description` exists. Fixed the option doc and ~30 examples (`groups.rst`).
- **`groups list --format` / `admin user-groups list --format`** — those commands have no `--format`. Removed from the remaining examples.
- **`issues list --project` / `--priority`** → `--project-id` / `--query` (`ls.rst`, `custom-fields.rst`, `learning-path.rst`, `troubleshooting.rst`).
- **`projects list --detailed`** → `-f "..."`; **`projects create --name/--key`** → positional `NAME SHORT_NAME` (`workflows.rst`).
- **`auth login --test`** → `auth status`; **`config list --show-file`** → reference the default `~/.config/youtrack-cli/.env` path (`configuration.rst`, `troubleshooting.rst`).
- **command-aliases**: replaced the fictional `yt settings` / `admin global-settings get|set` examples (none of which exist) with the real `admin global-settings list`.

Intentional examples were left untouched: shell tab-completion partials (`--a<TAB>`) and the troubleshooting "wrong-way" Problem statements shown next to their correct forms.

## Verification
Re-ran the live invented-options and example-option scans → clean (only the intentional items remain). No new docs-build warnings introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)