### PR TITLE
🔖 Release 0.23.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 📝 Removed inconsistent numbered section headers from the Quick Start guide (#693)
   - The headers were numbered out of order (`1, 2, 3, 1, 5, 6`) and inconsistent
     with every other docs page, none of which number their sections
+- 📝 Pointed the README shell-completion link at the `stable` docs instead of `latest`
 
 ## [0.23.1] - 2026-06-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- 📝 Removed inconsistent numbered section headers from the Quick Start guide (#693)
+  - The headers were numbered out of order (`1, 2, 3, 1, 5, 6`) and inconsistent
+    with every other docs page, none of which number their sections
+
 ## [0.23.1] - 2026-06-07
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.2] - 2026-06-07
+
 ### Fixed
 - 📝 Removed inconsistent numbered section headers from the Quick Start guide (#693)
   - The headers were numbered out of order (`1, 2, 3, 1, 5, 6`) and inconsistent

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ YouTrack CLI supports tab completion for bash, zsh, and fish shells:
 yt completion bash --install
 ```
 
-📖 **[Complete shell completion guide](https://yt-cli.readthedocs.io/en/latest/installation.html#shell-completion)**
+📖 **[Complete shell completion guide](https://yt-cli.readthedocs.io/en/stable/installation.html)**
 
 ### Basic Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "youtrack-cli"
-version = "0.23.1"
+version = "0.23.2"
 description = "YouTrack CLI - Command line interface for JetBrains YouTrack issue tracking system"
 readme = "README.md"
 requires-python = ">=3.10, <3.16"

--- a/uv.lock
+++ b/uv.lock
@@ -1862,7 +1862,7 @@ wheels = [
 
 [[package]]
 name = "youtrack-cli"
-version = "0.23.1"
+version = "0.23.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Cuts the **0.23.2** release (docs-only).

- Promotes the `[Unreleased]` entries to a dated `## [0.23.2] - 2026-06-07` CHANGELOG section.
- Bumps the package version to `0.23.2` in `pyproject.toml` and refreshes `uv.lock`.

### Included changes
- 📝 Removed inconsistent numbered section headers from the Quick Start guide (#693)
- 📝 Pointed the README shell-completion link at the `stable` docs instead of `latest`

After merge, tagging `0.23.2` will trigger the PyPI release and the Read the Docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)