### PR TITLE
⬆️ ci: group Dependabot updates into single PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,10 @@ updates:
     commit-message:
       prefix: ":arrow_up: deps"
       include: "scope"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
 
   # Update GitHub Actions weekly
   - package-ecosystem: "github-actions"
@@ -31,3 +35,7 @@ updates:
     commit-message:
       prefix: ":construction_worker: ci"
       include: "scope"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Add a catch-all groups config to both the uv and github-actions ecosystems so related dependency bumps are bundled into one PR instead of opening a separate PR per dependency.


Claude-Session: https://claude.ai/code/session_01GLJMz4yGu6YYmJge4WRwFX