### PR TITLE
🔖 Bump version to 0.24.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.6] - 2026-07-09
+
+### Fixed
+- 🩹 `yt auth status` now distinguishes "no credentials" from "credentials
+  stored but unreadable". When a keyring-backed login is on record
+  (`YOUTRACK_API_KEY=[Stored in keyring]` + base URL) but the token can no longer
+  be read from the system keyring — e.g. after an upgrade or move relocated the
+  CLI binary and the OS keychain stopped granting the new binary access — it now
+  says the credentials are stored but unreadable and to run `yt auth login` to
+  re-store them, instead of the misleading "No authentication credentials found"
+  (#746)
+
 ## [0.24.5] - 2026-07-09
 
 ### Security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "youtrack-cli"
-version = "0.24.5"
+version = "0.24.6"
 description = "YouTrack CLI - Command line interface for JetBrains YouTrack issue tracking system"
 readme = "README.md"
 requires-python = ">=3.10, <3.16"

--- a/uv.lock
+++ b/uv.lock
@@ -1992,7 +1992,7 @@ wheels = [
 
 [[package]]
 name = "youtrack-cli"
-version = "0.24.5"
+version = "0.24.6"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Patch release **0.24.6**.

### Fixed
- #746 `yt auth status` distinguishes "credentials stored but unreadable" (e.g. after an upgrade relocates the CLI binary and the OS keychain denies the new binary access) from "no credentials", with an actionable `yt auth login` hint.

Version + changelog only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)