### PR TITLE
🔖 Bump version to 0.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.1] - 2026-08-04
+
+### Fixed
+- 🐛 `yt issues comments list` no longer fails with `RuntimeError: Event loop is
+  closed` when an issue has no comments — most visibly when piping several issue
+  IDs via stdin (`cat issues.txt | yt issues comments list`). The shared HTTP
+  client is now rebound to the current event loop when reused across the
+  per-issue `asyncio.run()` calls, instead of reusing a client whose connection
+  pool was bound to a closed loop (#768)
+
+### Changed
+- 👷 The GitHub Release step in `release.yml` is now idempotent (#767)
+
 ## [0.25.0] - 2026-08-04
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "youtrack-cli"
-version = "0.25.0"
+version = "0.25.1"
 description = "YouTrack CLI - Command line interface for JetBrains YouTrack issue tracking system"
 readme = "README.md"
 requires-python = ">=3.10, <3.16"

--- a/uv.lock
+++ b/uv.lock
@@ -1991,7 +1991,7 @@ wheels = [
 
 [[package]]
 name = "youtrack-cli"
-version = "0.25.0"
+version = "0.25.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Patch release **0.25.1**. Bumps the version and records the changelog for the changes since
`v0.25.0`.

### Fixed
- 🐛 `yt issues comments list` no longer fails with `RuntimeError: Event loop is closed` when
  an issue has no comments (most visibly when piping IDs via stdin) — #768 / #769.

### Changed
- 👷 Idempotent GitHub Release step in `release.yml` — #767.

## Release process

After this merges, the release is cut by pushing the `v0.25.1` tag, which triggers
`release.yml` to publish to TestPyPI + PyPI and create the GitHub Release.

- `pyproject.toml` and `uv.lock` bumped to `0.25.1`
- `CHANGELOG.md` `## [0.25.1]` section added
- `just check` passes locally (lint, format, type, tests, security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01249mMTmW23CZgdEdoxGnuL