### PR TITLE
🐛 Fix multi-word --state filter returning incorrect issues (#721)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/001-fix-state-filter"
+}

--- a/specs/001-fix-state-filter/checklists/requirements.md
+++ b/specs/001-fix-state-filter/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Fix State Filter Returning Incorrect Issues
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-07
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec is grounded in the confirmed root cause: multi-word state values are not
+  escaped in query construction.

--- a/specs/001-fix-state-filter/plan.md
+++ b/specs/001-fix-state-filter/plan.md
@@ -1,0 +1,84 @@
+# Implementation Plan: Fix State Filter Returning Incorrect Issues
+
+**Branch**: `fix-state-filter-721` | **Date**: 2026-07-07 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/001-fix-state-filter/spec.md`
+
+## Summary
+
+The `yt issues list --state '<value>'` filter builds a YouTrack query of the form
+`State: In Progress`. YouTrack parses the unescaped multi-word value as
+`State: In` **AND** free-text `Progress`, so it matches any issue whose text
+mentions "Progress". The fix wraps the state value in YouTrack's curly-brace
+escaping (`State: {In Progress}`) at every point where the `state:` filter term
+is constructed from a user-supplied value, so multi-word states are treated as a
+single atomic filter term.
+
+## Technical Context
+
+**Language/Version**: Python 3.9+ (project targets multiple versions via `tox`)
+
+**Primary Dependencies**: `click`, `rich`, `pydantic`, `httpx` (existing; none added)
+
+**Storage**: N/A (stateless CLI over YouTrack REST API)
+
+**Testing**: `pytest` (real-object preference per constitution)
+
+**Target Platform**: Cross-platform CLI
+
+**Project Type**: Single-project CLI
+
+**Performance Goals**: No change; fix is pure query-string construction, no extra API calls
+
+**Constraints**: Must not regress single-word state filtering or query composition with project/assignee/free-text filters
+
+**Scale/Scope**: Two query-construction sites; ~1 small helper + escaping calls
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Code Quality**: PASS — small change, will pass `ruff`/`ty`; docs unaffected (no CLI surface change), but example in help text remains valid. No new dependencies (`uv` only).
+- **II. Testing (NON-NEGOTIABLE)**: PASS — adds a regression test that fails before / passes after, exercising the query built for a multi-word state (real objects, no network).
+- **III. UX Consistency**: PASS — no flag/naming change; output behavior becomes correct. No new user-facing surface.
+- **IV. Performance**: PASS — no additional API calls; pure string handling.
+
+No violations. Complexity Tracking not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-fix-state-filter/
+├── plan.md              # This file
+├── spec.md              # Feature spec
+├── research.md          # Phase 0 output
+├── quickstart.md        # Phase 1 validation guide
+├── checklists/
+│   └── requirements.md  # Spec quality checklist
+└── tasks.md             # /speckit-tasks output (not created here)
+```
+
+Note: `data-model.md` and `contracts/` are intentionally omitted — this is a bug
+fix with no new data entities and no change to the CLI command contract.
+
+### Source Code (repository root)
+
+```text
+youtrack_cli/
+├── managers/issues.py   # LIVE path: IssueManager.list_issues builds "State: {state}"  (line ~649)
+├── issues.py            # Legacy IssueClient.list_issues builds "state:{state}"          (line ~284)
+└── utils.py             # Candidate home for a small escape helper (or inline)
+
+tests/
+└── (existing issue tests) # Add regression test for multi-word state query construction
+```
+
+**Structure Decision**: Single-project layout (existing). The change touches the
+two sites where a `state:` filter term is composed from user input, plus one new
+regression test.
+
+## Complexity Tracking
+
+No constitution violations — section intentionally empty.

--- a/specs/001-fix-state-filter/quickstart.md
+++ b/specs/001-fix-state-filter/quickstart.md
@@ -1,0 +1,41 @@
+# Quickstart / Validation: Fix State Filter
+
+## Prerequisites
+
+- Authenticated `yt` CLI (`yt auth login`) against a YouTrack instance that has a
+  project with a multi-word workflow state (e.g. "In Progress").
+- At least one issue in state "In Progress" and one issue in a different state
+  whose description/comment mentions the words "in progress".
+
+## Automated check (no network)
+
+Run the regression test added for this fix:
+
+```bash
+uv run pytest -k "state_filter" -q
+```
+
+Expected: the test asserting the multi-word state query is brace-escaped passes.
+
+## Manual end-to-end check
+
+```bash
+yt issues list --project-id PROJECT --state 'In Progress' --format json
+```
+
+Expected outcomes:
+
+- Every returned issue has state exactly "In Progress" (SC-001).
+- The unrelated issue that only *mentions* "in progress" in its text is NOT
+  returned (SC-002).
+
+Regression check — single-word state still works:
+
+```bash
+yt issues list --project-id PROJECT --state Open
+```
+
+Expected: only "Open" issues returned, unchanged from prior behavior (SC-003).
+
+See [research.md](./research.md) for the escaping rationale and [plan.md](./plan.md)
+for the affected code sites.

--- a/specs/001-fix-state-filter/research.md
+++ b/specs/001-fix-state-filter/research.md
@@ -1,0 +1,50 @@
+# Research: Fix State Filter Returning Incorrect Issues
+
+## Decision: Escape multi-word filter values with YouTrack curly braces
+
+**Decision**: Wrap the `state` value in curly braces when composing the query:
+`State: {In Progress}`. Apply the same escaping at every site that builds a
+`state:` filter term from user input.
+
+**Rationale**: YouTrack's query language treats whitespace as a token separator.
+`State: In Progress` is parsed as the attribute filter `State: In` followed by a
+free-text term `Progress`, which matches summary/description/comments — exactly
+the reported defect. YouTrack's documented mechanism for a value containing
+spaces is curly-brace escaping: `State: {In Progress}` binds the whole value to
+the `State` attribute. Braces around a single-word value (`State: {Open}`) are
+also valid and harmless, so always-wrapping keeps the code branch-free.
+
+**Alternatives considered**:
+- **Quote with double quotes** (`State: "In Progress"`): YouTrack treats quoted
+  text as a full-text phrase, not an attribute-value binding — wrong semantics.
+- **Only escape when a space is present**: adds a conditional for no benefit;
+  braces are safe on single-word values, so always-wrap is simpler and correct.
+- **URL/percent encoding**: irrelevant — the problem is query *parsing*, not HTTP
+  transport; the HTTP client already encodes params.
+
+## Decision: Fix at both query-construction sites (root cause, not symptom)
+
+**Decision**: Apply escaping in `youtrack_cli/managers/issues.py`
+(`IssueManager.list_issues`, the path the live `yt issues list` command uses) and
+in `youtrack_cli/issues.py` (`IssueClient.list_issues`), since both build a
+`state:` term from raw user input and share the identical defect.
+
+**Rationale**: The ticket names the `list` command (manager path), but the legacy
+`IssueClient` path constructs the same broken `state:{state}` string. Fixing only
+the reported path leaves the sibling caller broken. A single shared escaping
+helper applied at both sites is the smallest change that fixes the root cause
+everywhere.
+
+**Alternatives considered**:
+- **Patch only the manager path**: smaller diff, but leaves `issues.py` latent
+  bug — rejected.
+- **Escape inside the low-level service/HTTP layer**: too broad; would risk
+  double-escaping user-supplied raw `--query` strings that intentionally contain
+  YouTrack syntax — rejected.
+
+## Verification approach
+
+Regression test asserts the composed query for a multi-word state contains the
+brace-escaped term (`{In Progress}`) and does not leave a bare trailing word that
+YouTrack would treat as free text. Test fails before the fix, passes after
+(Constitution II).

--- a/specs/001-fix-state-filter/spec.md
+++ b/specs/001-fix-state-filter/spec.md
@@ -1,0 +1,97 @@
+# Feature Specification: Fix State Filter Returning Incorrect Issues
+
+**Feature Branch**: `fix-state-filter-721`
+
+**Created**: 2026-07-07
+
+**Status**: Draft
+
+**Input**: Issue #721 — `yt issues list --project-id PROJECT --state 'In Progress'` returns issues that don't match the requested state. Multi-word state values are not escaped, so the trailing word is treated as a free-text search matching summary/description/comments.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Filter issues by a multi-word state (Priority: P1)
+
+A user lists issues for a project and filters by a state whose name contains a
+space (e.g. "In Progress", "To Verify", "Won't fix"). They expect only issues
+currently in that exact state to be returned.
+
+**Why this priority**: This is the reported defect. The filter silently returns
+wrong results, which erodes trust in every filtered list and any script built on
+it.
+
+**Independent Test**: Run the list command with a multi-word `--state` value and
+confirm every returned issue has that state, and that issues merely mentioning
+the words in their text are excluded.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project with issues in states "In Progress" and "Open", where one
+   "Open" issue mentions "in progress" in its description, **When** the user runs
+   `list --project-id P --state 'In Progress'`, **Then** only the "In Progress"
+   issues are returned and the "Open" issue is excluded.
+2. **Given** a state value containing a space, **When** the list command builds
+   its query, **Then** the state value is treated as a single atomic filter term,
+   not split into a filter term plus a free-text term.
+
+### User Story 2 - Single-word state filtering still works (Priority: P2)
+
+A user filters by a single-word state (e.g. "Open", "Fixed") and continues to get
+correct results as before.
+
+**Why this priority**: The fix must not regress the common single-word case.
+
+**Independent Test**: Run the list command with a single-word `--state` value and
+confirm only matching issues are returned.
+
+**Acceptance Scenarios**:
+
+1. **Given** issues in state "Open", **When** the user runs `list --state Open`,
+   **Then** only "Open" issues are returned.
+
+### Edge Cases
+
+- State value with leading/trailing whitespace.
+- State value already wrapped by the user in escaping characters (avoid
+  double-escaping).
+- Empty state value (no state filter applied).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The list command MUST return only issues whose state exactly matches
+  the requested `--state` value.
+- **FR-002**: The list command MUST treat a multi-word state value as a single
+  atomic filter term so its words are never interpreted as free-text search.
+- **FR-003**: Multi-word state filtering MUST NOT match against issue summary,
+  description, or comments.
+- **FR-004**: Single-word state filtering MUST continue to return the same correct
+  results it did before this change.
+- **FR-005**: The state filter MUST compose correctly with other filters
+  (project, assignee, free-text query) already supported by the list command.
+
+### Key Entities
+
+- **State filter**: The user-supplied value identifying the workflow state to
+  filter issues by; may contain spaces.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of issues returned for a multi-word state filter have that
+  exact state.
+- **SC-002**: Issues that only mention the state words in their text (and are not
+  in that state) are returned 0% of the time.
+- **SC-003**: Single-word state filtering results are unchanged from prior
+  behavior.
+- **SC-004**: A regression test covering the multi-word state case fails before
+  the fix and passes after.
+
+## Assumptions
+
+- The underlying issue tracker supports an escaping/quoting mechanism for filter
+  values that contain spaces (curly-brace escaping in YouTrack query syntax).
+- The fix is scoped to the issue list/search query construction; no change to the
+  CLI flag surface is required.

--- a/specs/001-fix-state-filter/tasks.md
+++ b/specs/001-fix-state-filter/tasks.md
@@ -1,0 +1,54 @@
+# Tasks: Fix State Filter Returning Incorrect Issues
+
+**Feature**: `specs/001-fix-state-filter` | **Branch**: `fix-state-filter-721`
+**Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+Bug fix scope — small, well-understood change. Tests requested per Constitution II
+(regression test required). No new dependencies, no data model, no contract change.
+
+## Phase 1: Setup
+
+_No setup required — existing project, no new dependencies (Constitution I: `uv` only, nothing to add)._
+
+## Phase 2: Foundational
+
+- [X] T001 Add a small helper `escape_query_value(value: str) -> str` that wraps a filter value in YouTrack curly braces (`{value}`), stripping surrounding whitespace and avoiding double-wrapping if already brace-wrapped, in `youtrack_cli/utils.py`.
+
+## Phase 3: User Story 1 — Filter issues by a multi-word state (Priority: P1)
+
+**Goal**: `list --state 'In Progress'` returns only issues in that exact state.
+
+**Independent Test**: Query built for a multi-word state is brace-escaped so YouTrack treats it as one atomic term; issues only mentioning the words in text are excluded.
+
+- [X] T002 [P] [US1] Add regression test asserting `IssueManager.list_issues(state="In Progress")` composes a query containing `State: {In Progress}` (not a bare trailing `Progress` term), in `tests/test_issues.py` (or the existing issues test module). Test MUST fail before T004.
+- [X] T003 [P] [US1] Add regression test asserting the legacy `IssueClient.list_issues(state="In Progress")` composes `state:{In Progress}`, in the same test module.
+- [X] T004 [US1] In `youtrack_cli/managers/issues.py` (`IssueManager.list_issues`, ~line 649), apply `escape_query_value(state)` when building the `State:` filter term.
+- [X] T005 [US1] In `youtrack_cli/issues.py` (`IssueClient.list_issues`, ~line 284), apply `escape_query_value(state)` when building the `state:` filter term.
+
+## Phase 4: User Story 2 — Single-word state filtering still works (Priority: P2)
+
+**Goal**: Single-word states (e.g. `Open`) remain correct after escaping.
+
+**Independent Test**: `list --state Open` returns only "Open" issues.
+
+- [X] T006 [P] [US2] Add regression test asserting a single-word state (`Open`) composes `State: {Open}` and returns correctly, in the same test module.
+
+## Phase 5: Polish & Cross-Cutting
+
+- [X] T007 Run `uv run pytest`, `uv run ruff check`, `uv run ruff format`, and `uv run ty` — all must pass (Constitution I & II gates).
+- [X] T008 Verify no `docs/` update is needed (no CLI surface change); confirm help-text examples in `youtrack_cli/commands/issues.py` remain valid.
+
+## Dependencies
+
+- T001 (helper) blocks T004, T005.
+- Tests T002, T003, T006 should be written to fail first (TDD, Constitution II), then pass after T004/T005.
+- T007 runs last.
+
+## Parallel Opportunities
+
+- T002, T003, T006 are independent test additions ([P], different assertions, same-or-different files — coordinate if same file).
+- T004 and T005 touch different files and can proceed in parallel once T001 exists.
+
+## MVP Scope
+
+User Story 1 (T001–T005) is the MVP — it resolves issue #721. US2 (T006) guards against regression.

--- a/tests/managers/test_issues.py
+++ b/tests/managers/test_issues.py
@@ -172,11 +172,26 @@ class TestIssueManagerRetrieval:
 
         await issue_manager.list_issues(state="Open", assignee="testuser")
 
-        # Verify filters were added to query
+        # Verify filters were added to query (state value is brace-escaped)
         call_args = issue_manager.issue_service.search_issues.call_args
         query = call_args[1]["query"]
-        assert "State: Open" in query
+        assert "State: {Open}" in query
         assert "Assignee: testuser" in query
+
+    @pytest.mark.asyncio
+    async def test_list_issues_multiword_state_is_escaped(self, issue_manager):
+        """Regression for #721: a multi-word state must be brace-escaped so YouTrack
+        treats it as one atomic term instead of splitting the trailing word into a
+        free-text search that matches summary/description/comments."""
+        issue_manager.issue_service.search_issues.return_value = {"status": "success", "data": []}
+
+        await issue_manager.list_issues(state="In Progress", project_id="TEST")
+
+        query = issue_manager.issue_service.search_issues.call_args[1]["query"]
+        # The whole value is bound to the State attribute...
+        assert "State: {In Progress}" in query
+        # ...and there is no bare trailing "Progress" free-text term.
+        assert "State: In Progress" not in query
 
 
 class TestIssueManagerUpdate:

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -275,6 +275,26 @@ class TestIssueManager:
             mock_client_manager.make_request.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_list_issues_multiword_state_is_escaped(self, issue_manager, sample_issue):
+        """Regression for #721: multi-word state must be brace-escaped in the query
+        so YouTrack does not treat the trailing word as a free-text search."""
+        with patch("youtrack_cli.issues.get_client_manager") as mock_get_client_manager:
+            mock_resp = Mock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = [sample_issue]
+            mock_resp.text = '{"mock": "response"}'
+            mock_resp.headers = {"content-type": "application/json"}
+            mock_client_manager = Mock()
+            mock_client_manager.make_request = AsyncMock(return_value=mock_resp)
+            mock_get_client_manager.return_value = mock_client_manager
+
+            await issue_manager.list_issues(project_id="PROJ", state="In Progress")
+
+            query = mock_client_manager.make_request.call_args[1]["params"]["query"]
+            assert "state:{In Progress}" in query
+            assert "state:In Progress" not in query
+
+    @pytest.mark.asyncio
     async def test_get_issue_success(self, issue_manager, sample_issue):
         """Test successful issue retrieval."""
         with patch("youtrack_cli.issues.get_client_manager") as mock_get_client_manager:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,6 +18,7 @@ from youtrack_cli.utils import (
     display_info,
     display_success,
     display_warning,
+    escape_query_value,
     format_timestamp,
     handle_error,
     make_request,
@@ -231,6 +232,22 @@ class TestOptimizeFields:
         base_params = {"query": "test"}
         result = optimize_fields(base_params)
         assert result == {"query": "test"}
+
+
+class TestEscapeQueryValue:
+    """Test escape_query_value (regression for #721)."""
+
+    def test_multiword_value_is_wrapped(self):
+        assert escape_query_value("In Progress") == "{In Progress}"
+
+    def test_single_word_value_is_wrapped(self):
+        assert escape_query_value("Open") == "{Open}"
+
+    def test_surrounding_whitespace_stripped(self):
+        assert escape_query_value("  In Progress  ") == "{In Progress}"
+
+    def test_already_wrapped_not_double_wrapped(self):
+        assert escape_query_value("{In Progress}") == "{In Progress}"
 
 
 class TestStreamLargeResponse:

--- a/youtrack_cli/issues.py
+++ b/youtrack_cli/issues.py
@@ -20,7 +20,7 @@ from .panels import (
     create_issue_overview_panel,
 )
 from .progress import get_progress_manager
-from .utils import format_timestamp
+from .utils import escape_query_value, format_timestamp
 
 __all__ = ["IssueManager"]
 
@@ -281,7 +281,7 @@ class IssueManager:
             if project_id:
                 query_parts.append(f"project:{project_id}")
             if state:
-                query_parts.append(f"state:{state}")
+                query_parts.append(f"state:{escape_query_value(state)}")
             if assignee:
                 query_parts.append(f"assignee:{assignee}")
             if query:

--- a/youtrack_cli/managers/issues.py
+++ b/youtrack_cli/managers/issues.py
@@ -647,7 +647,9 @@ class IssueManager:
 
         # Add state filter to query if provided
         if state:
-            query = f"State: {state} {query}".strip()
+            from ..utils import escape_query_value
+
+            query = f"State: {escape_query_value(state)} {query}".strip()
 
         # Add assignee filter to query if provided
         if assignee:

--- a/youtrack_cli/utils.py
+++ b/youtrack_cli/utils.py
@@ -586,6 +586,30 @@ async def batch_get_resources(
     return results
 
 
+def escape_query_value(value: str) -> str:
+    """Wrap a YouTrack query filter value in curly braces.
+
+    Multi-word values must stay a single atomic term.
+    YouTrack splits on whitespace, so ``State: In Progress`` parses as
+    ``State: In`` AND a free-text term ``Progress`` (matching summary/description/
+    comments). Curly-brace escaping binds the whole value to the attribute:
+    ``State: {In Progress}``. Braces are harmless on single-word values, and an
+    already-wrapped value is left untouched.
+
+    Examples:
+        >>> escape_query_value("In Progress")
+        '{In Progress}'
+        >>> escape_query_value("Open")
+        '{Open}'
+        >>> escape_query_value("{Already Wrapped}")
+        '{Already Wrapped}'
+    """
+    stripped = value.strip()
+    if stripped.startswith("{") and stripped.endswith("}"):
+        return stripped
+    return "{" + stripped + "}"
+
+
 def optimize_fields(
     base_params: dict[str, Any] | None = None,
     fields: list[str] | None = None,


### PR DESCRIPTION
## Summary

Fixes #721. `yt issues list --state 'In Progress'` returned issues that didn't match the requested state.

### Root cause
The `--state` filter built an unescaped YouTrack query, `State: In Progress`. YouTrack splits on whitespace, so it parsed this as `State: In` **AND** a free-text term `Progress` — matching the word "Progress" anywhere in an issue's summary, description, or comments.

### Fix
Wrap the state value in YouTrack's curly-brace escaping (`State: {In Progress}`) so a multi-word state is treated as a single atomic filter term. Applied at **both** query-construction sites:
- `youtrack_cli/managers/issues.py` — the live `yt issues list` path
- `youtrack_cli/issues.py` — the legacy `IssueClient` path

A small `escape_query_value` helper (in `youtrack_cli/utils.py`) does the escaping; it strips whitespace and avoids double-wrapping. Single-word states are unaffected (`{Open}` is valid and equivalent). No CLI flag changes; no new dependencies.

### Tests
Regression tests (fail before / pass after) for both paths plus the helper:
- `tests/managers/test_issues.py::TestIssueManagerRetrieval::test_list_issues_multiword_state_is_escaped`
- `tests/test_issues.py::TestIssueManager::test_list_issues_multiword_state_is_escaped`
- `tests/test_utils.py::TestEscapeQueryValue` (4 cases)
- Updated the existing filter test to expect the escaped form.

### Verification
`ruff check`, `ruff format --check`, `ty`, `pydocstyle`, and the regression tests all pass locally. The full suite was run with the network-dependent integration tests excluded (they hang without a live YouTrack connection in this environment); CI runs the complete suite.

### Spec Kit
Full workflow artifacts under `specs/001-fix-state-filter/` (spec, plan, research, quickstart, tasks, checklist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)