### PR TITLE
🔖 Release 0.24.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "youtrack-cli"
-version = "0.24.1"
+version = "0.24.2"
 description = "YouTrack CLI - Command line interface for JetBrains YouTrack issue tracking system"
 readme = "README.md"
 requires-python = ">=3.10, <3.16"

--- a/uv.lock
+++ b/uv.lock
@@ -1992,7 +1992,7 @@ wheels = [
 
 [[package]]
 name = "youtrack-cli"
-version = "0.24.1"
+version = "0.24.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Version bump to **0.24.2**. Ships the corrected #721 fix (client-side state filtering by the actual state field). CHANGELOG entry already on main from #724.

Merge → `just tag 0.24.2` → publishes to TestPyPI → PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)