### PR TITLE
📝 Finalize CHANGELOG for 0.23.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.1] - 2026-06-07
+
 ### Removed
 - 🔥 Removed the unused `selenium` dependency (#677)
   - It was added for a browser-automation article-reordering feature that was
@@ -68,6 +70,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     --show-file` → the default `~/.config/youtrack-cli/.env` path
   - Replaced the fictional `yt settings` / `admin global-settings get`/`set`
     examples in the command-aliases doc with the real `admin global-settings list`
+- 📝 Fixed broken documentation links and made the docs build warning-free
+  (#684, #685, #688, #689)
+  - Fixed dead links: the `api.com` placeholder URL in a docstring and the
+    GitHub Discussions link (Discussions isn't enabled), and corrected a
+    `:doc:` cross-reference so `just docs-check` reports no broken links
+  - Cleared all Sphinx build warnings (~200 short RST title underlines plus the
+    remaining `cmd` code-block lexer, inline-literal, autosummary, and docstring
+    warnings) so a clean docs build is warning-free
 
 ## [0.23.0] - 2026-06-07
 


### PR DESCRIPTION
## Summary
Prepares the `0.23.1` release per `PUBLISHING.md` and the `just` recipes. This PR does **only** the CHANGELOG prerequisite that `just release 0.23.1` checks for:

- Renames `## [Unreleased]` → `## [0.23.1] - 2026-06-07` and adds a fresh empty `## [Unreleased]`.
- Adds the missing user-facing entry for the broken-link fixes and warning-free docs build (#684, #685, #688, #689).

The `pyproject.toml` version bump is intentionally **not** included here — `just release 0.23.1` performs that bump, updates `uv.lock`, commits, tags `v0.23.1`, and pushes (which triggers the TestPyPI → PyPI publish via `release.yml`).

## Why 0.23.1 (patch)
`just release-check 0.23.1` classifies this as a PATCH bump. The 13 commits since v0.23.0 are documentation accuracy/quality fixes, the unused-`selenium` dependency removal, and CI tuning — no new features, no behavioral changes. The doc fixes only reach published ReadTheDocs on a version tag, which is the main motivation for cutting this release.

## Validation
- `just release-check 0.23.1` → ✅ valid PATCH increment, no existing `v0.23.1` tag
- `just check` → ✅ lint, format, ty, 1371 tests, zizmor all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)