### PR TITLE
🐛 Fix --state open (unresolved) + server-side state filtering (#721)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.3] - 2026-07-08
+
+### Fixed
+- 🐛 `yt issues list --state open` now returns all non-resolved issues (and
+  `--state resolved`/`closed` returns resolved issues). `open`/`unresolved` and
+  `resolved`/`closed` are handled as YouTrack resolution queries
+  (`#Unresolved`/`#Resolved`), which are independent of the state field's name.
+  Previously `--state open` matched only a literal state named "Open" and
+  returned nothing when a project had no such state (#721)
+
+### Changed
+- ⚡ Specific `--state` values are now filtered server-side using the project's
+  discovered state field name (State/Status/Stage/…), removing the previous
+  "fetched page only" limitation. Filtering falls back to client-side when the
+  field name can't be determined (no project specified) or is multi-word (#721)
+
 ## [0.24.2] - 2026-07-07
 
 ### Fixed

--- a/tests/managers/test_issues.py
+++ b/tests/managers/test_issues.py
@@ -57,7 +57,7 @@ def issue_manager(auth_manager):
         ]:
             setattr(manager.issue_service, method_name, AsyncMock())
 
-        for method_name in ["get_project", "get_project_custom_fields"]:
+        for method_name in ["get_project", "get_project_custom_fields", "discover_state_field"]:
             setattr(manager.project_service, method_name, AsyncMock())
 
         return manager
@@ -183,47 +183,88 @@ class TestIssueManagerRetrieval:
         }
 
     @pytest.mark.asyncio
-    async def test_list_issues_state_not_in_server_query(self, issue_manager):
-        """State must NOT be sent as a server-side query term — that made YouTrack
-        free-text match the value across summary/description/comments (#721).
-        Assignee still goes to the query."""
+    @pytest.mark.parametrize("keyword", ["open", "OPEN", "unresolved"])
+    async def test_list_issues_open_keyword_uses_unresolved_query(self, issue_manager, keyword):
+        """'open'/'unresolved' map to YouTrack's field-agnostic #Unresolved query,
+        returning all non-resolved issues regardless of the state field name."""
         issue_manager.issue_service.search_issues.return_value = {"status": "success", "data": []}
 
-        await issue_manager.list_issues(state="In Progress", assignee="testuser", project_id="TEST")
+        await issue_manager.list_issues(state=keyword, project_id="TEST")
 
         query = issue_manager.issue_service.search_issues.call_args[1]["query"]
-        assert "State" not in query
-        assert "In Progress" not in query
-        assert "Assignee: testuser" in query
+        assert "#Unresolved" in query
+        # No field-name term and no discovery needed for the keyword path.
+        issue_manager.project_service.discover_state_field.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_list_issues_filters_by_state_field_clientside(self, issue_manager):
-        """Regression for #721: only issues whose actual state field equals the
-        requested state are returned — not issues that merely mention the words."""
+    @pytest.mark.parametrize("keyword", ["resolved", "closed"])
+    async def test_list_issues_resolved_keyword_uses_resolved_query(self, issue_manager, keyword):
+        """'resolved'/'closed' map to #Resolved."""
+        issue_manager.issue_service.search_issues.return_value = {"status": "success", "data": []}
+
+        await issue_manager.list_issues(state=keyword, project_id="TEST")
+
+        assert "#Resolved" in issue_manager.issue_service.search_issues.call_args[1]["query"]
+
+    @pytest.mark.asyncio
+    async def test_list_issues_specific_state_filters_server_side(self, issue_manager):
+        """A specific state is filtered server-side using the project's discovered
+        state field name, brace-escaped — no client-side page filtering (#721)."""
+        issue_manager.project_service.discover_state_field.return_value = {
+            "status": "success",
+            "data": {"field_name": "Status"},
+        }
+        # Server returns exactly what the query asked for; manager must not re-filter.
+        issue_manager.issue_service.search_issues.return_value = {
+            "status": "success",
+            "data": [self._issue_with_state("PROJ-1", "In Progress")],
+        }
+
+        result = await issue_manager.list_issues(state="In Progress", project_id="TEST")
+
+        query = issue_manager.issue_service.search_issues.call_args[1]["query"]
+        assert "Status: {In Progress}" in query
+        assert [i["idReadable"] for i in result["data"]] == ["PROJ-1"]
+
+    @pytest.mark.asyncio
+    async def test_list_issues_specific_state_clientside_fallback(self, issue_manager):
+        """When the state field can't be discovered (e.g. no project), fall back to
+        filtering the fetched page by the actual state field value."""
+        issue_manager.project_service.discover_state_field.return_value = {"status": "error", "message": "nope"}
         in_progress = self._issue_with_state("PROJ-1", "In Progress")
-        # Same words appear in the summary, but the real state is Done — must be excluded.
         done_but_mentions = self._issue_with_state("PROJ-2", "Done", summary="working on In Progress items")
         issue_manager.issue_service.search_issues.return_value = {
             "status": "success",
             "data": [in_progress, done_but_mentions],
         }
 
-        result = await issue_manager.list_issues(state="In Progress", project_id="TEST")
+        result = await issue_manager.list_issues(state="in progress")  # no project_id
 
-        ids = [i["idReadable"] for i in result["data"]]
-        assert ids == ["PROJ-1"]
+        # 'In Progress' is not a state keyword, so it must not leak into the query.
+        assert "In Progress" not in issue_manager.issue_service.search_issues.call_args[1]["query"]
+        assert [i["idReadable"] for i in result["data"]] == ["PROJ-1"]
         assert result["count"] == 1
 
     @pytest.mark.asyncio
-    async def test_list_issues_state_match_is_case_insensitive(self, issue_manager):
-        """State matching ignores case and surrounding whitespace."""
+    async def test_list_issues_multiword_field_name_falls_back_to_clientside(self, issue_manager):
+        """A multi-word discovered field name (e.g. 'Workflow State') would misparse
+        in a query, so it falls back to client-side filtering."""
+        issue_manager.project_service.discover_state_field.return_value = {
+            "status": "success",
+            "data": {"field_name": "Workflow State"},
+        }
         issue_manager.issue_service.search_issues.return_value = {
             "status": "success",
-            "data": [self._issue_with_state("PROJ-1", "In Progress")],
+            "data": [
+                self._issue_with_state("PROJ-1", "In Progress", field_name="Workflow State"),
+                self._issue_with_state("PROJ-2", "Done", field_name="Workflow State"),
+            ],
         }
 
-        result = await issue_manager.list_issues(state="in progress", project_id="TEST")
+        result = await issue_manager.list_issues(state="In Progress", project_id="TEST")
 
+        query = issue_manager.issue_service.search_issues.call_args[1]["query"]
+        assert "Workflow State" not in query
         assert [i["idReadable"] for i in result["data"]] == ["PROJ-1"]
 
 

--- a/youtrack_cli/commands/issues.py
+++ b/youtrack_cli/commands/issues.py
@@ -432,7 +432,9 @@ def create(
 @click.option(
     "--state",
     "-s",
-    help="Filter by issue state",
+    help="Filter by issue state. Use a state name (e.g. 'In Progress'), or the "
+    "keywords 'open'/'unresolved' for all non-resolved issues and "
+    "'resolved'/'closed' for resolved issues.",
 )
 @click.option(
     "--assignee",

--- a/youtrack_cli/managers/issues.py
+++ b/youtrack_cli/managers/issues.py
@@ -649,11 +649,33 @@ class IssueManager:
         if assignee:
             query = f"Assignee: {assignee} {query}".strip()
 
-        # NOTE: state is intentionally NOT added to the server-side query. The
-        # state lives in a custom field whose name varies per project
-        # (State/Status/Stage), and a `State: <value>` query term makes YouTrack
-        # free-text match the value across summary/description/comments (#721).
-        # We filter by the issue's actual state field value below instead.
+        # State handling. The state lives in a custom field whose name varies per
+        # project (State/Status/Stage/...), so we never hard-code "State:" — that
+        # made YouTrack free-text match the value everywhere (#721).
+        #   - "open"/"unresolved" and "resolved"/"closed" map to YouTrack's
+        #     resolution query (#Unresolved/#Resolved), which is field-name
+        #     agnostic (Resolved is a property of the State field's values).
+        #   - a specific state name is filtered server-side using the project's
+        #     actual state field name (discovered + cached). If we cannot discover
+        #     it (e.g. no project given), we fall back to filtering the fetched
+        #     page client-side.
+        client_side_state: str | None = None
+        if state:
+            normalized = state.strip().casefold()
+            if normalized in ("open", "unresolved"):
+                query = f"#Unresolved {query}".strip()
+            elif normalized in ("resolved", "closed"):
+                query = f"#Resolved {query}".strip()
+            else:
+                field_name = await self._discover_state_field_name(project_id)
+                # Only filter server-side for single-word field names — a
+                # multi-word attribute (e.g. "Workflow State") would misparse in
+                # the query. Those fall back to client-side filtering.
+                if field_name and " " not in field_name:
+                    query = f"{field_name}: {{{state.strip()}}} {query}".strip()
+                else:
+                    client_side_state = state
+
         result = await self.search_issues(
             query=query,
             project_id=project_id,
@@ -665,18 +687,31 @@ class IssueManager:
             use_cached_fields=use_cached_fields,
         )
 
-        if state and result.get("status") == "success" and isinstance(result.get("data"), list):
-            wanted = state.strip().casefold()
+        if client_side_state and result.get("status") == "success" and isinstance(result.get("data"), list):
+            # Fallback path only (no project / discovery failed): filters the
+            # fetched page, so matches beyond it are missed — widen with --top.
+            wanted = client_side_state.strip().casefold()
             result["data"] = [
                 issue for issue in result["data"] if self._get_state_field_value(issue).casefold() == wanted
             ]
             result["count"] = len(result["data"])
-            # ponytail: filters the fetched page only; matches beyond the page
-            # size are missed. Widen with --top / pagination if a project has more
-            # issues than one page. Server-side filtering by the discovered state
-            # field name would remove this ceiling.
 
         return result
+
+    async def _discover_state_field_name(self, project_id: str | None) -> str | None:
+        """Resolve the project's actual state field name (State/Status/Stage/...)
+        for building a server-side state filter. Returns None when it cannot be
+        determined — e.g. no project was given, or discovery failed."""
+        if not project_id:
+            return None
+        try:
+            result = await self.project_service.discover_state_field(project_id)
+        except Exception:
+            return None
+        if result.get("status") == "success":
+            name = result.get("data", {}).get("field_name")
+            return name or None
+        return None
 
     def display_issues_table(self, issues: list[dict[str, Any]]) -> None:
         """Display issues in a simple table format."""


### PR DESCRIPTION
## Follow-up to #721: `yt issues list --state open` returned nothing

Two changes, both from your feedback:

### 1. `--state open` = unresolved (keyword handling)
`open`/`unresolved` now map to YouTrack's **`#Unresolved`** query and `resolved`/`closed` to **`#Resolved`**. Per JetBrains docs, Resolved/Unresolved are properties of the State field's *values*, so these queries are **independent of the field's name** — they work whether the field is State, Status, or Stage.

Previously `--state open` matched only a literal state named "Open" and returned nothing when a project has no such state.

### 2. Specific states now filter server-side (removes pagination ceiling)
A specific value like `--state 'In Progress'` is now filtered **server-side** using the project's **discovered state field name** (via `ProjectService.discover_state_field`, cached), e.g. `Status: {In Progress}`. This removes the previous "fetched page only" limitation from 0.24.2.

Falls back to client-side page filtering when the field name can't be determined (no `--project-id`) or is multi-word (e.g. "Workflow State", which would misparse in a query).

### Tests
- `open`/`OPEN`/`unresolved` → `#Unresolved`; `resolved`/`closed` → `#Resolved`
- specific state → server-side `{field}: {value}` from discovery
- fallback to client-side when discovery fails / no project / multi-word field
- 73 manager tests pass; verified against JetBrains query docs

Ships as 0.24.3. **Not releasing until you confirm `--state open` works against your instance.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)