### PR TITLE
👷 ci(release): make GitHub Release step idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,4 +82,13 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
         TAG: ${{ github.ref_name }}
-      run: gh release create "$TAG" dist/* --verify-tag --generate-notes
+      # Idempotent: if the release already exists (e.g. the tag was created via
+      # `gh release create`, or this is a re-run), upload the build artifacts to
+      # it instead of failing. Otherwise create the release as usual.
+      run: |
+        if gh release view "$TAG" >/dev/null 2>&1; then
+          echo "Release $TAG already exists; uploading build artifacts to it."
+          gh release upload "$TAG" dist/* --clobber
+        else
+          gh release create "$TAG" dist/* --verify-tag --generate-notes
+        fi


### PR DESCRIPTION
## Summary

The release workflow's final **Create GitHub Release** step ran `gh release create`, which fails if a release for the tag already exists. That's exactly what happened on the [v0.25.0 run](https://github.com/ryancheley/yt-cli/actions/runs/30913357718): the PyPI publish (step 8) succeeded, but step 9 failed with `a release with the same tag name already exists`, marking the whole run red.

This occurs whenever the tag is created via `gh release create` (the only option when an SSH tag push isn't available) or on a re-run.

## Change

Make the step idempotent:

```yaml
if gh release view "$TAG" >/dev/null 2>&1; then
  gh release upload "$TAG" dist/* --clobber   # attach artifacts to existing release
else
  gh release create "$TAG" dist/* --verify-tag --generate-notes
fi
```

If the release already exists, the build artifacts are uploaded to it (`--clobber`) instead of failing; otherwise it's created as before. No behavior change on the normal bare-tag path.

Verified: YAML parses, `zizmor` reports no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)