### PR TITLE
🔖 Bump version to 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-08-04
+
+### Added
+- ✨ `yt issues comments list` now accepts multiple issue IDs and reads IDs from
+  stdin (one per line) when none are passed as arguments, e.g.
+  `yt issues comments list PROJ-1 PROJ-2` or `cat issues.txt | yt issues comments
+  list`. Multiple issues are grouped per-issue in table output and keyed by issue
+  ID in `--format json`; a single issue keeps the original output shape (#759)
+- ✨ `yt issues comments list --query` filters comments by an `@mention` in the
+  comment text and/or the comment create date, combined with `and` — e.g.
+  `--query "@ryan and created >= 2026-01-01 and created < 2026-06-01"`. Dates use
+  ISO `YYYY-MM-DD` with `>`, `<`, `>=`, `<=`; mentions match the exact login (#758)
+
 ### Changed
 - 👷 CI no longer depends on Codecov. Each test-matrix job now uploads its
   coverage data as an artifact, and a new `coverage` job combines them, publishes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "youtrack-cli"
-version = "0.24.7"
+version = "0.25.0"
 description = "YouTrack CLI - Command line interface for JetBrains YouTrack issue tracking system"
 readme = "README.md"
 requires-python = ">=3.10, <3.16"

--- a/uv.lock
+++ b/uv.lock
@@ -1991,7 +1991,7 @@ wheels = [
 
 [[package]]
 name = "youtrack-cli"
-version = "0.24.7"
+version = "0.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Release 0.25.0

Prepares the 0.25.0 release: version bump (`pyproject.toml` + `uv.lock`) and CHANGELOG.

### Added
- ✨ `yt issues comments list` accepts multiple issue IDs and reads IDs from stdin (#759)
- ✨ `yt issues comments list --query` filters by `@mention` and/or create date (#758)

### Changed
- 👷 CI migrated from Codecov to an in-CI coverage gate (#700)

Not separately logged (per changelog convention): the keyring test-isolation fix (#762) and the Dependabot cryptography bump (#764).

### Release mechanics
Once this merges to `main`, tagging `v0.25.0` triggers `release.yml` → Test PyPI + PyPI publish. **Tag/publish is a separate, confirmed step** — this PR only prepares the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)