### PR TITLE
🐛 Fix --profile, add compact profile, warn on client-side state truncation (#726, #727, #728)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with single backslashes). Responses are now parsed leniently: strict parsing is
   tried first, then control characters are allowed, then stray backslashes are
   repaired, so one bad field no longer fails the whole request
+- 🐛 `yt issues list --profile {minimal,compact,standard,full}` now works. The
+  profile name was passed straight to the REST `fields=` parameter, so every
+  profile returned near-empty issues; it is now resolved to its actual field list
+  (#726)
+- 🐛 `yt issues list --state <value>` warns when it can only filter a state
+  client-side (no `--project-id`, so the state field can't be resolved
+  server-side) and the fetched page is full — previously matches beyond the page
+  were dropped with no indication. Specific states are already filtered
+  server-side when a project is given (#728)
+
+### Added
+- ✨ New `compact` field profile for issues: core fields plus `description` but
+  without the heavy `customFields` expansion, giving a lean `--format json`
+  payload for large/whole-project fetches over constrained networks (#727)
 
 ## [0.24.3] - 2026-07-08
 

--- a/tests/managers/test_issues.py
+++ b/tests/managers/test_issues.py
@@ -246,6 +246,34 @@ class TestIssueManagerRetrieval:
         assert result["count"] == 1
 
     @pytest.mark.asyncio
+    async def test_list_issues_profile_resolves_to_field_set(self, issue_manager):
+        """#726: a --profile name must be resolved to its field list, not passed
+        verbatim to the REST fields= param (which returned near-empty issues)."""
+        issue_manager.issue_service.search_issues.return_value = {"status": "success", "data": []}
+
+        await issue_manager.list_issues(field_profile="minimal", project_id="TEST")
+
+        fields = issue_manager.issue_service.search_issues.call_args[1]["fields"]
+        assert fields != "minimal"
+        assert "summary" in fields  # resolved to the actual minimal field list
+        assert "customFields" not in fields  # minimal carries no customFields
+
+    @pytest.mark.asyncio
+    async def test_list_issues_clientside_fallback_warns_on_full_page(self, issue_manager):
+        """#728: when state is filtered client-side (no project) and the fetched
+        page is full, warn that matches beyond it may be missing."""
+        issue_manager.project_service.discover_state_field.return_value = {"status": "error"}
+        # page_size default is 100 → a 100-issue page is "full".
+        data = [self._issue_with_state(f"P-{i}", "Done") for i in range(100)]
+        issue_manager.issue_service.search_issues.return_value = {"status": "success", "data": data}
+
+        with patch("youtrack_cli.managers.issues.logger") as mock_logger:
+            await issue_manager.list_issues(state="In Progress")  # no project_id → fallback
+
+        assert mock_logger.warning.called
+        assert "client-side" in mock_logger.warning.call_args[0][0]
+
+    @pytest.mark.asyncio
     async def test_list_issues_multiword_field_name_falls_back_to_clientside(self, issue_manager):
         """A multi-word discovered field name (e.g. 'Workflow State') would misparse
         in a query, so it falls back to client-side filtering."""

--- a/tests/test_field_selection.py
+++ b/tests/test_field_selection.py
@@ -67,6 +67,15 @@ class TestFieldSelector:
         assert profile.profile_name == "minimal"
         assert "id" in profile.fields
 
+    def test_compact_profile_is_lean_json(self):
+        """compact (#727) carries description + core fields but omits the heavy
+        customFields expansion that dominates large JSON payloads."""
+        fields = self.selector.get_fields("issues", "compact")
+
+        assert "summary" in fields
+        assert "description" in fields
+        assert "customFields" not in fields
+
     def test_get_profile_invalid_entity(self):
         """Test getting profile for invalid entity type."""
         profile = self.selector.get_profile("invalid", "minimal")

--- a/youtrack_cli/commands/issues.py
+++ b/youtrack_cli/commands/issues.py
@@ -448,8 +448,8 @@ def create(
 )
 @click.option(
     "--profile",
-    type=click.Choice(["minimal", "standard", "full"]),
-    help="Field selection profile (minimal, standard, full). Standard is default.",
+    type=click.Choice(["minimal", "compact", "standard", "full"]),
+    help="Field selection profile. 'compact' is lean for JSON (core fields + description, no customFields); 'minimal' is smallest. Defaults to the standard field set.",
 )
 @click.option(
     "--top",
@@ -859,8 +859,8 @@ def delete(ctx: click.Context, issue_id: str, force: bool) -> None:
 )
 @click.option(
     "--profile",
-    type=click.Choice(["minimal", "standard", "full"]),
-    help="Field selection profile (minimal, standard, full). Standard is default.",
+    type=click.Choice(["minimal", "compact", "standard", "full"]),
+    help="Field selection profile. 'compact' is lean for JSON (core fields + description, no customFields); 'minimal' is smallest. Defaults to the standard field set.",
 )
 @click.option(
     "--format",

--- a/youtrack_cli/field_selection.py
+++ b/youtrack_cli/field_selection.py
@@ -27,6 +27,21 @@ FIELD_PROFILES: dict[str, dict[str, list[str]]] = {
             "summary",
             "state(name,id)",
         ],
+        "compact": [
+            # Lean JSON-friendly set: core fields + description, but NO customFields
+            # expansion, which dominates payload size on large fetches (#727).
+            "id",
+            "numberInProject",
+            "summary",
+            "description",
+            "state(name,id)",
+            "priority(name,id)",
+            "type(name,id)",
+            "assignee(login,fullName,id)",
+            "project(id,name,shortName)",
+            "created",
+            "updated",
+        ],
         "standard": [
             "id",
             "numberInProject",

--- a/youtrack_cli/managers/issues.py
+++ b/youtrack_cli/managers/issues.py
@@ -205,9 +205,13 @@ class IssueManager:
         max_results: int | None = None,
     ) -> dict[str, Any]:
         """Search issues with enhanced formatting and pagination."""
-        # Handle field_profile parameter (legacy)
+        # Resolve a field profile name (minimal/standard/full) to its actual field
+        # list. Passing the profile name straight to the REST `fields=` param made
+        # YouTrack treat it as an unknown field and return near-empty issues (#726).
         if field_profile and not fields:
-            fields = field_profile
+            from ..field_selection import get_field_selector
+
+            fields = get_field_selector().get_fields("issues", field_profile)
 
         # Build the query with project filter if specified
         full_query = query
@@ -637,9 +641,13 @@ class IssueManager:
         assignee: str | None = None,
     ) -> dict[str, Any]:
         """List issues with enhanced filtering and pagination."""
-        # Handle field_profile parameter (legacy)
+        # Resolve a field profile name (minimal/standard/full) to its actual field
+        # list rather than passing the name straight to the REST `fields=` param,
+        # which returned near-empty issues for every profile (#726).
         if field_profile and not fields:
-            fields = field_profile
+            from ..field_selection import get_field_selector
+
+            fields = get_field_selector().get_fields("issues", field_profile)
 
         # Build query from parameters
         if query is None:
@@ -690,11 +698,22 @@ class IssueManager:
         if client_side_state and result.get("status") == "success" and isinstance(result.get("data"), list):
             # Fallback path only (no project / discovery failed): filters the
             # fetched page, so matches beyond it are missed — widen with --top.
+            raw_count = len(result["data"])
             wanted = client_side_state.strip().casefold()
             result["data"] = [
                 issue for issue in result["data"] if self._get_state_field_value(issue).casefold() == wanted
             ]
             result["count"] = len(result["data"])
+            # The state field couldn't be filtered server-side, so this only saw one
+            # page. If that page looks full, later matches may be silently missed (#728).
+            limit = top or page_size
+            if raw_count >= limit:
+                logger.warning(
+                    "State filter was applied client-side to a single full page of %d issues, so matching "
+                    "issues beyond it may be missing. Pass --project-id so the state can be filtered "
+                    "server-side across all issues, or widen --top.",
+                    raw_count,
+                )
 
         return result
 


### PR DESCRIPTION
Batched fixes for three related `yt issues list` issues.

## #726 — `--profile` is broken
The profile **name** (`minimal`/`standard`/`full`) was passed straight to the REST `fields=` param, so YouTrack treated it as an unknown field and every profile returned near-empty issues. Now resolved through `FieldSelector.get_fields("issues", profile)` in both `list_issues` and `search_issues`. Only activates when `--profile` is explicitly passed (default path unchanged).

## #727 — heavy JSON payloads / no way to trim
- With #726 fixed, `--profile minimal`/`compact` are now working payload levers.
- **Added a `compact` profile**: core fields + `description`, but **no `customFields` expansion** (the bulk of large payloads) — for whole-project `--format json` fetches over constrained networks.

## #728 — `--state` filtered client-side per page
Specific states are **already filtered server-side** (0.24.3) via the discovered state field name. The remaining client-side path (no `--project-id`, so the field can't be resolved) now **warns when the fetched page is full**, so truncated results aren't mistaken for complete ones.

## Tests
- #726: `--profile minimal` resolves to the real field list (not the string "minimal"), no `customFields`.
- #727: `compact` includes `description`, excludes `customFields`.
- #728: client-side fallback on a full page emits the truncation warning.
- 165 tests pass; lint/type-check clean.

Part of the batch before the 0.24.4 release (with #731).

🤖 Generated with [Claude Code](https://claude.com/claude-code)