### PR TITLE
🐛 test: isolate keyring backend per test (fixes flaky auth test)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,42 @@ def isolate_environment():
 
 
 @pytest.fixture(scope="function", autouse=True)
+def isolate_keyring():
+    """Give each test a fresh, empty in-memory keyring backend.
+
+    The keyring backend is process-wide global state that pytest does not reset
+    between tests, so credentials written (or leaked) by one test could be read
+    by another under randomized ordering. This mirrors ``isolate_environment``
+    for the keyring and removes any dependency on the developer's real keychain.
+    """
+    import keyring
+    from keyring.backend import KeyringBackend
+
+    class _MemKeyring(KeyringBackend):
+        priority = 1
+
+        def __init__(self):
+            super().__init__()
+            self._store: dict[tuple[str, str], str] = {}
+
+        def get_password(self, service, username):
+            return self._store.get((service, username))
+
+        def set_password(self, service, username, password):
+            self._store[(service, username)] = password
+
+        def delete_password(self, service, username):
+            self._store.pop((service, username), None)
+
+    previous = keyring.get_keyring()
+    keyring.set_keyring(_MemKeyring())
+    try:
+        yield
+    finally:
+        keyring.set_keyring(previous)
+
+
+@pytest.fixture(scope="function", autouse=True)
 def mock_dotenv_loading():
     """Mock dotenv loading to prevent real config files from loading."""
     with (


### PR DESCRIPTION
## Summary

Closes #749

`test_load_credentials_without_username` flaked under `pytest-randomly`: the `keyring` backend is process-wide global state pytest never resets between tests, so credentials written/leaked by one test could be read by another under an unlucky ordering — making env-based `load_credentials` tests read keyring values instead of their env vars.

## Fix

Add an autouse `isolate_keyring` fixture in `tests/conftest.py`, mirroring the existing `isolate_environment`: each test gets a fresh in-memory `KeyringBackend`, and the previous backend is restored afterward. Systemic — fixes the flake regardless of which test does the polluting, and removes any dependency on the developer's real keychain during tests.

## Verification

- `tests/test_auth.py`, `tests/test_security.py`, `tests/test_main.py` all pass.
- Ad-hoc proof: a test that seeds the keyring followed by an env-based `load_credentials` test — the latter now sees a clean backend (`username is None`).
- `tests/test_auth.py tests/test_main.py` green across seeds 1 / 42 / 777 / 12345.
- Full suite: 1418 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)