### PR TITLE
✨ feat(issues): accept multiple issue IDs and stdin in `comments list`

### DIFF
--- a/docs/commands/issues.rst
+++ b/docs/commands/issues.rst
@@ -418,10 +418,29 @@ List Comments
 
 .. code-block:: bash
 
-   yt issues comments list ISSUE_ID [OPTIONS]
+   yt issues comments list [ISSUE_ID ...] [OPTIONS]
+
+Accepts one or more issue IDs. When no IDs are passed as arguments, the command
+reads them from standard input, one per line (blank lines are ignored):
+
+.. code-block:: bash
+
+   # A single issue
+   yt issues comments list PROJ-123
+
+   # Several issues at once
+   yt issues comments list PROJ-123 PROJ-456
+
+   # Issue IDs piped from another command or a file
+   cat issues.txt | yt issues comments list
+
+When multiple issues are given, the table output is grouped under a heading per
+issue, and ``--format json`` returns an object keyed by issue ID. A single issue
+keeps the original output shape (a bare table / JSON list).
 
 **Options:**
-  * ``-h, --help`` - Show help and exit (this command takes no other options)
+  * ``--format [table|json]`` - Output format (default: ``table``)
+  * ``-h, --help`` - Show help and exit
 
 Update Comments
 ~~~~~~~~~~~~~~~

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -1577,6 +1577,98 @@ class TestIssuesCLI:
             assert result.exit_code == 0
             assert "adding comment" in result.output.lower()
 
+    def test_issues_comments_list_multiple_ids(self):
+        """Multiple issue IDs list comments for each, with per-issue headings."""
+        from youtrack_cli.main import main
+
+        runner = CliRunner()
+        comment = {
+            "id": "1-1",
+            "text": "Hello @ryan",
+            "created": 1767225600000,
+            "author": {"login": "ryan", "fullName": "Ryan Cheley"},
+        }
+
+        with patch("youtrack_cli.main.asyncio.run") as mock_run:
+            mock_run.return_value = {"status": "success", "data": [comment]}
+
+            result = runner.invoke(main, ["issues", "comments", "list", "PROJ-1", "PROJ-2"])
+
+            assert result.exit_code == 0
+            assert "PROJ-1" in result.output
+            assert "PROJ-2" in result.output
+
+    def test_issues_comments_list_from_stdin(self):
+        """Issue IDs are read from stdin (one per line) when no args are given."""
+        from youtrack_cli.main import main
+
+        runner = CliRunner()
+        comment = {
+            "id": "1-1",
+            "text": "Hello @ryan",
+            "created": 1767225600000,
+            "author": {"login": "ryan", "fullName": "Ryan Cheley"},
+        }
+
+        with patch("youtrack_cli.main.asyncio.run") as mock_run:
+            mock_run.return_value = {"status": "success", "data": [comment]}
+
+            result = runner.invoke(main, ["issues", "comments", "list"], input="PROJ-1\n\nPROJ-2\n")
+
+            assert result.exit_code == 0
+            # blank line ignored, both IDs processed
+            assert mock_run.call_count == 2
+
+    def test_issues_comments_list_no_ids_errors(self):
+        """No IDs from args or stdin produces a clear error."""
+        from youtrack_cli.main import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["issues", "comments", "list"], input="")
+
+        assert result.exit_code != 0
+        assert "No issue IDs provided" in result.output
+
+    def test_issues_comments_list_json_single_is_bare_list(self):
+        """Single ID JSON output keeps the original bare-list shape."""
+        import json
+
+        from youtrack_cli.main import main
+
+        try:
+            runner = CliRunner(mix_stderr=False)
+        except TypeError:
+            runner = CliRunner()
+        comment = {"id": "1-1", "text": "hi", "created": 1767225600000, "author": {"login": "ryan"}}
+
+        with patch("youtrack_cli.main.asyncio.run") as mock_run:
+            mock_run.return_value = {"status": "success", "data": [comment]}
+
+            result = runner.invoke(main, ["issues", "comments", "list", "PROJ-1", "--format", "json"])
+
+            assert result.exit_code == 0
+            assert json.loads(result.stdout) == [comment]
+
+    def test_issues_comments_list_json_multiple_is_keyed(self):
+        """Multiple IDs JSON output is keyed by issue ID."""
+        import json
+
+        from youtrack_cli.main import main
+
+        try:
+            runner = CliRunner(mix_stderr=False)
+        except TypeError:
+            runner = CliRunner()
+        comment = {"id": "1-1", "text": "hi", "created": 1767225600000, "author": {"login": "ryan"}}
+
+        with patch("youtrack_cli.main.asyncio.run") as mock_run:
+            mock_run.return_value = {"status": "success", "data": [comment]}
+
+            result = runner.invoke(main, ["issues", "comments", "list", "PROJ-1", "PROJ-2", "--format", "json"])
+
+            assert result.exit_code == 0
+            assert json.loads(result.stdout) == {"PROJ-1": [comment], "PROJ-2": [comment]}
+
     def test_issues_attach_upload_command(self):
         """Test the issues attach upload CLI command."""
         from youtrack_cli.main import main

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -1,5 +1,6 @@
 """Tests for issue management functionality."""
 
+import json
 import re
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -8,6 +9,21 @@ from click.testing import CliRunner
 
 from youtrack_cli.auth import AuthConfig
 from youtrack_cli.issues import IssueManager
+
+
+def _parse_trailing_json(output: str):
+    """Parse the JSON payload emitted by a command.
+
+    The CLI prints its JSON via ``click.echo`` with ``indent=2``, so the payload
+    always starts with a line that is just ``[`` or ``{`` and runs to the end of
+    output. Locating that line makes the assertion robust to any progress/log
+    noise that other tests may leak onto stdout under randomized ordering.
+    """
+    lines = output.splitlines()
+    for i, line in enumerate(lines):
+        if line.strip() in ("[", "{"):
+            return json.loads("\n".join(lines[i:]))
+    raise AssertionError(f"no JSON payload found in output: {output!r}")
 
 
 @pytest.fixture
@@ -1631,7 +1647,6 @@ class TestIssuesCLI:
 
     def test_issues_comments_list_json_single_is_bare_list(self):
         """Single ID JSON output keeps the original bare-list shape."""
-        import json
 
         from youtrack_cli.main import main
 
@@ -1641,15 +1656,13 @@ class TestIssuesCLI:
         with patch("youtrack_cli.main.asyncio.run") as mock_run:
             mock_run.return_value = {"status": "success", "data": [comment]}
 
-            # --quiet suppresses the progress message so stdout is pure JSON.
             result = runner.invoke(main, ["--quiet", "issues", "comments", "list", "PROJ-1", "--format", "json"])
 
             assert result.exit_code == 0
-            assert json.loads(result.output) == [comment]
+            assert _parse_trailing_json(result.output) == [comment]
 
     def test_issues_comments_list_json_multiple_is_keyed(self):
         """Multiple IDs JSON output is keyed by issue ID."""
-        import json
 
         from youtrack_cli.main import main
 
@@ -1664,7 +1677,7 @@ class TestIssuesCLI:
             )
 
             assert result.exit_code == 0
-            assert json.loads(result.output) == {"PROJ-1": [comment], "PROJ-2": [comment]}
+            assert _parse_trailing_json(result.output) == {"PROJ-1": [comment], "PROJ-2": [comment]}
 
     def test_issues_attach_upload_command(self):
         """Test the issues attach upload CLI command."""

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -1635,19 +1635,17 @@ class TestIssuesCLI:
 
         from youtrack_cli.main import main
 
-        try:
-            runner = CliRunner(mix_stderr=False)
-        except TypeError:
-            runner = CliRunner()
+        runner = CliRunner()
         comment = {"id": "1-1", "text": "hi", "created": 1767225600000, "author": {"login": "ryan"}}
 
         with patch("youtrack_cli.main.asyncio.run") as mock_run:
             mock_run.return_value = {"status": "success", "data": [comment]}
 
-            result = runner.invoke(main, ["issues", "comments", "list", "PROJ-1", "--format", "json"])
+            # --quiet suppresses the progress message so stdout is pure JSON.
+            result = runner.invoke(main, ["--quiet", "issues", "comments", "list", "PROJ-1", "--format", "json"])
 
             assert result.exit_code == 0
-            assert json.loads(result.stdout) == [comment]
+            assert json.loads(result.output) == [comment]
 
     def test_issues_comments_list_json_multiple_is_keyed(self):
         """Multiple IDs JSON output is keyed by issue ID."""
@@ -1655,19 +1653,18 @@ class TestIssuesCLI:
 
         from youtrack_cli.main import main
 
-        try:
-            runner = CliRunner(mix_stderr=False)
-        except TypeError:
-            runner = CliRunner()
+        runner = CliRunner()
         comment = {"id": "1-1", "text": "hi", "created": 1767225600000, "author": {"login": "ryan"}}
 
         with patch("youtrack_cli.main.asyncio.run") as mock_run:
             mock_run.return_value = {"status": "success", "data": [comment]}
 
-            result = runner.invoke(main, ["issues", "comments", "list", "PROJ-1", "PROJ-2", "--format", "json"])
+            result = runner.invoke(
+                main, ["--quiet", "issues", "comments", "list", "PROJ-1", "PROJ-2", "--format", "json"]
+            )
 
             assert result.exit_code == 0
-            assert json.loads(result.stdout) == {"PROJ-1": [comment], "PROJ-2": [comment]}
+            assert json.loads(result.output) == {"PROJ-1": [comment], "PROJ-2": [comment]}
 
     def test_issues_attach_upload_command(self):
         """Test the issues attach upload CLI command."""

--- a/youtrack_cli/commands/issues.py
+++ b/youtrack_cli/commands/issues.py
@@ -1328,7 +1328,7 @@ def add_comment(ctx: click.Context, issue_id: str, text: str) -> None:
 
 
 @comments.command(name="list")
-@click.argument("issue_id")
+@click.argument("issue_ids", nargs=-1)
 @click.option(
     "--format",
     type=click.Choice(["table", "json"]),
@@ -1338,37 +1338,68 @@ def add_comment(ctx: click.Context, issue_id: str, text: str) -> None:
 @click.pass_context
 def list_issue_comments(
     ctx: click.Context,
-    issue_id: str,
+    issue_ids: tuple[str, ...],
     format: str,
 ) -> None:
-    """List comments on an issue."""
+    """List comments on one or more issues.
+
+    Pass one or more issue IDs as arguments, or pipe them via stdin
+    (one ID per line) when no arguments are given.
+
+    Examples:
+        yt issues comments list ISSUE-123
+        yt issues comments list ISSUE-123 ISSUE-456
+        cat issues.txt | yt issues comments list
+    """
+    import sys
+
     from ..managers.issues import IssueManager
 
     console = get_console()
+
+    ids = list(issue_ids)
+    if not ids and not sys.stdin.isatty():
+        ids = [line.strip() for line in sys.stdin if line.strip()]
+    if not ids:
+        raise click.ClickException(
+            "No issue IDs provided. Pass one or more IDs as arguments or pipe them via stdin (one per line)."
+        )
+
     auth_manager = AuthManager(ctx.obj.get("config"))
     issue_manager = IssueManager(auth_manager)
 
-    print_status(f"💬 Fetching comments for issue '{issue_id}'...", output_format=format)
+    multiple = len(ids) > 1
+    json_output: dict[str, list] = {}
 
-    try:
-        result = asyncio.run(issue_manager.list_comments(issue_id))
+    for issue_id in ids:
+        print_status(f"💬 Fetching comments for issue '{issue_id}'...", output_format=format)
 
-        if result["status"] == "success":
-            comments = result["data"]
+        try:
+            result = asyncio.run(issue_manager.list_comments(issue_id))
+        except Exception as e:
+            console.print(f"❌ Error listing comments for '{issue_id}': {e}", style="red")
+            raise click.ClickException("Failed to list comments") from e
 
-            if format == "table":
-                issue_manager.display_comments_table(comments)
-            else:
-                import json
-
-                click.echo(json.dumps(comments, indent=2))
-        else:
+        if result["status"] != "success":
             console.print(f"❌ {result['message']}", style="red")
             raise click.ClickException("Failed to list comments")
 
-    except Exception as e:
-        console.print(f"❌ Error listing comments: {e}", style="red")
-        raise click.ClickException("Failed to list comments") from e
+        comments = result["data"]
+
+        if format == "table":
+            if multiple:
+                console.print(f"\n[bold]{issue_id}[/bold]")
+            issue_manager.display_comments_table(comments)
+        else:
+            json_output[issue_id] = comments
+
+    if format == "json":
+        import json
+
+        # Single ID keeps the original bare-list shape for backwards compatibility;
+        # multiple IDs are keyed by issue ID so callers can tell them apart.
+        payload: object = json_output if multiple else json_output[ids[0]]
+        click.echo(json.dumps(payload, indent=2))
 
 
 @comments.command(name="update")


### PR DESCRIPTION
## Summary

Closes #759

`yt issues comments list` now accepts **one or more issue IDs**, and reads IDs from **stdin** (one per line) when no arguments are given.

```bash
yt issues comments list PROJ-123                # single
yt issues comments list PROJ-123 PROJ-456       # multiple
cat issues.txt | yt issues comments list        # piped
```

## Behavior

- Multiple IDs → table output grouped under a per-issue heading; `--format json` returns an object keyed by issue ID.
- Single ID → original output shape unchanged (bare table / JSON list) for backwards compatibility.
- Blank/whitespace lines from stdin are ignored.
- No IDs from args or stdin → clear error.

## Tests

- multiple IDs as arguments
- IDs read from stdin (blank lines ignored)
- no IDs → error
- JSON single = bare list; JSON multiple = keyed by issue ID

## Docs

- `docs/commands/issues.rst` List Comments section updated with new usage and `--format` option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)