### PR TITLE
👷 ci(coverage): replace Codecov with an in-CI coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,14 +56,15 @@ jobs:
     - name: Install dependencies and run tests with tox-uv
       run: uvx --with tox-uv tox -e py$(echo ${{ matrix.python-version }} | tr -d '.')
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v4
+    - name: Rename coverage data for this Python version
+      run: mv .coverage ".coverage.${{ matrix.python-version }}"
+
+    - name: Upload coverage data
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        files: ./coverage.xml
-        fail_ci_if_error: false
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      continue-on-error: true
+        name: coverage-data-${{ matrix.python-version }}
+        path: .coverage.${{ matrix.python-version }}
+        include-hidden-files: true
 
   lint:
     if: github.event_name == 'pull_request'
@@ -163,39 +164,15 @@ jobs:
         echo "Documentation testing infrastructure is in place"
         echo "RST files found:" && find docs/ -name "*.rst" | wc -l
 
-  # Summary job for branch protection (PR-only; pushes are not gated)
-  tests-complete:
-    name: test
+  # Aggregate coverage across the test matrix and enforce the project threshold
+  # in-CI (replaces the former external coverage service). Runs even if a matrix
+  # job failed so a report is always produced; the failing test job still fails
+  # the summary gate below.
+  coverage:
+    name: coverage
     if: always() && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    needs: [test, lint, type-check, security, documentation]
-    steps:
-      - name: Check all jobs
-        env:
-          TEST_RESULT: ${{ needs.test.result }}
-          LINT_RESULT: ${{ needs.lint.result }}
-          TYPE_CHECK_RESULT: ${{ needs.type-check.result }}
-          SECURITY_RESULT: ${{ needs.security.result }}
-          DOCUMENTATION_RESULT: ${{ needs.documentation.result }}
-        run: |
-          if [[ "$TEST_RESULT" == "success" &&
-                "$LINT_RESULT" == "success" &&
-                "$TYPE_CHECK_RESULT" == "success" &&
-                "$SECURITY_RESULT" == "success" &&
-                "$DOCUMENTATION_RESULT" == "success" ]]; then
-            echo "All checks passed"
-            exit 0
-          else
-            echo "Some checks failed"
-            exit 1
-          fi
-
-  # Lightweight post-merge run: refreshes the Codecov baseline for the default
-  # branch without re-running the full matrix + lint/type/security/docs, which
-  # the PR already validated. Runs only on pushes (e.g. after a squash merge).
-  coverage-baseline:
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
+    needs: [test]
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
       with:
@@ -208,22 +185,62 @@ jobs:
         enable-cache: true
         cache-dependency-glob: "uv.lock"
 
-    - name: Set up Python
-      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v5
+    - name: Download coverage data
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        python-version: "3.11"
+        pattern: coverage-data-*
+        merge-multiple: true
 
-    - name: Run tests with coverage
-      run: uvx --with tox-uv tox -e py311
+    - name: Combine coverage, report to summary, and enforce threshold
+      run: |
+        uv tool install coverage
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v4
+        coverage combine
+        coverage html --skip-covered --skip-empty
+
+        # Write a markdown report to the run summary (never fail this line, so the
+        # summary is present even when the gate below fails).
+        coverage report --format=markdown >> "$GITHUB_STEP_SUMMARY" || true
+
+        # Enforce the threshold. No --fail-under here: coverage reads
+        # [tool.coverage.report] fail_under (currently 60) from pyproject.toml.
+        coverage report
+
+    - name: Upload HTML report if the coverage gate failed
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      if: ${{ failure() }}
       with:
-        files: ./coverage.xml
-        fail_ci_if_error: false
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      continue-on-error: true
+        name: html-report
+        path: htmlcov
+
+  # Summary job for branch protection (PR-only; pushes are not gated)
+  tests-complete:
+    name: test
+    if: always() && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    needs: [test, lint, type-check, security, documentation, coverage]
+    steps:
+      - name: Check all jobs
+        env:
+          TEST_RESULT: ${{ needs.test.result }}
+          LINT_RESULT: ${{ needs.lint.result }}
+          TYPE_CHECK_RESULT: ${{ needs.type-check.result }}
+          SECURITY_RESULT: ${{ needs.security.result }}
+          DOCUMENTATION_RESULT: ${{ needs.documentation.result }}
+          COVERAGE_RESULT: ${{ needs.coverage.result }}
+        run: |
+          if [[ "$TEST_RESULT" == "success" &&
+                "$LINT_RESULT" == "success" &&
+                "$TYPE_CHECK_RESULT" == "success" &&
+                "$SECURITY_RESULT" == "success" &&
+                "$DOCUMENTATION_RESULT" == "success" &&
+                "$COVERAGE_RESULT" == "success" ]]; then
+            echo "All checks passed"
+            exit 0
+          else
+            echo "Some checks failed"
+            exit 1
+          fi
 
   # Post-merge early-warning for Python 3.15 (prerelease). Kept off the per-PR
   # matrix because its source-built deps make it ~3x slower (issue #736); running

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/004-fix-json-output"
+  "feature_directory": "specs/005-ditch-codecov"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- 👷 CI no longer depends on Codecov. Each test-matrix job now uploads its
+  coverage data as an artifact, and a new `coverage` job combines them, publishes
+  a markdown coverage report to the run summary, and fails the build if aggregate
+  coverage drops below the project threshold (`[tool.coverage.report] fail_under`,
+  currently 60). The HTML report is uploaded only when the gate fails. The
+  post-merge `coverage-baseline` job (which existed only to refresh the external
+  service) was removed (#700)
+
 ## [0.24.7] - 2026-08-03
 
 ### Fixed

--- a/specs/005-ditch-codecov/checklists/requirements.md
+++ b/specs/005-ditch-codecov/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Ditch Codecov for a Self-Hosted Coverage Gate
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-04
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- FR-009 resolved via clarification: aggregate gate governed by
+  `[tool.coverage.report] fail_under = 60`, read from project config (not
+  hardcoded in CI). pytest `--cov-fail-under=50` left unchanged. All checklist
+  items now pass.
+- Kept deliberately implementation-light: no mention of specific action names,
+  step YAML, or file paths — those belong in `plan.md`.

--- a/specs/005-ditch-codecov/contracts/ci-coverage.md
+++ b/specs/005-ditch-codecov/contracts/ci-coverage.md
@@ -1,0 +1,69 @@
+# Contract: CI Coverage Gate
+
+The "interface" of this feature is the `ci.yml` job graph and the artifact
+contract between the `test` matrix and the `coverage` job. This document is the
+authoritative shape the implementation must satisfy.
+
+## `test` job (modified)
+
+**Inputs**: matrix `python-version`.
+
+**New responsibilities** (added after the existing tox test step):
+
+1. Rename the produced data file:
+   `mv .coverage ".coverage.${{ matrix.python-version }}"`.
+2. Upload it as an artifact:
+   - action: `actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1`
+   - `name: coverage-data-${{ matrix.python-version }}`
+   - `path: .coverage.${{ matrix.python-version }}`
+   - `include-hidden-files: true`
+
+**Removed**: the "Upload coverage to Codecov" step and its `CODECOV_TOKEN` env.
+
+## `coverage` job (new)
+
+```yaml
+coverage:
+  name: coverage
+  needs: [test]
+  if: always() && github.event_name == 'pull_request'
+  runs-on: ubuntu-latest
+  steps:
+    - checkout (persist-credentials: false)          # repo-pinned SHA
+    - setup-uv                                        # repo-pinned SHA
+    - download-artifact:                              # v8.0.1 SHA
+        pattern: coverage-data-*
+        merge-multiple: true
+    - run: |
+        uv tool install coverage
+        coverage combine
+        coverage html --skip-covered --skip-empty
+        coverage report --format=markdown >> "$GITHUB_STEP_SUMMARY" || true
+        coverage report            # threshold from pyproject fail_under=60
+    - upload-artifact (if: failure()):               # v7.0.1 SHA
+        name: html-report
+        path: htmlcov
+```
+
+**Contract guarantees**:
+
+- Runs even if a `test` job failed (`if: always()`), so a report is always
+  attempted.
+- Only runs on `pull_request` (mirrors the other PR-gated jobs; no push variant).
+- Exit status is failure iff aggregate coverage `< 60` (from `pyproject.toml`) or
+  no data could be combined.
+- Threshold is NOT written in the workflow (derived from config).
+
+## `tests-complete` summary job (modified)
+
+- `needs:` gains `coverage`.
+- The pass/fail evaluation gains `COVERAGE_RESULT: ${{ needs.coverage.result }}`
+  and requires it to be `success` alongside the existing five jobs.
+
+## Global constraints (unchanged invariants)
+
+- Every `uses:` is pinned to a full commit SHA with a `# vX` comment.
+- `checkout` uses `persist-credentials: false`.
+- `zizmor .github/workflows/` passes with no new findings.
+- `lint`, `type-check`, `security`, `documentation`, and push-only `test-py315`
+  are untouched.

--- a/specs/005-ditch-codecov/data-model.md
+++ b/specs/005-ditch-codecov/data-model.md
@@ -1,0 +1,64 @@
+# Phase 1 Data Model: Ditch Codecov
+
+This feature has no application data model. The "entities" are CI jobs and the
+artifacts that flow between them.
+
+## Entities
+
+### Per-version coverage data artifact
+
+- **Represents**: the raw coverage measurement from one matrix `test` job.
+- **Producer**: each `test` matrix job (one per Python version).
+- **Fields / attributes**:
+  - `name`: `coverage-data-<python-version>` (e.g. `coverage-data-3.11`,
+    `coverage-data-3.14t`).
+  - `contents`: a single file `.coverage.<python-version>` (renamed from
+    `.coverage`; a hidden dotfile).
+- **Rules**:
+  - Name MUST be unique per matrix entry so multiple versions coexist in one run.
+  - Upload MUST include hidden files.
+  - Produced even though a job may have a lower single-version percentage than the
+    aggregate (single-version pytest gate `--cov-fail-under=50` is separate).
+
+### Aggregate coverage result
+
+- **Represents**: the combined measurement across all versions.
+- **Producer**: the `coverage` job via `coverage combine` over all downloaded
+  `.coverage.*` files → a single `.coverage`.
+- **Rules**:
+  - Derived only from artifacts present in the run (no version numbers baked into
+    the aggregation step).
+  - Basis for both the summary report and the pass/fail gate.
+
+### Coverage summary report (markdown)
+
+- **Represents**: human-readable total, shown in the run summary.
+- **Producer**: `coverage report --format=markdown >> $GITHUB_STEP_SUMMARY`.
+- **Rules**: written on every `coverage`-job run (guarded so it is emitted even
+  when the subsequent gate fails).
+
+### Detailed coverage report (HTML)
+
+- **Represents**: drill-down for diagnosing a shortfall.
+- **Producer**: `coverage html --skip-covered --skip-empty` → `htmlcov/`.
+- **Rules**: uploaded as an artifact **only** when the gate fails
+  (`if: failure()`); absent on passing runs.
+
+## Job graph (state / dependency transitions)
+
+```text
+test (matrix: 3.10 … 3.14t)  ──► produces coverage-data-<v> artifacts
+        │
+        ├──► coverage        (needs: test, if: always())
+        │         combine → summary(markdown) → gate(fail_under=60 from config)
+        │         └─(on failure)─► upload htmlcov artifact
+        │
+lint, type-check, security, documentation  (unchanged)
+        │
+        └──► tests-complete  (needs: test, lint, type-check, security,
+                              documentation, coverage; if: always())
+                              passes only if ALL results == success
+```
+
+Removed: `coverage-baseline` (push-only; existed solely for Codecov baseline).
+Unchanged: `test-py315` (push-only prerelease early-warning).

--- a/specs/005-ditch-codecov/plan.md
+++ b/specs/005-ditch-codecov/plan.md
@@ -1,0 +1,102 @@
+# Implementation Plan: Ditch Codecov for a Self-Hosted Coverage Gate
+
+**Branch**: `700-ditch-codecov` | **Date**: 2026-08-04 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/005-ditch-codecov/spec.md`
+
+## Summary
+
+Remove Codecov from `.github/workflows/ci.yml` and replace it with an in-CI
+coverage gate. Each per-Python-version `test` job renames its `.coverage` data
+to a unique `.coverage.<version>` and uploads it as a hidden-file artifact
+`coverage-data-<version>`. A new `coverage` job (`needs: test`, `if: always()`)
+downloads all `coverage-data-*` artifacts (`merge-multiple`), runs
+`coverage combine`, writes a markdown report to `$GITHUB_STEP_SUMMARY`, and fails
+if aggregate coverage is below `[tool.coverage.report] fail_under = 60` (read from
+`pyproject.toml`, not hardcoded). On failure it uploads the HTML report. The
+`coverage` job is added to the `tests-complete` summary so branch protection gates
+on it. The post-merge `coverage-baseline` job (existed only to feed Codecov) is
+deleted. All actions stay SHA-pinned; the change must pass `zizmor`.
+
+## Technical Context
+
+**Language/Version**: GitHub Actions workflow YAML; coverage tooling is Python
+`coverage`/`pytest-cov` (coverage 7.x, pinned in `uv.lock`).
+
+**Primary Dependencies**: `actions/checkout@v4`, `astral-sh/setup-uv@v4`,
+`actions/upload-artifact@v7.0.1`, `actions/download-artifact@v8.0.1`, `uv tool
+install coverage`, `tox`/`tox-uv`.
+
+**Storage**: GitHub Actions run artifacts (per-version coverage data; HTML report
+on failure). No persistent storage.
+
+**Testing**: Validation is by CI behavior — a green run at/above threshold and a
+red `coverage` job below threshold. Local dry-run via `act` optional; primary
+verification is the PR's own CI plus `zizmor`.
+
+**Target Platform**: `ubuntu-latest` GitHub-hosted runners.
+
+**Project Type**: CLI project; this feature touches CI configuration only.
+
+**Performance Goals**: Coverage job adds ~1 short job after the matrix; no impact
+on the critical path beyond one extra sequential job that runs coverage combine
+(seconds).
+
+**Constraints**: All actions SHA-pinned; `checkout` with
+`persist-credentials: false`; must pass `zizmor .github/workflows/`; threshold not
+hardcoded (derived from `pyproject.toml`).
+
+**Scale/Scope**: One workflow file (`ci.yml`); matrix of 6 Python versions
+(`3.10, 3.11, 3.12, 3.13, 3.14, 3.14t`).
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Code Quality**: No application code changes. Docs: no `docs/` user-facing
+  change needed (CI-internal), but the repo README/badges must not reference
+  Codecov after removal — checked in tasks. `uv` remains the toolchain. ✅
+- **II. Testing Standards (NON-NEGOTIABLE)**: No test code changes; the feature
+  *is* a test/coverage gate. `zizmor` (GitHub Actions review) must pass — an
+  explicit acceptance item. The gate must not weaken existing enforcement. ✅
+- **III. UX Consistency**: Reviewer-facing coverage visibility is preserved via
+  the run-summary markdown report (replaces the Codecov PR comment/dashboard). ✅
+- **IV. Performance**: Negligible CI time change; no runtime impact. ✅
+
+No violations. Complexity Tracking not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/005-ditch-codecov/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (jobs/artifacts entities)
+├── quickstart.md        # Phase 1 output (how to validate)
+├── contracts/
+│   └── ci-coverage.md   # Phase 1 output (job graph + artifact contract)
+├── spec.md
+└── tasks.md             # /speckit-tasks output (not created here)
+```
+
+### Source Code (repository root)
+
+```text
+.github/workflows/
+└── ci.yml               # Only file changed: edit `test` job, add `coverage`
+                         # job, update `tests-complete`, delete `coverage-baseline`
+
+pyproject.toml           # Read-only here: [tool.coverage.report] fail_under = 60
+                         # supplies the threshold; [tool.coverage.run] parallel = true
+README.md                # Remove any Codecov badge/reference (verify)
+```
+
+**Structure Decision**: Single-file CI change plus a badge/reference sweep. No
+new source modules. `pyproject.toml` is the source of truth for the threshold and
+is not modified.
+
+## Complexity Tracking
+
+> No Constitution Check violations — section intentionally empty.

--- a/specs/005-ditch-codecov/quickstart.md
+++ b/specs/005-ditch-codecov/quickstart.md
@@ -1,0 +1,78 @@
+# Quickstart: Validating the Codecov → self-hosted coverage migration
+
+This feature is CI configuration, so validation is primarily by observing the
+PR's own CI run. Below are the checks that prove each requirement.
+
+## Prerequisites
+
+- The change is on branch `700-ditch-codecov` and pushed as a PR (CI is PR-gated).
+- `gh` CLI authenticated.
+
+## 1. Static / local checks (before relying on CI)
+
+```bash
+# No functional Codecov references remain (SC-001).
+# Expect: no output.
+grep -ri codecov .github README.md
+
+# Workflow is still valid YAML and passes the security review.
+uvx zizmor .github/workflows/
+
+# The threshold source of truth is present and is 60.
+grep -n "fail_under" pyproject.toml   # [tool.coverage.report] fail_under = 60
+```
+
+Sanity-check the combine mechanics locally (simulates two matrix jobs):
+
+```bash
+rm -f .coverage .coverage.*
+uv run pytest tests/test_console.py -q >/dev/null 2>&1 && mv .coverage .coverage.a
+uv run pytest tests/test_common.py  -q >/dev/null 2>&1 && mv .coverage .coverage.b
+uv tool run coverage combine        # or: uvx coverage combine
+uv tool run coverage report --format=markdown   # renders a markdown table
+rm -f .coverage .coverage.*
+```
+
+Expected: `coverage combine` reports "Combined data file …" for each input and
+`coverage report` prints a table. (Local numbers are low because only two test
+files ran — this only proves the *mechanics*, not the gate.)
+
+## 2. CI checks on the PR
+
+Open the PR CI run and confirm:
+
+| Requirement | What to verify |
+|-------------|----------------|
+| FR-003/004 | Each `test (3.x)` job has an artifact `coverage-data-3.x` containing `.coverage.3.x`. |
+| FR-005 | The `coverage` job runs even if a `test` job fails (`if: always()`). |
+| FR-006 | The `coverage` job log shows `coverage combine` merging all versions. |
+| FR-007 | The run **Summary** page shows a markdown coverage table with the total %. |
+| FR-008 | The `coverage` job is green (aggregate ≥ 60). |
+| FR-010 | On a green run there is **no** `html-report` artifact. |
+| FR-011 | The `test` (summary) required check depends on `coverage` and is green. |
+| SC-005 | The reported % reflects all matrix versions combined (≥ any single version). |
+
+## 3. Negative test (optional, do not merge)
+
+To prove the gate actually blocks (SC-003), temporarily lower coverage below 60
+(e.g. add a large uncovered module) on a throwaway commit and confirm:
+
+- the `coverage` job **fails**,
+- the run **Summary** still shows the markdown report (written before the gate),
+- an `html-report` artifact **is** produced (`if: failure()`),
+- `tests-complete` (the `test` required check) is **red**, blocking merge.
+
+Revert the throwaway commit before merging.
+
+## 4. Post-merge
+
+- Confirm the deleted `coverage-baseline` job no longer appears on `push` runs to
+  `main` (FR-002); `test-py315` still runs.
+
+## Diagnostics
+
+- If `coverage report` shows 0% or "No source for code": the combined data's
+  absolute paths didn't match the checkout path. Add a `[tool.coverage.paths]`
+  remap in `pyproject.toml` (see research R5) and re-run.
+- If the artifact is empty: the upload step is missing `include-hidden-files:
+  true` (the data file is a dotfile).

--- a/specs/005-ditch-codecov/research.md
+++ b/specs/005-ditch-codecov/research.md
@@ -1,0 +1,112 @@
+# Phase 0 Research: Ditch Codecov
+
+## R1 — Where does coverage data land after a `tox` run, and how many files?
+
+**Finding**: A local `pytest` (same invocation tox uses) leaves a **single**
+`.coverage` file in the repo root. `pytest-cov` auto-combines subprocess data
+into one file per run even with `[tool.coverage.run] parallel = true`.
+
+**Decision**: Each matrix job produces one `.coverage`. To aggregate across jobs
+we must give each job's file a **unique** name before upload, otherwise
+`download-artifact` with `merge-multiple: true` would overwrite identically named
+files.
+
+**Approach**: `mv .coverage ".coverage.${{ matrix.python-version }}"` after the
+test step, then upload. `coverage combine` auto-discovers any `.coverage.*` file,
+so the renamed files combine without extra arguments.
+
+**Alternatives considered**: Rename to a non-hidden name (e.g.
+`coverage-3.11.dat`) — rejected because `coverage combine` only auto-discovers the
+`.coverage.*` prefix; we'd have to pass explicit paths.
+
+## R2 — Uploading hidden coverage files as artifacts
+
+**Finding**: `actions/upload-artifact` excludes hidden (dot-prefixed) files by
+default. `.coverage.<version>` is a dotfile.
+
+**Decision**: Set `include-hidden-files: true` on the upload step (supported in
+current `upload-artifact`).
+
+## R3 — Correct, current SHA pins for the artifact actions
+
+**Finding** (via `gh api repos/<a>/releases/latest` — the latest tags are
+lightweight, so the ref SHA is the commit SHA):
+
+- `actions/upload-artifact` → `v7.0.1` → `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`
+- `actions/download-artifact` → `v8.0.1` → `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c`
+
+These match Hynek's snippet and are current. Existing jobs' pins are reused for
+`checkout` (`3d3c42e5…` v4) and `setup-uv` (`c771a70e…` v4) for consistency and a
+smaller `zizmor` surface.
+
+**Decision**: Pin exactly those SHAs with a trailing `# vX.Y.Z` comment (repo
+convention).
+
+## R4 — Deriving the threshold from config, not hardcoding
+
+**Finding**: `pyproject.toml` has `[tool.coverage.report] fail_under = 60`.
+`coverage report` reads `fail_under` from that config automatically and exits
+non-zero when below it.
+
+**Decision**: The enforcing command is a bare `coverage report` (no
+`--fail-under`), so the gate stays in sync with `pyproject.toml`. The markdown
+summary line uses `coverage report --format=markdown` and is guarded with
+`|| true` so the summary is always written even on a failing run; the following
+bare `coverage report` produces the actual pass/fail.
+
+**Rationale**: Satisfies FR-009 ("derive threshold from existing config, not a
+hardcoded number") and keeps a single source of truth.
+
+## R5 — Cross-job source path alignment for `coverage report`
+
+**Finding**: Coverage data stores absolute source paths. All matrix jobs and the
+`coverage` job run on `ubuntu-latest` and check out to the identical path
+(`/home/runner/work/yt-cli/yt-cli`), so combined data maps back to the checked-out
+sources without remapping.
+
+**Decision**: No `[tool.coverage.paths]` remapping needed. **Risk/mitigation**: if
+a future runner path change makes `coverage report` show 0%/missing files, add a
+`[tool.coverage.paths]` section. Noted in quickstart as the diagnostic.
+
+## R6 — Which Python runs the `coverage` tool
+
+**Finding**: `uv tool install coverage` provisions its own recent Python;
+`coverage report` parses source to count executable lines, so it should run on a
+Python new enough to understand the codebase's syntax. uv's default (latest
+stable) satisfies this.
+
+**Decision**: In the `coverage` job, `setup-uv` + `uv tool install coverage`; no
+separate `actions/setup-python` step (fewer steps, smaller audit surface). Coverage
+data format is stable across 7.x, so tool-vs-producer minor version skew is safe.
+
+## R7 — Keeping the gate from being skipped on test failure
+
+**Finding**: Spec requires the report to always run (FR-005) while still failing
+the overall run when a test job fails.
+
+**Decision**: `coverage` job uses `needs: [test]` + `if: always()`. Because the
+matrix `test` job remains a dependency of `tests-complete`, a failing test job
+still fails the summary gate independently of the `coverage` job's result.
+
+## R8 — Removing the `coverage-baseline` job
+
+**Finding**: `coverage-baseline` runs only on `push` and exists solely to
+re-upload coverage to Codecov for the default-branch baseline. With Codecov gone
+it has no remaining purpose (the `test-py315` push job is unrelated and stays).
+
+**Decision**: Delete the `coverage-baseline` job entirely (FR-002). PR runs
+compute and gate coverage; no default-branch baseline is needed.
+
+## R9 — Residual Codecov references
+
+**Finding**: The only **functional** Codecov reference is
+`.github/workflows/ci.yml`. Other `grep -ri codecov` matches are historical and
+must be left alone: `CHANGELOG.md` (release history) and
+`specs/002-ci-py315-speedup/research.md` (a past spec). The `.specify/feature.json`
+and `specs/005-ditch-codecov/` matches are just the substring in this feature's
+directory name. There is **no** Codecov badge in `README.md` and no
+`CODECOV_TOKEN` outside `ci.yml`.
+
+**Decision**: Only edit `ci.yml`. SC-001 verification is scoped to functional
+config: `grep -ri codecov .github README.md` returns nothing after the change.
+Historical mentions in `CHANGELOG.md`/old specs are intentionally preserved.

--- a/specs/005-ditch-codecov/spec.md
+++ b/specs/005-ditch-codecov/spec.md
@@ -1,0 +1,126 @@
+# Feature Specification: Ditch Codecov for a Self-Hosted Coverage Gate
+
+**Feature Branch**: `700-ditch-codecov`
+
+**Created**: 2026-08-04
+
+**Status**: Draft
+
+**Input**: User description: "Migrate the project's CI from Codecov to Hynek's 'ditch Codecov' pattern (GitHub issue #700): remove all Codecov usage and replace it with a single in-CI coverage job that combines per-matrix coverage data, publishes a report to the run summary, and fails the build when total coverage drops below the project's existing threshold."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Coverage gate without a third-party service (Priority: P1)
+
+As a maintainer, when a pull request runs CI, I want total test coverage to be
+computed from all Python-version test jobs and enforced against a threshold
+entirely within GitHub Actions, so that a drop in coverage blocks the merge
+without depending on Codecov.
+
+**Why this priority**: This is the core value of the migration — replacing the
+flaky external dependency with a self-contained gate. Without it, the feature
+delivers nothing.
+
+**Independent Test**: Open a PR; observe that the test matrix runs, a single
+coverage job aggregates results, and the PR is blocked if aggregate coverage is
+below the threshold and allowed when it is at or above it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a PR whose aggregate coverage is at or above the threshold, **When** CI runs, **Then** the coverage job succeeds and the branch-protection summary reports success.
+2. **Given** a PR whose aggregate coverage is below the threshold, **When** CI runs, **Then** the coverage job fails and the branch-protection summary reports failure, blocking merge.
+3. **Given** the test matrix runs across multiple Python versions, **When** the coverage job aggregates results, **Then** the reported total reflects the combined coverage of all matrix jobs, not a single version.
+
+---
+
+### User Story 2 - Visible coverage report on every run (Priority: P2)
+
+As a reviewer, I want a human-readable coverage summary attached to the CI run,
+so that I can see the current coverage percentage and which areas are lacking
+without leaving GitHub or logging into an external dashboard.
+
+**Why this priority**: Codecov's main day-to-day value was visibility; the
+replacement must preserve a readable report or reviewers lose insight.
+
+**Independent Test**: Open any CI run for a PR and confirm a coverage report is
+present in the run's summary view.
+
+**Acceptance Scenarios**:
+
+1. **Given** a completed CI run, **When** a reviewer opens the run summary, **Then** a markdown coverage report showing the total percentage is displayed.
+2. **Given** the coverage gate fails, **When** a reviewer inspects the run, **Then** a downloadable detailed (HTML) coverage report is available to diagnose the shortfall.
+3. **Given** the coverage gate passes, **When** the run completes, **Then** no detailed HTML report artifact is produced (kept only for failures to avoid clutter).
+
+---
+
+### User Story 3 - No residual Codecov footprint (Priority: P3)
+
+As a maintainer, I want every trace of Codecov removed from the project's CI, so
+that there are no dead steps, unused secrets references, or purposeless jobs left
+behind after the migration.
+
+**Why this priority**: Leftover configuration causes confusion and security
+review noise, but it does not block the core gate from working.
+
+**Independent Test**: Search the CI configuration for any Codecov reference and
+confirm none remain; confirm the post-merge job that existed only to refresh the
+Codecov baseline is gone.
+
+**Acceptance Scenarios**:
+
+1. **Given** the migrated CI configuration, **When** it is searched for Codecov references (action, steps, token), **Then** none are found.
+2. **Given** the previous post-merge job existed solely to refresh the external coverage baseline, **When** the migration is complete, **Then** that job no longer exists.
+
+---
+
+### Edge Cases
+
+- **A matrix test job fails or is cancelled**: the coverage job still runs (it must not be skipped by an upstream failure) and reports on whatever coverage data was produced; the overall run still fails because the failing test job fails the branch-protection summary.
+- **No coverage data is available** (e.g., all test jobs failed before producing data): the coverage job surfaces a clear failure rather than silently passing.
+- **Coverage is exactly at the threshold**: treated as passing (the threshold is inclusive).
+- **A new Python version is added to or removed from the matrix**: the coverage job aggregates whatever per-version data artifacts exist without configuration changes tied to specific version numbers.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: CI MUST NOT use Codecov in any form — the Codecov action, its upload steps, and any Codecov token reference MUST be removed.
+- **FR-002**: The post-merge job whose sole purpose was refreshing the external coverage baseline MUST be removed.
+- **FR-003**: Each per-Python-version test job MUST publish its raw coverage data as a run artifact uniquely identified by that Python version.
+- **FR-004**: Coverage data artifacts MUST be captured even though the underlying coverage data files are hidden (dotfile) names.
+- **FR-005**: A single coverage-aggregation job MUST run after the test matrix and MUST run even when one or more test jobs fail (so it always reports).
+- **FR-006**: The coverage-aggregation job MUST retrieve all per-version coverage data artifacts and combine them into a single aggregate result.
+- **FR-007**: The coverage-aggregation job MUST publish a human-readable (markdown) coverage report to the CI run summary.
+- **FR-008**: The coverage-aggregation job MUST fail when aggregate coverage is below the project's configured threshold, and MUST pass when it is at or above it.
+- **FR-009**: The enforced threshold MUST be the project's existing `[tool.coverage.report] fail_under` value (currently **60**), NOT 100%. The coverage-aggregation job MUST derive the threshold from the project's existing coverage configuration rather than hardcoding a number in the CI definition, so the gate stays in sync if the configured value changes.
+- **FR-010**: When and only when the coverage gate fails, the job MUST publish a detailed (HTML) coverage report as a downloadable artifact.
+- **FR-011**: The coverage-aggregation job MUST be included in the branch-protection summary job's dependencies and pass/fail evaluation so that it gates merges to the protected branch.
+- **FR-012**: All GitHub Actions used MUST remain pinned to specific commit SHAs, and the CI configuration MUST continue to pass the existing GitHub Actions security review (zizmor).
+- **FR-013**: Existing non-coverage CI behavior (lint, type-check, security, documentation jobs, and the post-merge early-warning job for the prerelease Python version) MUST remain unchanged.
+
+### Key Entities
+
+- **Per-version coverage data artifact**: the raw coverage measurement produced by one Python-version test job, uniquely named so multiple versions can coexist in one run and later be combined.
+- **Aggregate coverage result**: the single combined measurement derived from all per-version artifacts; the basis for both the summary report and the pass/fail gate.
+- **Coverage summary report**: the human-readable markdown rendering of the aggregate result, shown in the run summary.
+- **Detailed coverage report**: the drill-down (HTML) rendering, retained only on gate failure for diagnosis.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Zero Codecov references remain anywhere in the CI configuration (verifiable by search returning no matches).
+- **SC-002**: On every PR run, reviewers can read the total coverage percentage directly in the CI run summary without visiting any external service.
+- **SC-003**: A PR that reduces aggregate coverage below the threshold is blocked from merging by a failing required check.
+- **SC-004**: A PR at or above the threshold merges without any coverage-related failure.
+- **SC-005**: The reported coverage percentage reflects all Python versions in the matrix combined, and changes appropriately when a version's tests contribute more or less coverage.
+- **SC-006**: The CI security review passes with no new findings introduced by the migration.
+- **SC-007**: On a failing-coverage run, a detailed report artifact is downloadable; on a passing run, it is absent.
+
+## Assumptions
+
+- The project's test tooling already records coverage in a combinable form across parallel runs, so aggregating per-version data yields a correct total.
+- The aggregate gate is governed by `[tool.coverage.report] fail_under = 60`; the coverage tool reads this from the project's configuration, so the CI job does not restate the number. The separate pytest per-run `--cov-fail-under=50` stays as-is (it guards each local/CI test run; the aggregate gate is the stricter 60).
+- The migration is limited to the coverage/Codecov concern; unrelated CI jobs and their triggers are out of scope and remain as-is.
+- Branch protection is configured to require the summary check, so adding the coverage job to that summary is sufficient to gate merges (no separate repository-settings change is required as part of this feature).
+- Publishing coverage on pull-request runs is sufficient; refreshing a default-branch baseline is no longer needed once the external service is removed.

--- a/specs/005-ditch-codecov/tasks.md
+++ b/specs/005-ditch-codecov/tasks.md
@@ -73,7 +73,7 @@ failure-only HTML drill-down.
 - [X] T016 Run `uvx zizmor .github/workflows/` and confirm no new findings; confirm every `uses:` in `ci.yml` is a full SHA with a `# vX` comment and `checkout` uses `persist-credentials: false`. (FR-012)
 - [X] T017 [P] Add a `CHANGELOG.md` entry under the appropriate version noting the migration from Codecov to an in-CI coverage gate.
 - [X] T018 Verify SC-001 (`grep -ri codecov .github README.md` → empty) and FR-013 (lint, type-check, security, documentation, and `test-py315` jobs are byte-for-byte unchanged aside from the intended edits) via `git diff`.
-- [ ] T019 Push the branch, open the PR, and validate on the live run per quickstart §2 (per-version artifacts exist, `coverage` job combines + summarizes + gates green, no `html-report` on green, `test` required check green). Post-merge, confirm `coverage-baseline` no longer runs on push (quickstart §4).
+- [X] T019 Push the branch, open the PR, and validate on the live run per quickstart §2 (per-version artifacts exist, `coverage` job combines + summarizes + gates green, no `html-report` on green, `test` required check green). Post-merge, confirm `coverage-baseline` no longer runs on push (quickstart §4). **Verified on PR #763**: 6 `coverage-data-3.x` artifacts present; `coverage` job green at TOTAL 60.69% ≥ 60; run summary shows the markdown table; no `html-report` artifact on the green run; `test` summary check green. Note: `coverage combine` reported "Combined 5 files, skipped 1" — a benign de-dup of an identical per-version data file (same tests across versions produce identical arcs; union total is unchanged).
 
 ## Dependencies & Execution Order
 

--- a/specs/005-ditch-codecov/tasks.md
+++ b/specs/005-ditch-codecov/tasks.md
@@ -1,0 +1,98 @@
+# Tasks: Ditch Codecov for a Self-Hosted Coverage Gate
+
+**Feature**: `specs/005-ditch-codecov` | **Branch**: `700-ditch-codecov`
+**Inputs**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/ci-coverage.md](./contracts/ci-coverage.md), [quickstart.md](./quickstart.md)
+
+Tests: No unit-test tasks — this is CI configuration. Verification is by `zizmor`,
+local combine mechanics, and the PR's own CI run (see quickstart).
+
+**Note on parallelism**: nearly every task edits the single file
+`.github/workflows/ci.yml`, so `[P]` is rare — sequential edits to one file are not
+parallelizable. Tasks touching other files (README sweep, CHANGELOG) are marked
+`[P]`.
+
+## Phase 1: Setup
+
+- [X] T001 Confirm working branch is `700-ditch-codecov` and read the current `.github/workflows/ci.yml` `test`, `coverage-baseline`, and `tests-complete` jobs to anchor edits.
+- [X] T002 Confirm the threshold source of truth: `grep -n "fail_under" pyproject.toml` shows `[tool.coverage.report] fail_under = 60`; confirm `[tool.coverage.run] parallel = true` is present.
+
+## Phase 2: Foundational (blocking prerequisites)
+
+- [X] T003 Verify current SHA pins to use in `.github/workflows/ci.yml`: `actions/upload-artifact` → `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` (v7.0.1) and `actions/download-artifact` → `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` (v8.0.1); reuse existing repo pins for `actions/checkout` (v4) and `astral-sh/setup-uv` (v4). (Source: research R3.)
+- [X] T004 Validate combine mechanics locally per quickstart §1: produce two `.coverage.<x>` files, `coverage combine`, `coverage report` — confirm combine merges and `coverage report` exits non-zero when under `fail_under=60` (proves threshold-from-config). Clean up `.coverage*` afterward.
+
+## Phase 3: User Story 1 — Coverage gate without a third-party service (P1) 🎯 MVP
+
+**Goal**: Aggregate coverage across the matrix is computed and enforced against
+the threshold entirely in GitHub Actions; below-threshold PRs are blocked.
+
+**Independent test**: Open the PR; the test matrix runs, the `coverage` job
+aggregates all versions, and the `test` required check is red when aggregate < 60
+and green when ≥ 60.
+
+- [X] T005 [US1] In the `test` job of `.github/workflows/ci.yml`, remove the "Upload coverage to Codecov" step (the `codecov/codecov-action` step and its `CODECOV_TOKEN` env). (FR-001)
+- [X] T006 [US1] In the `test` job, after the tox test step, add a step to rename the data file: `mv .coverage ".coverage.${{ matrix.python-version }}"`. (data-model: per-version artifact; research R1)
+- [X] T007 [US1] In the `test` job, add an `actions/upload-artifact` step (v7.0.1 SHA) with `name: coverage-data-${{ matrix.python-version }}`, `path: .coverage.${{ matrix.python-version }}`, and `include-hidden-files: true`. (FR-003, FR-004; research R2)
+- [X] T008 [US1] Add a new `coverage` job to `.github/workflows/ci.yml` with `name: coverage`, `needs: [test]`, `if: always() && github.event_name == 'pull_request'`, `runs-on: ubuntu-latest`; steps: `actions/checkout` (repo v4 SHA, `persist-credentials: false`) and `astral-sh/setup-uv` (repo v4 SHA). (FR-005; contract)
+- [X] T009 [US1] In the `coverage` job, add an `actions/download-artifact` step (v8.0.1 SHA) with `pattern: coverage-data-*` and `merge-multiple: true`. (FR-006)
+- [X] T010 [US1] In the `coverage` job, add the gate `run:` block: `uv tool install coverage`; `coverage combine`; then the enforcing `coverage report` (bare — threshold from `pyproject.toml`, NOT hardcoded). (FR-008, FR-009; research R4)
+- [X] T011 [US1] Add `coverage` to the `tests-complete` job `needs:` list and add `COVERAGE_RESULT: ${{ needs.coverage.result }}` to its env, requiring `"$COVERAGE_RESULT" == "success"` in the pass/fail check. (FR-011; contract)
+
+**Checkpoint**: US1 delivers the MVP — a working, merge-gating aggregate coverage
+check with no Codecov. (US2/US3 add visibility and cleanup.)
+
+## Phase 4: User Story 2 — Visible coverage report on every run (P2)
+
+**Goal**: A readable coverage report is attached to every CI run; a detailed HTML
+report is available only when the gate fails.
+
+**Independent test**: Open a CI run's Summary → a markdown coverage table is shown;
+on a failing run an `html-report` artifact is downloadable, on a passing run it is
+absent.
+
+- [X] T012 [US2] In the `coverage` job `run:` block (before the enforcing report), add `coverage html --skip-covered --skip-empty` and `coverage report --format=markdown >> "$GITHUB_STEP_SUMMARY" || true` so the summary is always written even when the gate later fails. (FR-007; research R4)
+- [X] T013 [US2] In the `coverage` job, add a final `actions/upload-artifact` step (v7.0.1 SHA) guarded by `if: failure()` with `name: html-report` and `path: htmlcov` (uploads the detailed report only on gate failure). (FR-010)
+
+**Checkpoint**: US2 complete — reviewers get run-summary visibility and
+failure-only HTML drill-down.
+
+## Phase 5: User Story 3 — No residual Codecov footprint (P3)
+
+**Goal**: Every trace of Codecov is gone, including the purposeless post-merge job.
+
+**Independent test**: `grep -ri codecov .github README.md` returns nothing; the
+`coverage-baseline` job no longer exists.
+
+- [X] T014 [US3] Delete the entire `coverage-baseline` job from `.github/workflows/ci.yml` (it existed only to refresh the Codecov baseline). Leave the `test-py315` push job untouched. (FR-002; research R8)
+- [X] T015 [P] [US3] Sweep for stray Codecov references in functional files: confirm `README.md` has no Codecov badge and remove it if present. Do NOT touch historical mentions in `CHANGELOG.md` or old specs. (FR-001; research R9)
+
+**Checkpoint**: US3 complete — no functional Codecov footprint remains.
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [X] T016 Run `uvx zizmor .github/workflows/` and confirm no new findings; confirm every `uses:` in `ci.yml` is a full SHA with a `# vX` comment and `checkout` uses `persist-credentials: false`. (FR-012)
+- [X] T017 [P] Add a `CHANGELOG.md` entry under the appropriate version noting the migration from Codecov to an in-CI coverage gate.
+- [X] T018 Verify SC-001 (`grep -ri codecov .github README.md` → empty) and FR-013 (lint, type-check, security, documentation, and `test-py315` jobs are byte-for-byte unchanged aside from the intended edits) via `git diff`.
+- [ ] T019 Push the branch, open the PR, and validate on the live run per quickstart §2 (per-version artifacts exist, `coverage` job combines + summarizes + gates green, no `html-report` on green, `test` required check green). Post-merge, confirm `coverage-baseline` no longer runs on push (quickstart §4).
+
+## Dependencies & Execution Order
+
+- **Setup (T001–T002)** → **Foundational (T003–T004)** → **US1 (T005–T011)** → **US2 (T012–T013)** → **US3 (T014–T015)** → **Polish (T016–T019)**.
+- US1 is the MVP and must land first; US2 extends the same `coverage` job; US3 is independent cleanup and could technically be done in parallel with US2 but touches the same file, so keep sequential.
+- T004 (local mechanics) should pass before writing the `coverage` job (T008–T010).
+- T015 and T017 touch files other than `ci.yml` → marked `[P]`.
+
+## Parallel Opportunities
+
+- Limited: the core edits all live in `.github/workflows/ci.yml` (sequential).
+- `[P]` tasks: **T015** (README sweep) and **T017** (CHANGELOG entry) can run
+  alongside the `ci.yml` edits since they touch different files.
+
+## Implementation Strategy
+
+1. **MVP first**: complete Phase 1–3 (US1) → a functioning, merge-gating coverage
+   check with Codecov removed from the `test` job. This alone closes the core of
+   issue #700.
+2. **Increment**: add US2 (visibility) then US3 (cleanup).
+3. **Validate**: Polish phase runs `zizmor`, checks the diff scope, and confirms
+   behavior on the live PR run.


### PR DESCRIPTION
## Summary

Closes #700

Migrates CI off Codecov to a self-contained coverage gate (Hynek's ["ditch Codecov"](https://hynek.me/articles/ditch-codecov-python/) pattern), **adapted to this repo's real threshold (60), not 100%**.

- Each `test (3.x)` job renames its `.coverage` → `.coverage.<version>` and uploads it as a hidden-file artifact `coverage-data-<version>`.
- New **`coverage`** job (`needs: test`, `if: always()`) downloads all `coverage-data-*` (`merge-multiple`), runs `coverage combine`, writes a markdown report to the run **Summary**, and enforces the threshold via a bare `coverage report` — which reads `[tool.coverage.report] fail_under = 60` from `pyproject.toml` (no hardcoded number). HTML report is uploaded **only on failure**.
- `coverage` is added to the `tests-complete` branch-protection summary so it gates merges.
- Deleted the post-merge `coverage-baseline` job (existed only to refresh Codecov). Removed the Codecov action and `CODECOV_TOKEN`.

## Notes

- All actions remain SHA-pinned (`upload-artifact@v7.0.1`, `download-artifact@v8.0.1`, plus the repo's existing `checkout`/`setup-uv` pins); `zizmor` passes with no findings.
- Combine mechanics + threshold-from-config verified locally before wiring the job.
- Built with the full Spec Kit workflow — spec/plan/tasks/analyze artifacts are under `specs/005-ditch-codecov/`.

## Validation on this PR (T019)

- [ ] Per-version `coverage-data-3.x` artifacts present
- [ ] `coverage` job combines + writes summary + gate green (aggregate ≥ 60)
- [ ] No `html-report` artifact on a green run
- [ ] `test` required check green

🤖 Generated with [Claude Code](https://claude.com/claude-code)