### PR TITLE
🧹 Remove lingering Python 3.9 references and dead workarounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-06-08
+
+### Changed
+- 📝 Documented Python **3.10+** as the minimum supported version across the
+  installation, quickstart, learning-path, troubleshooting, and development
+  guides, plus `CONTRIBUTING.md` — the previous packaging drop of Python 3.9
+  (#650, released in 0.23.0) had left these references stale
+- 🩹 Updated the `pre-commit-doctor.sh` Python-version check to expect 3.10+
+
+### Removed
+- 🔥 Removed obsolete Python 3.9 compatibility workarounds — the lazy
+  `asyncio.Lock` initialization in both the HTTP client and cache managers.
+  Python 3.10+ constructs locks without binding to an event loop, so the lock
+  is now created eagerly. This also closes a latent race where concurrent
+  first-callers could each create a separate lock, defeating the mutual exclusion
+
 ## [0.23.2] - 2026-06-07
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Thank you for your interest in contributing to YouTrack CLI! This document provi
 
 ### Prerequisites
 
-- Python 3.9 or higher
+- Python 3.10 or higher
 - [uv](https://docs.astral.sh/uv/) package manager
 - Git
 - A YouTrack instance for testing (optional, but recommended)
@@ -92,7 +92,7 @@ yt-cli/
 
 - **Code Style**: Follow PEP 8, enforced by `ruff`
 - **Line Length**: Maximum 120 characters
-- **Python Version**: Support Python 3.9+
+- **Python Version**: Support Python 3.10+
 - **Type Hints**: Required for all public APIs
 
 ### Docstring Standards
@@ -170,7 +170,7 @@ uv run tox
 
 - All new features must have tests
 - Maintain or improve test coverage
-- Tests must pass on Python 3.9-3.13
+- Tests must pass on Python 3.10-3.15
 - Integration tests should use the `FPU` project for testing
 
 ## Documentation

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -9,7 +9,7 @@ Development Setup
 Prerequisites
 ~~~~~~~~~~~~~
 
-* Python 3.9 or higher
+* Python 3.10 or higher
 * `uv <https://docs.astral.sh/uv/>`_ package manager
 * Git
 
@@ -393,7 +393,7 @@ Test against multiple Python versions using tox with enhanced uv integration for
    uvx --with tox-uv tox -e type
 
    # Run multiple environments in parallel
-   uvx --with tox-uv tox -e py39,py310,py311,py312,py313
+   uvx --with tox-uv tox -e py310,py311,py312,py313,py314,py315
 
 The project uses the **tox-uv plugin** with enhanced configuration to leverage uv's exceptional speed for creating and managing test environments. This provides **1.5x to 10x faster** test execution compared to traditional pip-based installation, significantly reducing development feedback loops.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@ Installation
 Requirements
 ------------
 
-* Python 3.9 or higher
+* Python 3.10 or higher
 * An active YouTrack instance
 * API access to your YouTrack instance
 

--- a/docs/learning-path.rst
+++ b/docs/learning-path.rst
@@ -33,7 +33,7 @@ Prerequisites Check
 
 Before starting, ensure you have:
 
-- Python 3.9+ installed
+- Python 3.10+ installed
 - Basic command line familiarity (cd, ls, basic navigation)
 - Access to a YouTrack instance
 - Your YouTrack credentials or API token

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -24,7 +24,7 @@ YouTrack is an issue tracking and project management tool by JetBrains. If you'r
 * A YouTrack instance URL (ask your team lead or admin)
 * API token or login credentials (see Authentication section below)
 * Basic command line familiarity
-* Python 3.9+ installed on your system
+* Python 3.10+ installed on your system
 
 Authentication
 --------------

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -44,7 +44,7 @@ Python Version Issues
 
 **Problem**: Installation fails with Python version errors.
 
-**Solution**: YouTrack CLI requires Python 3.9 or higher.
+**Solution**: YouTrack CLI requires Python 3.10 or higher.
 
 .. code-block:: bash
 
@@ -52,8 +52,8 @@ Python Version Issues
    python --version
 
    # If using multiple Python versions
-   python3.9 -m pip install youtrack-cli
-   python3.9 -m youtrack_cli --help
+   python3.10 -m pip install youtrack-cli
+   python3.10 -m youtrack_cli --help
 
 Virtual Environment Issues
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/scripts/pre-commit-doctor.sh
+++ b/scripts/pre-commit-doctor.sh
@@ -65,11 +65,11 @@ fi
 # Check Python version
 print_check "Checking Python version..."
 PYTHON_VERSION=$(uv run python --version 2>&1)
-if [[ $PYTHON_VERSION == *"3.9"* ]] || [[ $PYTHON_VERSION == *"3.1"* ]]; then
+if [[ $PYTHON_VERSION == *"3.1"* ]]; then
     print_success "Python version compatible: $PYTHON_VERSION"
 else
     print_warning "Python version may not be compatible: $PYTHON_VERSION"
-    print_fix "This project requires Python 3.9+"
+    print_fix "This project requires Python 3.10+"
 fi
 
 # Check virtual environment

--- a/youtrack_cli/cache.py
+++ b/youtrack_cli/cache.py
@@ -60,17 +60,10 @@ class Cache:
         self._cache: OrderedDict[str, CacheEntry] = OrderedDict()
         self._default_ttl = default_ttl
         self._max_size = max_size
-        self._lock: asyncio.Lock | None = None
+        self._lock: asyncio.Lock = asyncio.Lock()
         self._hits = 0
         self._misses = 0
         self._evictions = 0
-
-    @property
-    def _get_lock(self) -> asyncio.Lock:
-        """Get or create the async lock. Lazy initialization to avoid event loop issues."""
-        if self._lock is None:
-            self._lock = asyncio.Lock()
-        return self._lock
 
     async def get(self, key: str) -> Any | None:
         """Get a value from the cache.
@@ -81,7 +74,7 @@ class Cache:
         Returns:
             Cached value or None if not found/expired
         """
-        async with self._get_lock:
+        async with self._lock:
             entry = self._cache.get(key)
             if entry is None:
                 logger.debug("Cache miss", key=key)
@@ -113,7 +106,7 @@ class Cache:
         ttl = ttl or self._default_ttl
         tags = tags or set()
 
-        async with self._get_lock:
+        async with self._lock:
             # Check if we need to evict entries for size limit
             if self._max_size and len(self._cache) >= self._max_size and key not in self._cache:
                 await self._evict_lru()
@@ -137,7 +130,7 @@ class Cache:
         Returns:
             True if the key was deleted, False if not found
         """
-        async with self._get_lock:
+        async with self._lock:
             if key in self._cache:
                 del self._cache[key]
                 logger.debug("Cache deleted", key=key)
@@ -146,7 +139,7 @@ class Cache:
 
     async def clear(self) -> None:
         """Clear all cached values."""
-        async with self._get_lock:
+        async with self._lock:
             count = len(self._cache)
             self._cache.clear()
             logger.debug("Cache cleared", removed_entries=count)
@@ -157,7 +150,7 @@ class Cache:
         Returns:
             Number of entries removed
         """
-        async with self._get_lock:
+        async with self._lock:
             expired_keys = [key for key, entry in self._cache.items() if entry.is_expired]
 
             for key in expired_keys:
@@ -188,7 +181,7 @@ class Cache:
         Returns:
             Number of entries invalidated
         """
-        async with self._get_lock:
+        async with self._lock:
             matching_keys = [key for key in self._cache.keys() if fnmatch.fnmatch(key, pattern)]
 
             for key in matching_keys:
@@ -208,7 +201,7 @@ class Cache:
         Returns:
             Number of entries invalidated
         """
-        async with self._get_lock:
+        async with self._lock:
             tag_set = set(tags)
             matching_keys = [key for key, entry in self._cache.items() if entry.tags.intersection(tag_set)]
 
@@ -233,7 +226,7 @@ class Cache:
         ttl = ttl or self._default_ttl
         tags = tags or set()
 
-        async with self._get_lock:
+        async with self._lock:
             now = time.time()
             for key, value in items.items():
                 # Check if we need to evict entries for size limit
@@ -259,7 +252,7 @@ class Cache:
         Returns:
             Number of keys actually deleted
         """
-        async with self._get_lock:
+        async with self._lock:
             deleted_count = 0
             for key in keys:
                 if key in self._cache:
@@ -277,7 +270,7 @@ class Cache:
         Returns:
             Dictionary with cache statistics
         """
-        async with self._get_lock:
+        async with self._lock:
             now = time.time()
             expired_count = sum(1 for entry in self._cache.values() if entry.is_expired)
             total_requests = self._hits + self._misses

--- a/youtrack_cli/client.py
+++ b/youtrack_cli/client.py
@@ -111,7 +111,7 @@ class HTTPClientManager:
         self._default_timeout = default_timeout
         self._verify_ssl = verify_ssl
         self._client: httpx.AsyncClient | None = None
-        self._lock: asyncio.Lock | None = None
+        self._lock: asyncio.Lock = asyncio.Lock()
 
     async def _ensure_client(self) -> httpx.AsyncClient:
         """Ensure the HTTP client is initialized.
@@ -123,10 +123,6 @@ class HTTPClientManager:
             Initialized httpx.AsyncClient instance.
         """
         if self._client is None or self._client.is_closed:
-            # Create lock if it doesn't exist (for Python 3.9 compatibility)
-            if self._lock is None:
-                self._lock = asyncio.Lock()
-
             async with self._lock:
                 if self._client is None or self._client.is_closed:
                     # Configure SSL verification
@@ -708,7 +704,7 @@ def reset_client_manager_sync() -> None:
         return
     except RuntimeError:
         # RuntimeError means either:
-        # 1. There's already an event loop running (Python 3.9+)
+        # 1. There's already an event loop running
         # 2. Some other async-related issue
         pass
     except Exception as e:


### PR DESCRIPTION
The packaging drop of Python 3.9 (#650) shipped in 0.23.0 but left stale references behind. Update docs to state Python 3.10+ as the minimum, fix the pre-commit-doctor version check, and remove the obsolete lazy asyncio.Lock workarounds in the HTTP client and cache managers (now created eagerly, which also closes a latent first-caller race). Adds 0.24.0 CHANGELOG notes.