### PR TITLE
🔖 Bump version to 0.24.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.5] - 2026-07-09
+
+### Security
+- 🔒 `yt articles attach download` now sanitizes the server-supplied attachment
+  filename: directory components are stripped so a hostile filename
+  (`../../…` or an absolute path) can no longer write outside the working
+  directory. Explicit `--output` paths are unchanged (#740)
+- 🔒 Authenticating against an insecure `http://` base URL now prints a cleartext
+  warning before the API token is sent, so credentials are never transmitted
+  over cleartext silently. Warn-only: the request still proceeds, so
+  `http://localhost` and on-prem plain-HTTP instances keep working (#741)
+- 🔒 The interactive tutorial no longer executes example commands through a
+  system shell (`shell=True`); commands run via a parsed argument list, so shell
+  metacharacters cannot spawn secondary processes. A dead shell-executing code
+  path was removed (#742)
+- 🔒 Added a `SECURITY.md` vulnerability disclosure policy (#743)
+
+### Changed
+- ⚡ CI: Python 3.15 (prerelease) no longer runs on every pull request; it runs
+  post-merge on `main` instead, cutting ~1.5 min off each PR's critical path
+  while retaining 3.15 early-warning coverage (#736)
+
 ## [0.24.4] - 2026-07-08
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "youtrack-cli"
-version = "0.24.4"
+version = "0.24.5"
 description = "YouTrack CLI - Command line interface for JetBrains YouTrack issue tracking system"
 readme = "README.md"
 requires-python = ">=3.10, <3.16"

--- a/uv.lock
+++ b/uv.lock
@@ -1992,7 +1992,7 @@ wheels = [
 
 [[package]]
 name = "youtrack-cli"
-version = "0.24.4"
+version = "0.24.5"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Patch release **0.24.5** — security fixes.

Bumps `pyproject.toml` + `uv.lock` and adds the `[0.24.5]` CHANGELOG entry for everything merged since v0.24.4:

### Security
- #740 sanitize server-supplied article attachment filename (path traversal)
- #741 warn before sending the token over cleartext `http://`
- #742 tutorial executor runs without a shell (removed `shell=True` + dead path)
- #743 add `SECURITY.md` disclosure policy

### Changed
- #736 CI: Python 3.15 moved off the per-PR critical path

No code changes here — version + changelog only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)