### PR TITLE
🐛 Parse API responses leniently to survive malformed field values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.4] - 2026-07-08
+
+### Fixed
+- 🐛 `yt issues list` no longer aborts with a JSON parse error when an issue's
+  `description` (or another field) contains characters the API returns as
+  malformed JSON — literal control characters (raw newlines/tabs) or invalid
+  backslash escapes (e.g. a Windows path `C:\\…` or a regex `\\d+` serialized
+  with single backslashes). Responses are now parsed leniently: strict parsing is
+  tried first, then control characters are allowed, then stray backslashes are
+  repaired, so one bad field no longer fails the whole request
+
 ## [0.24.3] - 2026-07-08
 
 ### Fixed

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -63,6 +63,21 @@ class TestBaseService:
         with pytest.raises(ValueError, match="Response is not JSON"):
             base_service._parse_json_response(mock_response)
 
+    def test_parse_json_response_recovers_from_invalid_escape(self, base_service):
+        """A malformed description (invalid backslash escape) must not abort the
+        request — the parser falls back to a lenient parse (#721 follow-up)."""
+        import json
+
+        mock_response = Mock()
+        mock_response.headers = {"content-type": "application/json"}
+        # A regex written in the description: "\d+" is an invalid JSON escape, so
+        # strict response.json() raises — mirror that with a real strict parse.
+        mock_response.text = r'{"description": "match \d+ digits"}'
+        mock_response.json.side_effect = lambda: json.loads(mock_response.text)
+
+        result = base_service._parse_json_response(mock_response)
+        assert result == {"description": r"match \d+ digits"}
+
 
 class TestIssueService:
     """Test cases for IssueService."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,6 +20,7 @@ from youtrack_cli.utils import (
     display_warning,
     format_timestamp,
     handle_error,
+    loads_lenient,
     make_request,
     optimize_fields,
     paginate_issues,
@@ -231,6 +232,34 @@ class TestOptimizeFields:
         base_params = {"query": "test"}
         result = optimize_fields(base_params)
         assert result == {"query": "test"}
+
+
+class TestLoadsLenient:
+    """Test lenient JSON parsing for malformed YouTrack responses."""
+
+    def test_valid_json_unaffected(self):
+        assert loads_lenient('{"description": "normal text"}') == {"description": "normal text"}
+
+    def test_valid_escapes_preserved(self):
+        result = loads_lenient(r'{"description": "quote \" tab \t unicode A newline \n backslash \\"}')
+        assert result["description"] == 'quote " tab \t unicode A newline \n backslash \\'
+
+    def test_literal_control_character_allowed(self):
+        # Raw newline inside the string (strict json.loads rejects this).
+        assert loads_lenient('{"description": "line1\nline2"}') == {"description": "line1\nline2"}
+
+    def test_invalid_backslash_escape_repaired(self):
+        # A regex written in a description: "\d+" is an invalid JSON escape.
+        assert loads_lenient(r'{"description": "match \d+ digits"}') == {"description": r"match \d+ digits"}
+
+    def test_lone_backslash_repaired(self):
+        assert loads_lenient(r'{"description": "50\% done"}') == {"description": r"50\% done"}
+
+    def test_unrecoverable_json_still_raises(self):
+        import json
+
+        with pytest.raises(json.JSONDecodeError):
+            loads_lenient('{"description": ')
 
 
 class TestStreamLargeResponse:

--- a/youtrack_cli/services/base.py
+++ b/youtrack_cli/services/base.py
@@ -1,5 +1,6 @@
 """Base service class for YouTrack API communication."""
 
+import json
 from typing import Any
 
 import httpx
@@ -49,7 +50,16 @@ class BaseService:
             if "application/json" not in content_type:
                 raise ValueError(f"Response is not JSON. Content-Type: {content_type}")
 
-            return response.json()
+            try:
+                return response.json()
+            except json.JSONDecodeError:
+                # YouTrack occasionally returns field values (notably issue
+                # descriptions) with literal control characters or improperly
+                # escaped backslashes, which strict parsing rejects. Fall back to
+                # a lenient parse so one bad description doesn't abort the request.
+                from ..utils import loads_lenient
+
+                return loads_lenient(response.text)
         except Exception as e:
             # Try to provide more context about the error
             status_code = response.status_code

--- a/youtrack_cli/utils.py
+++ b/youtrack_cli/utils.py
@@ -7,6 +7,8 @@ The utilities provide consistent interfaces for API interactions, response
 handling, and user feedback with proper error handling and logging.
 """
 
+import json
+import re
 from collections.abc import AsyncGenerator
 from datetime import datetime
 from enum import Enum
@@ -47,6 +49,36 @@ __all__ = [
 
 logger = get_logger(__name__)
 console = get_console()
+
+# Matches a valid JSON escape (kept intact) OR a lone backslash (repaired). By
+# consuming valid escapes first, a genuine "\\" pair is left untouched.
+_INVALID_JSON_ESCAPE_RE = re.compile(r'\\(["\\/bfnrtu])|\\')
+
+
+def loads_lenient(text: str) -> Any:
+    """Parse JSON, tolerating two malformations occasionally present in YouTrack
+    field values (most often issue descriptions):
+
+    1. Literal control characters inside strings (raw newlines/tabs) — allowed by
+       ``strict=False``.
+    2. Invalid backslash escapes — e.g. a Windows path ``C:\\Users`` or a regex
+       ``\\d+`` serialized with single backslashes. Any backslash that is not part
+       of a valid JSON escape sequence is doubled before re-parsing.
+
+    Strict parsing is tried first, so well-formed responses are unaffected. Raises
+    ``json.JSONDecodeError`` if the text is still unparseable after repair.
+    """
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+    try:
+        return json.loads(text, strict=False)
+    except json.JSONDecodeError:
+        pass
+    repaired = _INVALID_JSON_ESCAPE_RE.sub(lambda m: m.group(0) if m.group(1) else "\\\\", text)
+    logger.warning("Response contained invalid JSON escapes; parsed after repairing backslashes")
+    return json.loads(repaired, strict=False)
 
 
 class PaginationType(Enum):


### PR DESCRIPTION
## Problem

`yt issues list` aborted with a JSON parse error ("improper escape") when an issue's **description** (or another field) came back as malformed JSON from the YouTrack API. Two causes, both reproduced:

1. **Literal control characters** inside a string (raw newline/tab) → `Invalid control character`
2. **Invalid backslash escapes** — a Windows path `C:\…` or a regex `\d+` serialized with single backslashes → `Invalid \escape`

Because `response.json()` is strict, one bad description aborted the entire request.

## Fix

Add `loads_lenient()` (in `utils.py`) with a graceful cascade:
1. strict `json.loads` (fast path — well-formed responses unchanged)
2. `strict=False` (allows literal control characters)
3. repair stray backslashes — double any backslash that isn't part of a valid JSON escape — then re-parse

Wired into `BaseService._parse_json_response` as a **fallback only**, triggered when `response.json()` raises. Logs a warning when the repair path is used.

## Notes / trade-off
- Valid escapes (`\n`, `\t`, `\uXXXX`, `\\`) are preserved; only invalid ones are repaired.
- A pathological case (invalid backslash immediately followed by a valid-escape letter, e.g. `\f` in a path) can lose fidelity on that one char — an unavoidable ambiguity in malformed JSON — but it no longer crashes.

## Tests
- `loads_lenient`: valid JSON unaffected, valid escapes preserved, control chars allowed, invalid escapes repaired, unrecoverable still raises.
- `BaseService._parse_json_response` recovers from an invalid-escape body.
- 107+ tests pass; lint/type-check clean.

Ships as 0.24.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)