### PR TITLE
🔖 Release 0.24.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "youtrack-cli"
-version = "0.24.2"
+version = "0.24.3"
 description = "YouTrack CLI - Command line interface for JetBrains YouTrack issue tracking system"
 readme = "README.md"
 requires-python = ">=3.10, <3.16"

--- a/uv.lock
+++ b/uv.lock
@@ -1992,7 +1992,7 @@ wheels = [
 
 [[package]]
 name = "youtrack-cli"
-version = "0.24.2"
+version = "0.24.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Version bump to **0.24.3**. Ships the `--state open` = unresolved fix + server-side state filtering (#721, #729). CHANGELOG entry already on main.

Merge → `just tag 0.24.3` → publishes to TestPyPI → PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)