### PR TITLE
✨ feat(issues): add `--query` filter to `comments list`

### DIFF
--- a/docs/commands/issues.rst
+++ b/docs/commands/issues.rst
@@ -438,7 +438,34 @@ When multiple issues are given, the table output is grouped under a heading per
 issue, and ``--format json`` returns an object keyed by issue ID. A single issue
 keeps the original output shape (a bare table / JSON list).
 
+Filtering with ``--query``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use ``--query`` to filter comments by an **@mention** in the comment text and/or
+the comment **create date**. Terms are combined with ``and`` (the only supported
+connector):
+
+* ``@name`` – matches comments whose text mentions ``@name`` (exact login, so
+  ``@ryan`` does not match ``@ryanc``).
+* ``created OP DATE`` – compares the comment's create date against an ISO
+  ``YYYY-MM-DD`` date (interpreted as local start-of-day), where ``OP`` is one of
+  ``>``, ``<``, ``>=``, ``<=``. Use two bounds for a range.
+
+.. code-block:: bash
+
+   # Comments that mention @ryan
+   yt issues comments list PROJ-123 --query "@ryan"
+
+   # Comments created on or after a date
+   yt issues comments list PROJ-123 --query "created >= 2026-01-01"
+
+   # Comments mentioning @ryan created within a date range
+   yt issues comments list PROJ-123 --query "@ryan and created >= 2026-01-01 and created < 2026-06-01"
+
+An unrecognized term (for example ``author: bob``) produces a clear error.
+
 **Options:**
+  * ``--query TEXT`` - Filter comments by @mention and/or create date (see above)
   * ``--format [table|json]`` - Output format (default: ``table``)
   * ``-h, --help`` - Show help and exit
 

--- a/tests/test_comment_query.py
+++ b/tests/test_comment_query.py
@@ -1,0 +1,61 @@
+"""Tests for the ``yt issues comments list --query`` filter."""
+
+from datetime import datetime
+
+import pytest
+
+from youtrack_cli.comment_query import QueryError, filter_comments
+
+
+def _ms(date_str: str) -> int:
+    return int(datetime.strptime(date_str, "%Y-%m-%d").timestamp() * 1000)
+
+
+@pytest.fixture
+def comments():
+    return [
+        {"id": "1", "text": "hello @ryan", "created": _ms("2026-03-01")},
+        {"id": "2", "text": "ping @ryanc", "created": _ms("2026-03-01")},
+        {"id": "3", "text": "hi @ryan again", "created": _ms("2025-12-01")},
+        {"id": "4", "text": "no mention here", "created": _ms("2026-05-01")},
+    ]
+
+
+def test_mention_matches_exact_login_only(comments):
+    result = filter_comments(comments, "@ryan")
+    assert [c["id"] for c in result] == ["1", "3"]
+
+
+def test_created_greater_than(comments):
+    result = filter_comments(comments, "created > 2026-01-01")
+    assert [c["id"] for c in result] == ["1", "2", "4"]
+
+
+def test_created_range_with_bounds(comments):
+    result = filter_comments(comments, "created >= 2026-01-01 and created < 2026-04-01")
+    assert [c["id"] for c in result] == ["1", "2"]
+
+
+def test_mention_and_date_combined(comments):
+    result = filter_comments(comments, "@ryan and created > 2026-01-01")
+    assert [c["id"] for c in result] == ["1"]
+
+
+def test_and_is_case_insensitive(comments):
+    result = filter_comments(comments, "@ryan AND created > 2026-01-01")
+    assert [c["id"] for c in result] == ["1"]
+
+
+def test_comment_missing_created_is_excluded_by_date_term():
+    result = filter_comments([{"id": "x", "text": "@ryan"}], "created > 2020-01-01")
+    assert result == []
+
+
+def test_invalid_term_raises():
+    with pytest.raises(QueryError):
+        filter_comments([], "author: bob")
+
+
+def test_invalid_date_raises():
+    with pytest.raises(ValueError):
+        filter_comments([], "created > 2026-13-40")

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -1679,6 +1679,39 @@ class TestIssuesCLI:
             assert result.exit_code == 0
             assert _parse_trailing_json(result.output) == {"PROJ-1": [comment], "PROJ-2": [comment]}
 
+    def test_issues_comments_list_query_filters_output(self):
+        """--query filters the fetched comments before display."""
+        from youtrack_cli.main import main
+
+        runner = CliRunner()
+        keep = {"id": "1", "text": "hello @ryan", "created": 1772323200000, "author": {"login": "ryan"}}
+        drop = {"id": "2", "text": "no mention", "created": 1772323200000, "author": {"login": "bob"}}
+
+        with patch("youtrack_cli.main.asyncio.run") as mock_run:
+            mock_run.return_value = {"status": "success", "data": [keep, drop]}
+
+            result = runner.invoke(
+                main, ["--quiet", "issues", "comments", "list", "PROJ-1", "--query", "@ryan", "--format", "json"]
+            )
+
+            assert result.exit_code == 0
+            assert _parse_trailing_json(result.output) == [keep]
+
+    def test_issues_comments_list_invalid_query_errors(self):
+        """An unparseable --query produces a clear error."""
+        from youtrack_cli.main import main
+
+        runner = CliRunner()
+        comment = {"id": "1", "text": "hi", "created": 1772323200000, "author": {"login": "ryan"}}
+
+        with patch("youtrack_cli.main.asyncio.run") as mock_run:
+            mock_run.return_value = {"status": "success", "data": [comment]}
+
+            result = runner.invoke(main, ["issues", "comments", "list", "PROJ-1", "--query", "author: bob"])
+
+            assert result.exit_code != 0
+            assert "Invalid query term" in result.output
+
     def test_issues_attach_upload_command(self):
         """Test the issues attach upload CLI command."""
         from youtrack_cli.main import main

--- a/youtrack_cli/commands/issues.py
+++ b/youtrack_cli/commands/issues.py
@@ -1330,6 +1330,14 @@ def add_comment(ctx: click.Context, issue_id: str, text: str) -> None:
 @comments.command(name="list")
 @click.argument("issue_ids", nargs=-1)
 @click.option(
+    "--query",
+    default=None,
+    help=(
+        "Filter comments. Combine terms with 'and': an @mention (e.g. @ryan) "
+        'and/or a create date (e.g. "created >= 2026-01-01").'
+    ),
+)
+@click.option(
     "--format",
     type=click.Choice(["table", "json"]),
     default="table",
@@ -1339,12 +1347,21 @@ def add_comment(ctx: click.Context, issue_id: str, text: str) -> None:
 def list_issue_comments(
     ctx: click.Context,
     issue_ids: tuple[str, ...],
+    query: str | None,
     format: str,
 ) -> None:
-    """List comments on one or more issues.
+    r"""List comments on one or more issues.
 
     Pass one or more issue IDs as arguments, or pipe them via stdin
     (one ID per line) when no arguments are given.
+
+    Use --query to filter comments by an @mention and/or the comment create
+    date, combined with 'and':
+
+    \b
+        yt issues comments list ISSUE-123 --query "@ryan"
+        yt issues comments list ISSUE-123 --query "created > 2026-01-01"
+        yt issues comments list ISSUE-123 --query "@ryan and created >= 2026-01-01 and created < 2026-06-01"
 
     Examples:
         yt issues comments list ISSUE-123
@@ -1353,6 +1370,7 @@ def list_issue_comments(
     """
     import sys
 
+    from ..comment_query import QueryError, filter_comments
     from ..managers.issues import IssueManager
 
     console = get_console()
@@ -1385,6 +1403,12 @@ def list_issue_comments(
             raise click.ClickException("Failed to list comments")
 
         comments = result["data"]
+
+        if query:
+            try:
+                comments = filter_comments(comments, query)
+            except QueryError as e:
+                raise click.ClickException(str(e)) from e
 
         if format == "table":
             if multiple:

--- a/youtrack_cli/comment_query.py
+++ b/youtrack_cli/comment_query.py
@@ -1,0 +1,123 @@
+"""Filtering of issue comments by a small ``--query`` expression.
+
+Supported terms, combined with ``and`` (the only connector):
+
+* ``@name`` – the comment text contains that at-mention.
+* ``created OP DATE`` – the comment's ``created`` timestamp (epoch
+  milliseconds) compared against an ISO ``YYYY-MM-DD`` date, where ``OP`` is
+  one of ``>``, ``<``, ``>=``, ``<=``. The date is interpreted as local
+  start-of-day.
+
+Example: ``@ryan and created >= 2026-01-01 and created < 2026-06-01``
+"""
+
+from __future__ import annotations
+
+import operator
+import re
+from collections.abc import Callable
+from datetime import datetime
+from typing import Any
+
+_CREATED_RE = re.compile(r"^created\s*(>=|<=|>|<)\s*(\d{4}-\d{2}-\d{2})$")
+_OPS: dict[str, Callable[[Any, Any], bool]] = {
+    ">": operator.gt,
+    "<": operator.lt,
+    ">=": operator.ge,
+    "<=": operator.le,
+}
+
+
+class QueryError(ValueError):
+    """Raised when a ``--query`` expression cannot be parsed."""
+
+
+def _date_to_epoch_ms(date_str: str) -> int:
+    """Convert an ISO ``YYYY-MM-DD`` date to local start-of-day epoch ms."""
+    dt = datetime.strptime(date_str, "%Y-%m-%d")
+    return int(dt.timestamp() * 1000)
+
+
+def _created_predicate(op: str, threshold_ms: int) -> Callable[[dict[str, Any]], bool]:
+    compare = _OPS[op]
+
+    def predicate(comment: dict[str, Any]) -> bool:
+        created = comment.get("created")
+        if created is None:
+            return False
+        return compare(int(created), threshold_ms)
+
+    return predicate
+
+
+def _mention_predicate(mention: str) -> Callable[[dict[str, Any]], bool]:
+    # Anchor on a trailing non-word boundary so ``@ryan`` does not match
+    # ``@ryanc``. ``-`` is treated as part of a name (logins may contain it).
+    pattern = re.compile(re.escape(mention) + r"(?![\w-])")
+
+    def predicate(comment: dict[str, Any]) -> bool:
+        return bool(pattern.search(comment.get("text") or ""))
+
+    return predicate
+
+
+def build_predicates(query: str) -> list[Callable[[dict[str, Any]], bool]]:
+    """Parse ``query`` into a list of per-comment predicates.
+
+    Raises:
+        QueryError: if any term is not a supported ``@mention`` or
+            ``created OP DATE`` expression.
+    """
+    terms = [t.strip() for t in re.split(r"\s+and\s+", query.strip(), flags=re.IGNORECASE) if t.strip()]
+    if not terms:
+        raise QueryError("Query is empty.")
+
+    predicates: list[Callable[[dict[str, Any]], bool]] = []
+    for term in terms:
+        created_match = _CREATED_RE.match(term)
+        if created_match:
+            op, date_str = created_match.group(1), created_match.group(2)
+            predicates.append(_created_predicate(op, _date_to_epoch_ms(date_str)))
+        elif term.startswith("@") and len(term) > 1:
+            predicates.append(_mention_predicate(term))
+        else:
+            raise QueryError(
+                f"Invalid query term: {term!r}. "
+                "Expected an @mention or a 'created OP YYYY-MM-DD' expression joined by 'and'."
+            )
+    return predicates
+
+
+def filter_comments(comments: list[dict[str, Any]], query: str) -> list[dict[str, Any]]:
+    """Return the comments matching every term in ``query``."""
+    predicates = build_predicates(query)
+    return [c for c in comments if all(p(c) for p in predicates)]
+
+
+def _demo() -> None:
+    comments = [
+        {"text": "hello @ryan", "created": _date_to_epoch_ms("2026-03-01")},
+        {"text": "ping @ryanc", "created": _date_to_epoch_ms("2026-03-01")},
+        {"text": "hi @ryan again", "created": _date_to_epoch_ms("2025-12-01")},
+    ]
+    # @mention alone
+    assert [c["text"] for c in filter_comments(comments, "@ryan")] == ["hello @ryan", "hi @ryan again"]
+    # @mention does not match a longer login
+    assert filter_comments(comments, "@ryan and created > 2026-01-01") == [comments[0]]
+    # date range
+    assert filter_comments(comments, "created >= 2026-01-01 and created < 2026-06-01") == [
+        comments[0],
+        comments[1],
+    ]
+    # invalid term
+    try:
+        filter_comments(comments, "author: bob")
+    except QueryError:
+        pass
+    else:  # pragma: no cover
+        raise AssertionError("expected QueryError")
+    print("ok")
+
+
+if __name__ == "__main__":
+    _demo()


### PR DESCRIPTION
## Summary

Closes #758

Adds a `--query` flag to `yt issues comments list` for filtering comments by an **@mention** and/or the comment **create date**, combined with `and`.

```bash
yt issues comments list PROJ-123 --query "@ryan"
yt issues comments list PROJ-123 --query "created >= 2026-01-01"
yt issues comments list PROJ-123 --query "@ryan and created >= 2026-01-01 and created < 2026-06-01"
```

## Query spec

- **Connector:** `and` only (case-insensitive). No `or`/grouping.
- **`@name`:** matches comments whose text mentions `@name`. Exact login — `@ryan` does not match `@ryanc`.
- **`created OP DATE`:** compares the comment's `created` field (stored as epoch ms) against an ISO `YYYY-MM-DD` date (local start-of-day). `OP` ∈ `>`, `<`, `>=`, `<=`. Two bounds express a range.
- Unparseable term → clear `ClickException`.

## Implementation

- New pure module `youtrack_cli/comment_query.py` (`filter_comments`, `QueryError`) with a `__main__` self-check.
- `commands/issues.py`: `--query` option applied per issue after fetch; composes with the multi-ID / stdin behavior from #759.

## Tests

- `tests/test_comment_query.py`: mention exactness, date ops, ranges, combined terms, case-insensitive `and`, missing `created`, invalid term, invalid date.
- `tests/test_issues.py`: `--query` filters command output; invalid query errors.

## Docs

- `docs/commands/issues.rst`: new "Filtering with --query" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)