### PR TITLE
🔖 Release 0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.1] - 2026-07-07
+
+### Fixed
+- 🐛 `yt issues list --state 'In Progress'` no longer returns issues that don't
+  match the requested state. Multi-word state values were built into the
+  YouTrack query unescaped (`State: In Progress`), so YouTrack parsed the
+  trailing word as a free-text term matching summary/description/comments. State
+  values are now wrapped in curly-brace escaping (`State: {In Progress}`) so the
+  filter is treated as a single atomic term (#721)
+
 ## [0.24.0] - 2026-06-08
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "youtrack-cli"
-version = "0.24.0"
+version = "0.24.1"
 description = "YouTrack CLI - Command line interface for JetBrains YouTrack issue tracking system"
 readme = "README.md"
 requires-python = ">=3.10, <3.16"

--- a/uv.lock
+++ b/uv.lock
@@ -1992,7 +1992,7 @@ wheels = [
 
 [[package]]
 name = "youtrack-cli"
-version = "0.24.0"
+version = "0.24.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Version bump to **0.24.1** plus CHANGELOG entry for the #721 fix (multi-word `--state` filter escaping).

Merging this to `main`, then pushing the `v0.24.1` tag (via `just tag 0.24.1`) triggers `release.yml` to build and publish to TestPyPI → PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)