### PR TITLE
🔖 Release 0.24.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "youtrack-cli"
-version = "0.24.3"
+version = "0.24.4"
 description = "YouTrack CLI - Command line interface for JetBrains YouTrack issue tracking system"
 readme = "README.md"
 requires-python = ">=3.10, <3.16"

--- a/uv.lock
+++ b/uv.lock
@@ -1992,7 +1992,7 @@ wheels = [
 
 [[package]]
 name = "youtrack-cli"
-version = "0.24.3"
+version = "0.24.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Version bump to **0.24.4**. Batched list/JSON fixes: #721 (JSON parse), #726 (profile), #727 (pagination + compact + ndjson), #728 (state warning). CHANGELOG already on main.

Merge → `just tag 0.24.4` → publishes to TestPyPI → PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)