### PR TITLE
✨ Add --format ndjson streaming output (#727)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ✨ New `compact` field profile for issues: core fields plus `description` but
   without the heavy `customFields` expansion, giving a lean `--format json`
   payload for large/whole-project fetches over constrained networks (#727)
+- ✨ New `yt issues list --format ndjson`: streams one JSON issue per line as
+  pages arrive, so a large/whole-project fetch uses bounded memory and can be
+  piped and processed incrementally (e.g. `| jq`), rather than buffering the
+  whole result set before output (#727)
 
 ## [0.24.3] - 2026-07-08
 

--- a/tests/managers/test_issues.py
+++ b/tests/managers/test_issues.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from youtrack_cli.auth import AuthManager
+from youtrack_cli.exceptions import YouTrackError
 from youtrack_cli.managers.issues import IssueManager
 
 
@@ -190,6 +191,37 @@ class TestIssueManagerRetrieval:
 
         assert result["count"] == 100
         assert issue_manager.issue_service.search_issues.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_stream_list_issues_yields_across_pages(self, issue_manager):
+        """#727: streaming yields issues one at a time across bounded pages without
+        buffering the whole result set."""
+        page1 = {"status": "success", "data": [{"idReadable": f"P-{i}"} for i in range(100)]}
+        page2 = {"status": "success", "data": [{"idReadable": f"P-{i}"} for i in range(100, 130)]}
+        issue_manager.issue_service.search_issues = AsyncMock(side_effect=[page1, page2])
+
+        got = [issue["idReadable"] async for issue in issue_manager.stream_list_issues(page_size=100)]
+
+        assert got == [f"P-{i}" for i in range(130)]
+        assert issue_manager.issue_service.search_issues.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_stream_list_issues_first_page_error_raises(self, issue_manager):
+        """A first-page failure raises rather than silently yielding nothing."""
+        issue_manager.issue_service.search_issues = AsyncMock(return_value={"status": "error", "message": "boom"})
+
+        with pytest.raises(YouTrackError):
+            [issue async for issue in issue_manager.stream_list_issues()]
+
+    @pytest.mark.asyncio
+    async def test_stream_list_issues_open_keyword_uses_unresolved(self, issue_manager):
+        """Streaming applies the same state handling: 'open' → #Unresolved."""
+        issue_manager.issue_service.search_issues = AsyncMock(return_value={"status": "success", "data": []})
+
+        [issue async for issue in issue_manager.stream_list_issues(state="open", project_id="TEST")]
+
+        query = issue_manager.issue_service.search_issues.call_args[1]["query"]
+        assert "#Unresolved" in query
 
     @pytest.mark.asyncio
     async def test_search_issues_error_on_first_page_surfaces(self, issue_manager):

--- a/youtrack_cli/commands/issues.py
+++ b/youtrack_cli/commands/issues.py
@@ -488,9 +488,10 @@ def create(
 )
 @click.option(
     "--format",
-    type=click.Choice(["table", "json"]),
+    type=click.Choice(["table", "json", "ndjson"]),
     default="table",
-    help="Output format",
+    help="Output format. 'ndjson' streams one JSON issue per line as pages arrive "
+    "(bounded memory, pipe-friendly for large/whole-project fetches).",
 )
 @click.option(
     "--paginated",
@@ -575,6 +576,32 @@ def list_issues(
                 output_format=format,
                 style="yellow",
             )
+
+        if format == "ndjson":
+            # Stream one JSON issue per line as pages arrive, so a large/whole-project
+            # fetch uses bounded memory and can be piped incrementally (#727).
+            import json
+
+            async def _stream_ndjson() -> int:
+                count = 0
+                async for issue in issue_manager.stream_list_issues(
+                    project_id=project_id,
+                    fields=fields,
+                    field_profile=profile,
+                    page_size=page_size,
+                    top=top,
+                    max_results=max_results,
+                    query=query,
+                    state=state,
+                    assignee=assignee,
+                ):
+                    click.echo(json.dumps(issue))
+                    count += 1
+                return count
+
+            emitted = asyncio.run(_stream_ndjson())
+            print_status(f"Streamed {emitted} issues", output_format=format, style="dim")
+            return
 
         result = asyncio.run(
             issue_manager.list_issues(

--- a/youtrack_cli/console.py
+++ b/youtrack_cli/console.py
@@ -250,7 +250,7 @@ def get_error_console() -> Console:
 
 #: Output formats that are intended to be consumed by other programs. Status and
 #: progress messages must not be written to stdout for these formats.
-MACHINE_READABLE_FORMATS = frozenset({"json", "csv"})
+MACHINE_READABLE_FORMATS = frozenset({"json", "csv", "ndjson"})
 
 
 def print_status(message: str, *, output_format: str | None = None, style: str = "blue") -> None:

--- a/youtrack_cli/managers/issues.py
+++ b/youtrack_cli/managers/issues.py
@@ -1,5 +1,6 @@
 """Issue manager for YouTrack CLI business logic."""
 
+from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import Any
 
@@ -8,6 +9,7 @@ from rich.table import Table
 from ..auth import AuthManager
 from ..console import get_console
 from ..custom_field_manager import CustomFieldManager
+from ..exceptions import YouTrackError
 from ..logging import get_logger
 from ..pagination import create_paginated_display
 from ..panels import (
@@ -667,39 +669,9 @@ class IssueManager:
             fields = get_field_selector().get_fields("issues", field_profile)
 
         # Build query from parameters
-        if query is None:
-            query = ""
-
-        # Add assignee filter to query if provided
-        if assignee:
-            query = f"Assignee: {assignee} {query}".strip()
-
-        # State handling. The state lives in a custom field whose name varies per
-        # project (State/Status/Stage/...), so we never hard-code "State:" — that
-        # made YouTrack free-text match the value everywhere (#721).
-        #   - "open"/"unresolved" and "resolved"/"closed" map to YouTrack's
-        #     resolution query (#Unresolved/#Resolved), which is field-name
-        #     agnostic (Resolved is a property of the State field's values).
-        #   - a specific state name is filtered server-side using the project's
-        #     actual state field name (discovered + cached). If we cannot discover
-        #     it (e.g. no project given), we fall back to filtering the fetched
-        #     page client-side.
-        client_side_state: str | None = None
-        if state:
-            normalized = state.strip().casefold()
-            if normalized in ("open", "unresolved"):
-                query = f"#Unresolved {query}".strip()
-            elif normalized in ("resolved", "closed"):
-                query = f"#Resolved {query}".strip()
-            else:
-                field_name = await self._discover_state_field_name(project_id)
-                # Only filter server-side for single-word field names — a
-                # multi-word attribute (e.g. "Workflow State") would misparse in
-                # the query. Those fall back to client-side filtering.
-                if field_name and " " not in field_name:
-                    query = f"{field_name}: {{{state.strip()}}} {query}".strip()
-                else:
-                    client_side_state = state
+        query, client_side_state = await self._apply_state_and_assignee_filters(
+            query, state=state, assignee=assignee, project_id=project_id
+        )
 
         result = await self.search_issues(
             query=query,
@@ -735,6 +707,98 @@ class IssueManager:
                 )
 
         return result
+
+    async def _apply_state_and_assignee_filters(
+        self, query: str | None, *, state: str | None, assignee: str | None, project_id: str | None
+    ) -> tuple[str, str | None]:
+        """Fold assignee and state filters into the server query.
+
+        Returns the query plus, when the state must be filtered client-side (its
+        field name can't be resolved for a server-side term), the casefolded state
+        value to match against each issue; otherwise None. Shared by list_issues
+        and stream_list_issues so state handling stays in one place.
+
+        State: 'open'/'unresolved' and 'resolved'/'closed' map to YouTrack's
+        field-agnostic #Unresolved/#Resolved; a specific state is added as
+        `<discovered field>: {value}` when the field name is a single word, else it
+        falls back to client-side filtering (#721, #728).
+        """
+        query = query or ""
+        if assignee:
+            query = f"Assignee: {assignee} {query}".strip()
+        client_side_state: str | None = None
+        if state:
+            normalized = state.strip().casefold()
+            if normalized in ("open", "unresolved"):
+                query = f"#Unresolved {query}".strip()
+            elif normalized in ("resolved", "closed"):
+                query = f"#Resolved {query}".strip()
+            else:
+                field_name = await self._discover_state_field_name(project_id)
+                if field_name and " " not in field_name:
+                    query = f"{field_name}: {{{state.strip()}}} {query}".strip()
+                else:
+                    client_side_state = normalized
+        return query, client_side_state
+
+    async def stream_list_issues(
+        self,
+        *,
+        project_id: str | None = None,
+        fields: str | None = None,
+        field_profile: str | None = None,
+        page_size: int = 100,
+        top: int | None = None,
+        max_results: int | None = None,
+        query: str | None = None,
+        state: str | None = None,
+        assignee: str | None = None,
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        """Yield issues one at a time, fetched in bounded pages, for streaming
+        (NDJSON) output.
+
+        Applies the same field/query/state filtering as list_issues but never
+        holds the whole result set in memory — each page is emitted as it arrives,
+        so a whole-project fetch streams rather than buffering (#727). Raises
+        YouTrackError if the very first page fails; a later page failure ends the
+        stream after logging (issues already yielded are kept).
+        """
+        if field_profile and not fields:
+            from ..field_selection import get_field_selector
+
+            fields = get_field_selector().get_fields("issues", field_profile)
+
+        query, client_side_state = await self._apply_state_and_assignee_filters(
+            query, state=state, assignee=assignee, project_id=project_id
+        )
+        full_query = f"project: {project_id} {query}".strip() if project_id else query
+
+        overall_limit = top if top is not None else max_results
+        per_page = page_size if page_size and page_size > 0 else 100
+        fetched = 0
+        offset = 0
+        while overall_limit is None or fetched < overall_limit:
+            this_page = per_page if overall_limit is None else min(per_page, overall_limit - fetched)
+            page_result = await self.issue_service.search_issues(
+                query=full_query, fields=fields, top=this_page, skip=offset
+            )
+            if page_result.get("status") != "success":
+                if fetched == 0:
+                    raise YouTrackError(page_result.get("message", "Failed to list issues"))
+                logger.warning("Issue streaming stopped after a failed page at skip=%d", offset)
+                return
+            page_data = page_result.get("data") or []
+            if not isinstance(page_data, list):
+                page_data = []
+            fetched += len(page_data)
+            offset += len(page_data)
+            emit = page_data
+            if client_side_state:
+                emit = [i for i in page_data if self._get_state_field_value(i).casefold() == client_side_state]
+            for issue in emit:
+                yield issue
+            if len(page_data) < this_page:
+                return
 
     async def _discover_state_field_name(self, project_id: str | None) -> str | None:
         """Resolve the project's actual state field name (State/Status/Stage/...)


### PR DESCRIPTION
Completes #727: whole-project `--format json` buffered the entire result set in memory before printing.

## What
`yt issues list --format ndjson` streams **one JSON issue per line** as bounded pages arrive:
- Constant memory (doesn't hold the whole project).
- Pipe/process incrementally: `yt issues list --project-id X --format ndjson | jq -c 'select(.state)'`.
- If a late page fails, issues already streamed are on stdout (a warning goes to stderr).

## How
- `IssueManager.stream_list_issues` — async generator yielding issues, paging in ≤`page_size` requests.
- Shared `_apply_state_and_assignee_filters` helper so streaming and `list_issues` use the **same** field/query/state logic (no drift — state handling now lives in one place).
- `ndjson` added to `MACHINE_READABLE_FORMATS`, so status lines go to stderr and stdout is pure NDJSON.

## Tests
- streams across pages (100 + 30 → 130 issues, 2 calls)
- first-page error raises; state keyword (`open` → `#Unresolved`) applied in streaming too
- 353 tests pass; lint/type-check clean; `--format` help verified

Final piece of the 0.24.4 batch. After this merges I'll cut 0.24.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)