### PR TITLE
📝 Fix remaining short RST title underlines (clean-build warning sweep)

### DIFF
--- a/docs/commands/auth.rst
+++ b/docs/commands/auth.rst
@@ -379,7 +379,7 @@ Troubleshooting Certificate Issues
    cat intermediate.crt root.crt > ca-bundle.crt
 
 Security Features
-----------------
+-----------------
 
 Credential Storage
 ~~~~~~~~~~~~~~~~~~
@@ -580,7 +580,7 @@ Common error scenarios and solutions:
   * Re-authenticate: ``yt auth login``
 
 Configuration Files
-------------------
+-------------------
 
 Credential Storage Location
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -647,7 +647,7 @@ Operational Security
 4. **Team Guidelines**: Establish team standards for authentication
 
 Automation and CI/CD
--------------------
+--------------------
 
 Environment Variables
 ~~~~~~~~~~~~~~~~~~~~~
@@ -693,7 +693,7 @@ Service Account Setup
    yt projects list
 
 Integration Examples
--------------------
+--------------------
 
 Script Authentication
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/commands/boards.rst
+++ b/docs/commands/boards.rst
@@ -172,7 +172,7 @@ Board Types
   * Continuous delivery focus
 
 Board Components
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 **Columns**
   Represent different stages of work (To Do, In Progress, Done, etc.)
@@ -190,7 +190,7 @@ Board Components
   Rules that determine which issues appear on the board
 
 Board Configuration
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 **Ownership**
   Boards have owners who can configure settings and permissions
@@ -208,7 +208,7 @@ Common Workflows
 ----------------
 
 Board Discovery
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -225,7 +225,7 @@ Board Discovery
    yt boards list | grep -i "dev"
 
 Board Analysis
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -240,7 +240,7 @@ Board Analysis
    yt boards show PROJECT-BOARD --format json
 
 Board Maintenance
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -253,7 +253,7 @@ Board Maintenance
    yt boards update TEAM-B-BOARD --name "Feature Team Board"
 
 Project Board Management
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -296,7 +296,7 @@ Board Reporting and Analytics
 -----------------------------
 
 Board Inventory
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -310,7 +310,7 @@ Board Inventory
    yt boards list --format json > boards_metadata.json
 
 Configuration Analysis
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -324,7 +324,7 @@ Configuration Analysis
    yt boards list --format json | jq '.[] | {name: .name, owner: .owner}'
 
 Performance Monitoring
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -386,7 +386,7 @@ JSON format provides structured data for automation and integration:
    ]
 
 Board Detail View
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 When viewing a specific board, detailed information is displayed:
 
@@ -436,10 +436,10 @@ Common error scenarios and solutions:
   Check connectivity if boards fail to load or update.
 
 Integration Examples
--------------------
+--------------------
 
 Board Monitoring Script
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -462,7 +462,7 @@ Board Monitoring Script
    done
 
 Board Backup Script
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -483,7 +483,7 @@ Board Backup Script
    echo "Board backup completed in $BACKUP_DIR"
 
 Project Board Analysis
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -514,21 +514,21 @@ Use Cases
 ---------
 
 Team Organization
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 * **Multi-team Projects**: Use separate boards for different teams working on the same project
 * **Feature Teams**: Create boards for specific feature development streams
 * **Cross-functional Work**: Set up boards that span multiple projects or components
 
 Workflow Management
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 * **Process Improvement**: Analyze board configurations to optimize team workflows
 * **Standardization**: Ensure consistent board setup across similar teams
 * **Compliance**: Monitor board usage for process compliance requirements
 
 Project Management
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 * **Portfolio View**: Track multiple projects through their associated boards
 * **Resource Planning**: Use board data for capacity and resource allocation

--- a/docs/commands/ls.rst
+++ b/docs/commands/ls.rst
@@ -63,7 +63,7 @@ Common Usage Patterns
 ---------------------
 
 Personal Issue Management
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Quickly check your assigned work:
 
@@ -83,7 +83,7 @@ Quickly check your assigned work:
    yt ls --assignee me --type Task
 
 Project Overview
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 Get a quick project status overview:
 
@@ -102,7 +102,7 @@ Get a quick project status overview:
    yt ls -p DEMO --priority High
 
 Team and Workflow Monitoring
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Monitor team progress and workflow status:
 
@@ -120,7 +120,7 @@ Monitor team progress and workflow status:
    yt ls --tag "needs-review"
 
 Data Export and Integration
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Export issue data for reports and analysis:
 
@@ -287,7 +287,7 @@ Generate team-level status reports:
    done
 
 CI/CD Integration
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 Integrate issue checking into development workflows:
 
@@ -306,7 +306,7 @@ Performance and Efficiency Tips
 -------------------------------
 
 Optimizing List Operations
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Make listing operations faster and more efficient:
 

--- a/docs/commands/new.rst
+++ b/docs/commands/new.rst
@@ -80,7 +80,7 @@ Rapidly create bug reports with essential information:
        --description "User profile data is being corrupted when updated via API endpoint"
 
 Feature Requests
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 Create feature requests and enhancement issues:
 
@@ -99,7 +99,7 @@ Create feature requests and enhancement issues:
    yt new WEB "Improve search performance" --type Enhancement --tag "performance,search"
 
 Task Management
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 Create task and maintenance issues:
 
@@ -115,7 +115,7 @@ Create task and maintenance issues:
    yt new API "Refactor authentication module" --type Task --tag "refactor,security,tech-debt"
 
 Sprint and Project Planning
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Create issues for sprint and project planning activities:
 
@@ -177,7 +177,7 @@ Create issues with comprehensive information:
        --tag "security,biometric,enhancement"
 
 Batch Issue Creation
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 While not directly supported, combine with shell scripting for batch creation:
 
@@ -196,7 +196,7 @@ While not directly supported, combine with shell scripting for batch creation:
    done
 
 Template-Based Creation
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Create standardized issues using templates:
 
@@ -231,7 +231,7 @@ Workflow Integration
 --------------------
 
 Development Workflow
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 Integrate issue creation into development processes:
 
@@ -252,7 +252,7 @@ Integrate issue creation into development processes:
        --tag "dashboard,widget,ui"
 
 Customer Support Integration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Create issues from customer feedback and support requests:
 
@@ -273,7 +273,7 @@ Create issues from customer feedback and support requests:
        --tag "customer-request,export"
 
 CI/CD and Automation
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 Integrate issue creation into automated workflows:
 
@@ -344,7 +344,7 @@ Automation and Integration
 --------------------------
 
 Shell Integration
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 Create shell functions for common issue creation patterns:
 
@@ -377,7 +377,7 @@ Create shell functions for common issue creation patterns:
    }
 
 Git Integration
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 Integrate issue creation with git workflows:
 
@@ -399,7 +399,7 @@ Integrate issue creation with git workflows:
    }
 
 IDE and Editor Integration
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Integrate with development tools:
 

--- a/docs/commands/reports.rst
+++ b/docs/commands/reports.rst
@@ -121,10 +121,10 @@ Generate velocity reports analyzing team performance across recent sprints.
    yt reports velocity PROJECT-BETA --sprints 5
 
 Report Features and Concepts
----------------------------
+----------------------------
 
 Burndown Reports
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 **Purpose**
   Track project or sprint progress by showing how work is being completed over time.
@@ -148,7 +148,7 @@ Burndown Reports
   * Stakeholder reporting
 
 Velocity Reports
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 **Purpose**
   Analyze team performance and capacity across multiple sprints for planning.
@@ -173,10 +173,10 @@ Velocity Reports
   * Seasonal or cyclical patterns
 
 Report Output and Visualization
-------------------------------
+-------------------------------
 
 Burndown Report Format
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: text
 
@@ -206,7 +206,7 @@ Burndown Report Format
    └────────────┴─────────────┴─────────────┴─────────────────┘
 
 Velocity Report Format
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: text
 
@@ -238,7 +238,7 @@ Common Workflows
 ----------------
 
 Sprint Monitoring
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -254,7 +254,7 @@ Sprint Monitoring
      --start-date "2024-01-01" --end-date "2024-01-14"
 
 Project Tracking
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -268,7 +268,7 @@ Project Tracking
    yt reports burndown PROJECT-GAMMA --start-date "2024-02-15" --end-date "2024-03-15"
 
 Team Performance Analysis
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -286,7 +286,7 @@ Team Performance Analysis
    yt reports velocity TEAM-B-PROJECT --sprints 5
 
 Release Planning
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -300,7 +300,7 @@ Release Planning
    yt reports burndown MILESTONE-PROJECT --sprint "Milestone 1"
 
 Stakeholder Reporting
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -340,7 +340,7 @@ Report Analysis Guidelines
 --------------------------
 
 Burndown Analysis
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 **Healthy Patterns**
   * Steady, consistent progress toward completion
@@ -358,7 +358,7 @@ Burndown Analysis
   * Adjust resources or timeline if needed
 
 Velocity Analysis
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 **Positive Indicators**
   * Consistent delivery across sprints
@@ -376,10 +376,10 @@ Velocity Analysis
   * Adjust sprint planning based on actual capacity
 
 Performance Metrics
-------------------
+-------------------
 
 Burndown Metrics
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 **Completion Rate**
   Percentage of planned work completed within the timeframe.
@@ -394,7 +394,7 @@ Burndown Metrics
   Projected completion date based on current progress.
 
 Velocity Metrics
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 **Average Velocity**
   Mean completion rate across analyzed sprints.
@@ -435,7 +435,7 @@ Integration and Automation
 --------------------------
 
 Automated Reporting
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -452,7 +452,7 @@ Automated Reporting
    mail -s "Daily Burndown Report" stakeholders@company.com < daily_burndown.txt
 
 Weekly Reporting
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -469,7 +469,7 @@ Weekly Reporting
    done
 
 Data Export for Analysis
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -492,7 +492,7 @@ Limitations
 * Real-time reporting may have data refresh delays
 
 Future Enhancements
-------------------
+-------------------
 
 * Additional report types (cycle time, lead time, etc.)
 * Custom report templates and configurations

--- a/docs/commands/time.rst
+++ b/docs/commands/time.rst
@@ -240,7 +240,7 @@ Duration Formats
 The time tracking system supports flexible duration input formats:
 
 Hours Format
-~~~~~~~~~~~
+~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -250,7 +250,7 @@ Hours Format
    yt time log ISSUE-123 "0.25h"     # 15 minutes
 
 Minutes Format
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -260,7 +260,7 @@ Minutes Format
    yt time log ISSUE-123 "120m"      # 2 hours
 
 Combined Format
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -270,7 +270,7 @@ Combined Format
    yt time log ISSUE-123 "0h 45m"    # 45 minutes
 
 Numeric Format
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -293,7 +293,7 @@ ISO Format
    yt time log ISSUE-123 "1h" --date "2024-12-31"
 
 US Format
-~~~~~~~~
+~~~~~~~~~
 
 .. code-block:: bash
 
@@ -302,7 +302,7 @@ US Format
    yt time log ISSUE-123 "1h" --date "12/31/2024"
 
 European Format
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -311,7 +311,7 @@ European Format
    yt time log ISSUE-123 "1h" --date "31.12.2024"
 
 Relative Dates
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -342,7 +342,7 @@ Listing Available Work Types
    yt time work-types --format json > available_work_types.json
 
 Development Work
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -352,7 +352,7 @@ Development Work
    yt time log ISSUE-123 "1h" --work-type "Code Review" --description "PR review"
 
 Testing Activities
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -362,7 +362,7 @@ Testing Activities
    yt time log ISSUE-123 "30m" --work-type "Automation" --description "Test automation"
 
 Documentation
-~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -371,7 +371,7 @@ Documentation
    yt time log ISSUE-123 "45m" --work-type "Writing" --description "User guide updates"
 
 Analysis and Planning
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -384,7 +384,7 @@ Common Workflows
 ----------------
 
 Daily Time Logging
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -397,7 +397,7 @@ Daily Time Logging
    yt time log ISSUE-123 "4h" --date "yesterday" --description "Feature completion"
 
 Historical Time Entry
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -407,7 +407,7 @@ Historical Time Entry
    yt time log ISSUE-123 "2h" --date "2024-01-17" --description "Documentation"
 
 Time Reporting and Analysis
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -424,7 +424,7 @@ Time Reporting and Analysis
    yt time summary --user-id john.doe --group-by type --start-date "2024-01-01"
 
 Sprint Time Tracking
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -439,7 +439,7 @@ Sprint Time Tracking
    yt time list --start-date "2024-01-15" --end-date "2024-01-29" --format json
 
 Billing and Client Reporting
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -476,10 +476,10 @@ Best Practices
 10. **Integration**: Use time data for sprint planning and capacity estimation.
 
 Reporting and Analytics
-----------------------
+-----------------------
 
 Time Summary Reports
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -493,7 +493,7 @@ Time Summary Reports
    yt time summary --group-by type --start-date "2024-01-01" --end-date "2024-01-31"
 
 Detailed Time Reports
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -507,7 +507,7 @@ Detailed Time Reports
    yt time list --start-date "2024-01-15" --end-date "2024-01-21" --format json
 
 Export and Integration
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -562,7 +562,7 @@ JSON Format
    ]
 
 Summary Format
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 .. code-block:: text
 
@@ -602,7 +602,7 @@ Common error scenarios and solutions:
   The CLI will show available work types when an invalid type is provided. Use ``yt time work-types`` to list all available work types beforehand.
 
 Performance Optimization
------------------------
+------------------------
 
 .. code-block:: bash
 

--- a/docs/commands/velocity.rst
+++ b/docs/commands/velocity.rst
@@ -71,7 +71,7 @@ Team velocity measures the amount of work a development team completes in a give
   * **Capacity Utilization:** How much of planned work is actually completed
 
 Velocity Report Components
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A comprehensive velocity report typically includes:
 
@@ -96,7 +96,7 @@ Report Analysis and Interpretation
 -----------------------------------
 
 Sprint Count Selection
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 Choose the appropriate number of sprints to analyze based on your needs:
 
@@ -137,7 +137,7 @@ Choose the appropriate number of sprints to analyze based on your needs:
   * Provides statistically significant data for predictions
 
 Velocity Trend Analysis
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Understanding velocity trends helps inform planning decisions:
 
@@ -211,7 +211,7 @@ Track team performance and identify improvement opportunities:
   * Celebrate team growth and increasing effectiveness
 
 Release and Portfolio Planning
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use velocity data for higher-level planning activities:
 
@@ -310,7 +310,7 @@ Integrate velocity data into sprint planning workflows:
    echo "Recommended sprint capacity: $(echo "$CURRENT_VELOCITY * 0.8" | bc)"
 
 Performance Dashboard Creation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Export velocity data for team dashboards and visualization:
 
@@ -391,7 +391,7 @@ Common Issues
   * Verify you have appropriate read permissions for project data
 
 Data Quality Issues
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 **Velocity Anomalies:**
   * Review sprint scope changes and mid-sprint adjustments

--- a/docs/developer-guidelines.rst
+++ b/docs/developer-guidelines.rst
@@ -357,7 +357,7 @@ For functions with doctests:
 - Output should be predictable across different environments
 
 Troubleshooting Common Issues
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Import errors in doctests:**
 
@@ -525,7 +525,7 @@ Good examples are worth more than lengthy descriptions:
         """
 
 3. Document Edge Cases
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 Mention important behavioral details:
 

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -123,7 +123,7 @@ The system automatically detects which pagination type to use based on the endpo
    print(f"Has more results: {result['has_after']}")
 
 Entity-Specific Pagination Functions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For convenience, use entity-specific pagination functions that automatically apply the correct configuration:
 

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -1,5 +1,5 @@
 Security Features
-================
+=================
 
 YouTrack CLI includes comprehensive security enhancements to protect user credentials and provide audit capabilities for enterprise environments.
 
@@ -14,7 +14,7 @@ The security features include:
 - **Sensitive Data Masking**: Automatic masking of credentials in output and logs
 
 Command Audit Logging
---------------------
+---------------------
 
 All CLI commands are automatically logged with timestamps for security auditing and compliance purposes.
 
@@ -52,7 +52,7 @@ Audit logging can be disabled using the ``--secure`` flag::
 This prevents command logging while maintaining other security features.
 
 Credential Encryption
---------------------
+---------------------
 
 Credentials are encrypted at rest using industry-standard encryption and the system keyring where available.
 
@@ -90,7 +90,7 @@ For CI/CD environments, you can disable keyring and use environment variables::
     export YOUTRACK_TOKEN="your-api-token"
 
 Token Expiration Management
--------------------------
+---------------------------
 
 The CLI proactively monitors token expiration and provides warnings before tokens expire.
 
@@ -177,7 +177,7 @@ This includes entries for:
 5. Consider using organizational certificate authorities for internal systems
 
 Sensitive Data Masking
----------------------
+----------------------
 
 All output and logs automatically mask sensitive information to prevent credential exposure.
 
@@ -201,7 +201,7 @@ After masking::
     token=***MASKED***
 
 Security Best Practices
-----------------------
+-----------------------
 
 **For Individual Users:**
 
@@ -251,7 +251,7 @@ Security Best Practices
 4. **Secret Rotation**: Implement regular token rotation for automated systems
 
 Configuration Options
---------------------
+---------------------
 
 Security features can be configured through environment variables or the configuration file.
 
@@ -285,7 +285,7 @@ Add to ``~/.config/youtrack-cli/.env``::
     YT_AUDIT_MAX_ENTRIES=1000
 
 Troubleshooting
---------------
+---------------
 
 **Keyring Issues:**
 
@@ -336,7 +336,7 @@ If token warnings are incorrect:
 3. Verify token format and YouTrack version compatibility
 
 Security Considerations
----------------------
+-----------------------
 
 **Limitations:**
 


### PR DESCRIPTION
## Summary
Follow-up to #685, which fixed title underlines only in the files Sphinx happened to re-parse. Sphinx builds incrementally, so that run's "warning-free" result masked pre-existing `Title underline too short` warnings in files it didn't touch. A **clean** rebuild (`rm -rf docs/_build` first) surfaced ~180 more.

This extends **98 underlines across 10 files**: `auth`, `boards`, `ls`, `new`, `reports`, `time`, `velocity` command refs plus `developer-guidelines`, `performance`, and `security`.

## Safety
- Only underline lines changed — verified all 98 added lines are pure-punctuation underline characters (clean `98 insertions / 98 deletions`).
- Confirmed with a **clean** `rm -rf docs/_build` rebuild this time (not incremental): **0** title-underline warnings remain, down from ~187 total to 9.

## Out of scope
The 9 remaining warnings are unrelated pre-existing categories — Pygments `cmd` lexer (`installation.rst`), an inline-literal markup issue, autosummary stub-file notices, and a docstring definition-list nit in `utils.py`. Happy to tackle those separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)