### PR TITLE
📝 Fix the last 9 docs-build warnings (clean build now warning-free)

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -12,17 +12,6 @@ is the command-line tool, the underlying Python modules can be used programmatic
    exceptions
    utils
 
-Core Modules
-------------
-
-.. autosummary::
-   :toctree: _autosummary
-
-   youtrack_cli.client
-   youtrack_cli.models
-   youtrack_cli.exceptions
-   youtrack_cli.utils
-
 Client API
 ----------
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -20,14 +20,14 @@ Windows
 
 2. **Verify Python installation**:
 
-   .. code-block:: cmd
+   .. code-block:: bash
 
       python --version
       pip --version
 
 3. **Install YouTrack CLI**:
 
-   .. code-block:: cmd
+   .. code-block:: bash
 
       pip install youtrack-cli
 
@@ -240,9 +240,9 @@ Verification
 To verify that shell completion is working:
 
 1. Start a new shell session
-2. Type ``yt `` and press Tab twice
+2. Type ``yt`` followed by a space and press Tab twice
 3. You should see available commands like ``issues``, ``articles``, ``projects``, etc.
-4. Try typing ``yt issues `` and press Tab to see subcommands
+4. Try typing ``yt issues`` followed by a space and press Tab to see subcommands
 
 **Example completion behavior:**
 

--- a/youtrack_cli/utils.py
+++ b/youtrack_cli/utils.py
@@ -523,11 +523,12 @@ async def batch_get_resources(
     Returns:
         List of resource data in the same order as input IDs
 
-    Example:
+    Example::
+
         resources = await batch_get_resources(
             "https://youtrack.example.com/api/issues/{id}",
             ["PROJ-1", "PROJ-2", "PROJ-3"],
-            headers=auth_headers
+            headers=auth_headers,
         )
     """
     if "{id}" not in base_url:


### PR DESCRIPTION
## Summary
Clears the final 9 warnings from a clean (`rm -rf docs/_build`) Sphinx build, across four categories:

- **`api/index.rst` (4 warnings)** — removed the redundant `.. autosummary:: :toctree: _autosummary` block. With `autosummary_generate = False` it couldn't create stub files ("stub file not found"), and the modules are already documented via the toctree + the per-module `automodule` pages (`client.rst`, `models.rst`, `exceptions.rst`, `utils.rst`).
- **`installation.rst` (2 warnings)** — `.. code-block:: cmd` → `bash`. `cmd` isn't a Pygments lexer, and the rest of the file already uses `bash` for the same `python --version` / `pip install` commands.
- **`installation.rst` (2 warnings)** — fixed two inline literals that ended with a space inside the backticks (``` ``yt `` ``` → ``` ``yt`` followed by a space ```), which produced "inline literal start-string without end-string".
- **`youtrack_cli/utils.py` (1 warning)** — made the `batch_get_resources` docstring `Example` a literal block (`Example::`) so its indented code no longer trips "definition list ends without a blank line; unexpected unindent".

## Verification
A clean `rm -rf docs/_build` rebuild now reports **0 warnings** (down from 9). Combined with #685/#688 (underlines) and #684 (linkcheck), both a clean docs build and `just docs-check` are now fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)